### PR TITLE
Replaced all occurrences of Bramble with Brambl

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 How to Contribute
 -----------------
 
-Thank you very much for considering contributing to BrambleSc! It is people like you that make open-source projects
+Thank you very much for considering contributing to BramblSc! It is people like you that make open-source projects
 happen.
 
 Before you begin however, please be sure to read
-our [Contributor Code of Conduct](https://github.com/Topl/BrambleSc/blob/main/.github/CODE_OF_CONDUCT.md). We want to
+our [Contributor Code of Conduct](https://github.com/Topl/BramblSc/blob/main/.github/CODE_OF_CONDUCT.md). We want to
 ensure a healthy and collaborative environment here and will be enforcing these rules.
 
 **STOP RIGHT NOW AND READ THE CONTRIBUTOR LICENSE AGREEMENT AND CODE OF CONDUCT**
@@ -25,21 +25,21 @@ questions or that your question rather belongs in one place than another.
 Getting Started
 ---------------
 If you have played around with the client and found some issues that crashes the client, be sure to submit
-an [Issue](https://github.com/Topl/BrambleSc/issues)
+an [Issue](https://github.com/Topl/BramblSc/issues)
 
 * Make sure you have a GitHub account
 * Submit a ticket for your issue, assuming one does not already exist.
     * Clearly describe the issue including steps to reproduce when it is a bug.
     * Make sure you fill in the earliest version that you know has the issue.
 
-Improving and updating the [Wiki](https://github.com/Topl/BrambleSc/wiki) is always welcomed. It is probably the easiest
+Improving and updating the [Wiki](https://github.com/Topl/BramblSc/wiki) is always welcomed. It is probably the easiest
 way to be involved with open-source development. Everyone will love you forever for doing this.
 
 * Make sure you have a GitHub account
-* `git clone https://github.com/Topl/BrambleSc.wiki.git`
-* Create a new repository on your github account. Let's call it "BrambleSc-Wiki".
+* `git clone https://github.com/Topl/BramblSc.wiki.git`
+* Create a new repository on your github account. Let's call it "BramblSc-Wiki".
 * Remove the original "origin" remote and add your github repo as new "origin" `git remote rm origin`
-  and `git remote add origin git@github.com:<YOUR_USERNAME>/BrambleSc-Wiki.git`
+  and `git remote add origin git@github.com:<YOUR_USERNAME>/BramblSc-Wiki.git`
 * Make your proposed changes locally, then push them to your github account: `git push -u origin main` (`-u origin main`
   only required the first time; afterwards just do `git push`)
 * Submit a ticket to our Github issue tracker requesting maintainers to review your changes and merge them in. Please be
@@ -57,7 +57,7 @@ Making Changes
 3. Make sure you have added the necessary tests for your changes.
 4. Run all the tests to assure nothing else was accidentally broken.
 5. Run `sbt clean preparePR` to check linting, formatting, and that all tests pass
-6. Submit a [new pull request](https://github.com/Topl/BrambleSc/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) in the
+6. Submit a [new pull request](https://github.com/Topl/BramblSc/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) in the
    proper format:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/topl/bramblsc?label=release&sort=semver&style=plastic)
 
-# BrambleSc
+# BramblSc
+
 Topl's Brambl SDK implemented in Scala
 
 Multiple artifacts will be built from this repo. Some will be just for Topl clients and some will be shared. Currently 

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  homepage := Some(url("https://github.com/Topl/BrambleSc")),
+  homepage := Some(url("https://github.com/Topl/BramblSc")),
   sonatypeCredentialHost := "s01.oss.sonatype.org",
   sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   Test / publishArtifact := false,


### PR DESCRIPTION
## Purpose

To fix typos. It should say "BramblSc" or "Brambl"

## Approach

Replaced all occurrences of "Bramble" with "Brambl"

## Testing

- Sanity checked that code still compiles
- Verified that the GitHub links work

## Tickets
* Done as part of TSDK-240

