### PR TITLE
TSDK-304: Enhance AuthorizationFailed Error to include QuivrRuntimeErrors

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
@@ -9,7 +9,7 @@ object Blake2b256Digest extends Hash {
   override val routine: String = "blake2b256"
 
   override def hash(preimage: Preimage): Digest = {
-    val digest = (new Blake2b256).hash(ByteVector(preimage.toByteArray ++ preimage.toByteArray))
+    val digest = (new Blake2b256).hash(ByteVector(preimage.input.toByteArray ++ preimage.salt.toByteArray))
     Digest().withDigest32(
       Digest.Digest32(ByteString.copyFrom(digest.toArray))
     )

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
@@ -24,7 +24,7 @@ object Blake2b256DigestInterpreter {
     override def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] = t match {
       case DigestVerification(Some(Digest(Digest.Value.Digest32(d), _)), Some(Preimage(p, salt, _)), _) =>
         val testHash: ByteVector = (new Blake2b256).hash(ByteVector(p.toByteArray ++ salt.toByteArray))
-        val expectedHash = ByteVector(d.toByteArray)
+        val expectedHash = ByteVector(d.value.toByteArray)
         if (testHash === expectedHash)
           Either.right[QuivrRuntimeError, DigestVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionAuthorizationError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionAuthorizationError.scala
@@ -10,8 +10,10 @@ object TransactionAuthorizationError {
    * Generic error for when a transaction is not authorized
    *
    * Temporary until the interpreter utilized Contextual and Permanent errors
+   *
+   * @param errors the errors that occurred during the authorization process, if available
    */
-  case object AuthorizationFailed extends TransactionAuthorizationError
+  case class AuthorizationFailed(errors: List[QuivrRuntimeError] = List.empty) extends TransactionAuthorizationError
 
   /**
    * An Authorization error indicating that this transaction was invalid only within the provided validation context.

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -9,7 +9,10 @@ import co.topl.brambl.models.KnownIdentifier
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.validation.TransactionAuthorizationError.AuthorizationFailed
 import co.topl.brambl.validation.{TransactionAuthorizationError, TransactionSyntaxError}
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
+  EvaluationAuthorizationFailed,
+  LockedPropositionIsUnsatisfiable
+}
 import com.google.protobuf.ByteString
 import quivr.models.Int128
 
@@ -61,12 +64,16 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val provenAttestation = provenTx.inputs.head.attestation.getPredicate
     val result =
       errs.contains(TransactionSyntaxError.NonPositiveOutputValue(negativeValue)) &&
-      errs.contains(TransactionAuthorizationError.AuthorizationFailed(List(
-        // Contains all failed propositions and proofs: Locked, Height and Tick
-        LockedPropositionIsUnsatisfiable,
-        EvaluationAuthorizationFailed(provenAttestation.lock.challenges(3), provenAttestation.responses(3)),
-        EvaluationAuthorizationFailed(provenAttestation.lock.challenges(4), provenAttestation.responses(4))
-      )))
+      errs.contains(
+        TransactionAuthorizationError.AuthorizationFailed(
+          List(
+            // Contains all failed propositions and proofs: Locked, Height and Tick
+            LockedPropositionIsUnsatisfiable,
+            EvaluationAuthorizationFailed(provenAttestation.lock.challenges(3), provenAttestation.responses(3)),
+            EvaluationAuthorizationFailed(provenAttestation.lock.challenges(4), provenAttestation.responses(4))
+          )
+        )
+      )
     assert(result)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val catsCoreVersion = "2.8.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.3"
-    val quivr4sVersion = "3bcc730"  // scala-steward:off
+    val quivr4sVersion = "ef14fe2"  // scala-steward:off
     val protobufSpecsVersion = "c920f90" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }


### PR DESCRIPTION
## Purpose

When Authorization validation fails, a single AuthorizationFailed error is returned. This overwrites the QuivrRuntimeErrors that led to the authorization failure (useful information is lost). 

## Approach

If available, include the QuivrRuntimeErrors that occurred if Authorization Validation fails. Note that these may not be the finalized errors; determining the proper errors to return in different cases will be revisited in [TSDK-252](https://topl.atlassian.net/browse/TSDK-252).

During testing, a bug was found in Blake2b256 and its validator; it is fixed as part of this PR

## Testing

- Updated the affected unit test
- Ensured all existing tests pass

## Tickets
* Closes TSDK-304


[TSDK-252]: https://topl.atlassian.net/browse/TSDK-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ