### PR TITLE
TSDK-328 Fix flaky unit test

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
@@ -10,8 +10,8 @@ object Ed25519Signature extends Signing {
   override val routine: String = "ed25519"
 
   override def createKeyPair(seed: Array[Byte]): KeyPair = {
-    val seedLength = Ed25519.instance.seedLength
-    val (sk, vk) = Ed25519.instance.deriveKeyPairFromSeed(ByteVector(seed.padTo(seedLength, 0.toByte)))
+    val instance = new Ed25519
+    val (sk, vk) = instance.deriveKeyPairFromSeed(ByteVector(seed.padTo(instance.seedLength, 0.toByte)))
     val skBytes = sk.toArray
     val vkBytes = vk.toArray
     KeyPair(
@@ -24,7 +24,7 @@ object Ed25519Signature extends Signing {
     val privateKey = ByteVector(sk.value.toByteArray)
     val message = ByteVector(msg.value.toByteArray)
     Witness(
-      ByteString.copyFrom(Ed25519.instance.sign(privateKey, message).toArray)
+      ByteString.copyFrom((new Ed25519).sign(privateKey, message).toArray)
     )
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
@@ -23,9 +23,7 @@ object Ed25519SignatureInterpreter {
      */
     override def validate(t: SignatureVerification): F[Either[QuivrRuntimeError, SignatureVerification]] = t match {
       case SignatureVerification(Some(VerificationKey(vk, _)), Some(Witness(sig, _)), Some(Message(msg, _)), _) =>
-        if (
-          Ed25519.instance.verify(ByteVector(sig.toByteArray), ByteVector(msg.toByteArray), ByteVector(vk.toByteArray))
-        )
+        if ((new Ed25519).verify(ByteVector(sig.toByteArray), ByteVector(msg.toByteArray), ByteVector(vk.toByteArray)))
           Either.right[QuivrRuntimeError, SignatureVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.
           Either

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -64,7 +64,7 @@ object CredentiallerInterpreter {
     private def getProof(msg: SignableBytes, proposition: Proposition, idx: Option[Indices]): F[Proof] = {
       // TODO: Temporary until we have a way to map routines strings to the actual Routine
       val signingRoutines = Map(
-        "ed25519" -> Ed25519Signature
+        Ed25519Signature.routine -> Ed25519Signature
       )
       proposition.value match {
         case _: Proposition.Value.Locked => Prover.lockedProver[F].prove((), msg)


### PR DESCRIPTION
## Purpose

A test unit test was not consistent. When running the test via Intellij IDE, it was consistently passing. However, the test is run via SBT (including Github actions), the result was inconsistent (sometimes passing, sometimes failing). 

Debugging revealed that the issue is caused by Ed25519Signature.createKeyPair (Ed25519.instance.deriveKeyPairFromSeed) not being deterministic when run in SBT. Specifically, the Verification Key returned was not the one expected. It came up today in EOD check-in that Ed25519.instance was not thread-safe.

## Approach

- Updated the unit test to be more verbose
- Replaced the usage of `Ed25519.instance` with `new Ed25519`

## Testing

- Updated the flaky test to be more verbose
- Manually ran the test suite using **SBT** 15 times consecutively to ensure the test _consistently_ passes

## Tickets
* TSDK-328: Topl/Brambl#218