### PR TITLE
Box Values, Remove KnownIdentifier, Generators

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
@@ -1,9 +1,8 @@
 package co.topl.brambl.builders
 
-import co.topl.brambl.models.KnownIdentifier.{TransactionOutput32, TransactionOutput64}
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.builders.{InputBuildRequest, OutputBuildRequest}
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
-import com.google.protobuf.ByteString
 import quivr.models.SmallData
 
 /**
@@ -65,8 +64,7 @@ trait TransactionBuilder[F[_]] {
     inputRequests:  List[InputBuildRequest],
     outputRequests: List[OutputBuildRequest],
     schedule:       Option[Schedule] = None,
-    output32Refs:   List[TransactionOutput32] = List(),
-    output64Refs:   List[TransactionOutput64] = List(),
+    outputRefs:     List[TransactionOutputAddress] = List(),
     metadata:       Option[SmallData] = None
   ): F[Either[List[BuilderError], IoTransaction]]
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -95,7 +95,8 @@ object ContainsImmutable {
 
     implicit val iotxScheduleImmutable: ContainsImmutable[Schedule] = (schedule: Schedule) =>
       schedule.min.immutable ++
-      schedule.max.immutable
+      schedule.max.immutable ++
+      schedule.timestamp.immutable
 
     implicit val spentOutputImmutable: ContainsImmutable[SpentTransactionOutput] = (stxo: SpentTransactionOutput) =>
       stxo.address.immutable ++
@@ -116,6 +117,7 @@ object ContainsImmutable {
       case Value.Value.Topl(v)         => v.immutable
       case Value.Value.Asset(v)        => v.immutable
       case Value.Value.Registration(v) => v.immutable
+      case Value.Value.Empty           => Array[Byte](0).immutable
     }
 
     implicit val addressImmutable: ContainsImmutable[Address] = (address: Address) =>

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -4,6 +4,7 @@ import co.topl.brambl.models._
 import co.topl.brambl.models.box.{Box, Lock, Value}
 import co.topl.brambl.models.common.ImmutableBytes
 import co.topl.brambl.models.transaction._
+import co.topl.consensus.models.StakingAddress
 import co.topl.quivr.Tokens
 import com.google.protobuf.ByteString
 import quivr.models._
@@ -226,8 +227,11 @@ object ContainsImmutable {
     implicit val lvlValueImmutable: ContainsImmutable[Value.LVL] =
       _.quantity.immutable
 
+    implicit val stakingAddressImmutable: ContainsImmutable[StakingAddress] =
+      _.value.immutable
+
     implicit val toplValueImmutable: ContainsImmutable[Value.TOPL] =
-      v => v.quantity.immutable
+      v => v.quantity.immutable ++ v.stakingAddress.immutable
 
     implicit val assetValueImmutable: ContainsImmutable[Value.Asset] = (asset: Value.Asset) =>
       asset.label.immutable ++
@@ -247,7 +251,7 @@ object ContainsImmutable {
         v.subRoot.immutable
 
     implicit val registrationValueImmutable: ContainsImmutable[Value.Registration] =
-      v => v.registration.immutable
+      v => v.registration.immutable ++ v.stakingAddress.immutable
 
     // consider making predicate non-empty
     implicit val predicateLockImmutable: ContainsImmutable[Lock.Predicate] = (predicate: Lock.Predicate) =>

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -114,7 +114,8 @@ object ContainsImmutable {
       box.value.immutable
 
     implicit val valueImmutable: ContainsImmutable[Value] = _.value match {
-      case Value.Value.Token(v) => v.immutable
+      case Value.Value.Lvl(v)   => v.immutable
+      case Value.Value.Topl(v)  => v.immutable
       case Value.Value.Asset(v) => v.immutable
     }
 
@@ -215,7 +216,25 @@ object ContainsImmutable {
       case KnownIdentifier.Value.TransactionOutput64(r) => knownOutput64IdentifierImmutable.immutableBytes(r)
     }
 
-    implicit val tokenValueImmutable: ContainsImmutable[Value.Token] = (token: Value.Token) => token.quantity.immutable
+    implicit val lvlValueImmutable: ContainsImmutable[Value.LVL] =
+      _.quantity.immutable
+
+    implicit val toplValueImmutable: ContainsImmutable[Value.TOPL] =
+      v =>
+        v.quantity.immutable ++
+        v.registration.immutable
+
+    implicit val signatureKesSumImmutable: ContainsImmutable[co.topl.consensus.models.SignatureKesSum] =
+      v =>
+        v.verificationKey.immutable ++
+        v.signature.immutable ++
+        v.witness.immutable
+
+    implicit val signatureKesProductImmutable: ContainsImmutable[co.topl.consensus.models.SignatureKesProduct] =
+      v =>
+        v.superSignature.immutable ++
+        v.subSignature.immutable ++
+        v.subRoot.immutable
 
     implicit val assetValueImmutable: ContainsImmutable[Value.Asset] = (asset: Value.Asset) =>
       asset.label.immutable ++

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -98,31 +98,30 @@ object ContainsImmutable {
       schedule.max.immutable
 
     implicit val spentOutputImmutable: ContainsImmutable[SpentTransactionOutput] = (stxo: SpentTransactionOutput) =>
-      stxo.knownIdentifier.immutable ++
+      stxo.address.immutable ++
       stxo.attestation.immutable ++
-      stxo.value.immutable ++
-      stxo.datum.immutable
+      stxo.value.immutable
 
     implicit val unspentOutputImmutable: ContainsImmutable[UnspentTransactionOutput] =
       (utxo: UnspentTransactionOutput) =>
         utxo.address.immutable ++
-        utxo.value.immutable ++
-        utxo.datum.immutable
+        utxo.value.immutable
 
     implicit val boxImmutable: ContainsImmutable[Box] = (box: Box) =>
       box.lock.immutable ++
       box.value.immutable
 
     implicit val valueImmutable: ContainsImmutable[Value] = _.value match {
-      case Value.Value.Lvl(v)   => v.immutable
-      case Value.Value.Topl(v)  => v.immutable
-      case Value.Value.Asset(v) => v.immutable
+      case Value.Value.Lvl(v)          => v.immutable
+      case Value.Value.Topl(v)         => v.immutable
+      case Value.Value.Asset(v)        => v.immutable
+      case Value.Value.Registration(v) => v.immutable
     }
 
     implicit val addressImmutable: ContainsImmutable[Address] = (address: Address) =>
       address.network.immutable ++
       address.ledger.immutable ++
-      address.identifier.immutable
+      address.id.immutable
 
     implicit val size32EvidenceImmutable: ContainsImmutable[Evidence.Sized32] =
       ev => ev.digest.immutable
@@ -197,32 +196,41 @@ object ContainsImmutable {
       case Identifier.Value.IoTransaction64(i)   => ioTransaction64IdentifierImmutable.immutableBytes(i)
     }
 
-    implicit val knownOutput32IdentifierImmutable: ContainsImmutable[KnownIdentifier.TransactionOutput32] =
-      (knownId: KnownIdentifier.TransactionOutput32) =>
-        knownId.network.immutable ++
-        knownId.ledger.immutable ++
-        knownId.index.immutable ++
-        knownId.id.immutable
+    implicit val transactionOutputAddressImmutable: ContainsImmutable[TransactionOutputAddress] =
+      v =>
+        v.network.immutable ++
+        v.ledger.immutable ++
+        v.index.immutable ++
+        v.id.immutable
 
-    implicit val knownOutput64IdentifierImmutable: ContainsImmutable[KnownIdentifier.TransactionOutput64] =
-      (knownId: KnownIdentifier.TransactionOutput64) =>
-        knownId.network.immutable ++
-        knownId.ledger.immutable ++
-        knownId.index.immutable ++
-        knownId.id.immutable
+    implicit val transactionOutputAddressIdImmutable: ContainsImmutable[TransactionOutputAddress.Id] = {
+      case TransactionOutputAddress.Id.IoTransaction32(id) => id.immutable
+      case TransactionOutputAddress.Id.IoTransaction64(id) => id.immutable
+      case e                                               => throw new MatchError(e)
+    }
 
-    implicit val knownIdentifierImmutable: ContainsImmutable[KnownIdentifier] = _.value match {
-      case KnownIdentifier.Value.TransactionOutput32(r) => knownOutput32IdentifierImmutable.immutableBytes(r)
-      case KnownIdentifier.Value.TransactionOutput64(r) => knownOutput64IdentifierImmutable.immutableBytes(r)
+    implicit val lockAddressImmutable: ContainsImmutable[LockAddress] =
+      v =>
+        v.network.immutable ++
+        v.ledger.immutable ++
+        v.id.immutable
+
+    implicit val lockAddressIdImmutable: ContainsImmutable[LockAddress.Id] = {
+      case LockAddress.Id.Lock32(id) => id.immutable
+      case LockAddress.Id.Lock64(id) => id.immutable
+      case e                         => throw new MatchError(e)
     }
 
     implicit val lvlValueImmutable: ContainsImmutable[Value.LVL] =
       _.quantity.immutable
 
     implicit val toplValueImmutable: ContainsImmutable[Value.TOPL] =
-      v =>
-        v.quantity.immutable ++
-        v.registration.immutable
+      v => v.quantity.immutable
+
+    implicit val assetValueImmutable: ContainsImmutable[Value.Asset] = (asset: Value.Asset) =>
+      asset.label.immutable ++
+      asset.quantity.immutable ++
+      asset.metadata.immutable
 
     implicit val signatureKesSumImmutable: ContainsImmutable[co.topl.consensus.models.SignatureKesSum] =
       v =>
@@ -236,10 +244,8 @@ object ContainsImmutable {
         v.subSignature.immutable ++
         v.subRoot.immutable
 
-    implicit val assetValueImmutable: ContainsImmutable[Value.Asset] = (asset: Value.Asset) =>
-      asset.label.immutable ++
-      asset.quantity.immutable ++
-      asset.metadata.immutable
+    implicit val registrationValueImmutable: ContainsImmutable[Value.Registration] =
+      v => v.registration.immutable
 
     // consider making predicate non-empty
     implicit val predicateLockImmutable: ContainsImmutable[Lock.Predicate] = (predicate: Lock.Predicate) =>
@@ -333,7 +339,6 @@ object ContainsImmutable {
     implicit val iotxEventImmutable: ContainsImmutable[Event.IoTransaction] =
       event =>
         event.schedule.immutable ++
-        event.references32.immutable ++
         event.metadata.immutable
 
     implicit val stxoEventImmutable: ContainsImmutable[Event.SpentTransactionOutput] =

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -1,7 +1,8 @@
 package co.topl.brambl.dataApi
 
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Box
-import co.topl.brambl.models.{Indices, KnownIdentifier}
+import co.topl.brambl.models.Indices
 import co.topl.brambl.routines.signatures.Signing
 import quivr.models.{KeyPair, Preimage}
 
@@ -17,15 +18,6 @@ import quivr.models.{KeyPair, Preimage}
 trait DataApi {
 
   /**
-   * Return the indices associated to a known identifier.
-   * Simplifying assumption is that KnownIdentifier and Indices are 1 to 1
-   *
-   * @param id The known identifier for which to retrieve the indices
-   * @return The indices associated to the known identifier if it exists. Else None
-   */
-  def getIndicesByKnownIdentifier(id: KnownIdentifier): Option[Indices]
-
-  /**
    * Return the box associated to a known identifier.
    *
    * A Box is created from a utxo. A KnownIdentifier combines an Identifier and an index. For the simple use-case,
@@ -37,7 +29,7 @@ trait DataApi {
    * @param id The known identifier for which to retrieve the box
    * @return The box associated to the known identifier if it exists. Else None
    */
-  def getBoxByKnownIdentifier(id: KnownIdentifier): Option[Box]
+  def getBoxByKnownIdentifier(id: TransactionOutputAddress): Option[Box]
 
   /**
    * Return the preimage secret associated to indices.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -18,6 +18,15 @@ import quivr.models.{KeyPair, Preimage}
 trait DataApi {
 
   /**
+   * Return the indices associated to a known identifier.
+   * Simplifying assumption is that KnownIdentifier and Indices are 1 to 1
+   *
+   * @param id The known identifier for which to retrieve the indices
+   * @return The indices associated to the known identifier if it exists. Else None
+   */
+  def getIndicesByKnownIdentifier(id: TransactionOutputAddress): Option[Indices]
+
+  /**
    * Return the box associated to a known identifier.
    *
    * A Box is created from a utxo. A KnownIdentifier combines an Identifier and an index. For the simple use-case,

--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
@@ -15,8 +15,8 @@ object Ed25519Signature extends Signing {
     val skBytes = sk.toArray
     val vkBytes = vk.toArray
     KeyPair(
-      VerificationKey(ByteString.copyFrom(vkBytes)).some,
-      SigningKey(ByteString.copyFrom(skBytes)).some
+      VerificationKey(ByteString.copyFrom(vkBytes)),
+      SigningKey(ByteString.copyFrom(skBytes))
     )
   }
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
@@ -1,0 +1,40 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.common.ContainsEvidence
+import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
+import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.box.Lock
+
+import scala.language.implicitConversions
+
+trait LockSyntax {
+
+  implicit def lockAsLockSyntaxOps(lock: Lock): LockSyntaxOps =
+    new LockSyntaxOps(lock)
+
+  implicit def predicateLockAsLockSyntaxOps(lock: Lock.Predicate): PredicateLockSyntaxOps =
+    new PredicateLockSyntaxOps(lock)
+}
+
+class LockSyntaxOps(val lock: Lock) extends AnyVal {
+
+  def address(network: Int, ledger: Int): LockAddress =
+    LockAddress(network, ledger)
+      .withLock32(
+        Identifier.Lock32(
+          ContainsEvidence[Lock].sized32Evidence(lock)
+        )
+      )
+}
+
+class PredicateLockSyntaxOps(val lock: Lock.Predicate) extends AnyVal {
+
+  def address(network: Int, ledger: Int): LockAddress =
+    LockAddress(network, ledger)
+      .withLock32(
+        Identifier.Lock32(
+          ContainsEvidence[Lock].sized32Evidence(Lock().withPredicate(lock))
+        )
+      )
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionIdSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionIdSyntax.scala
@@ -1,0 +1,18 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionOutputAddress
+
+import scala.language.implicitConversions
+
+trait TransactionIdSyntax {
+
+  implicit def transactionIdAsIdSyntaxOps(id: Identifier.IoTransaction32): TransactionIdSyntaxOps =
+    new TransactionIdSyntaxOps(id)
+}
+
+class TransactionIdSyntaxOps(val id: Identifier.IoTransaction32) extends AnyVal {
+
+  def outputAddress(network: Int, ledger: Int, index: Int): TransactionOutputAddress =
+    TransactionOutputAddress(network, ledger, index, TransactionOutputAddress.Id.IoTransaction32(id))
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
@@ -1,0 +1,3 @@
+package co.topl.brambl
+
+package object syntax extends LockSyntax with TransactionIdSyntax {}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
@@ -22,7 +22,7 @@ object Blake2b256DigestInterpreter {
      * @return The DigestVerification object if the digest is valid, otherwise an error
      */
     override def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] = t match {
-      case DigestVerification(Some(Digest(Digest.Value.Digest32(d), _)), Some(Preimage(p, salt, _)), _) =>
+      case DigestVerification(Digest(Digest.Value.Digest32(d), _), Preimage(p, salt, _), _) =>
         val testHash: ByteVector = (new Blake2b256).hash(ByteVector(p.toByteArray ++ salt.toByteArray))
         val expectedHash = ByteVector(d.value.toByteArray)
         if (testHash === expectedHash)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
@@ -22,7 +22,7 @@ object Ed25519SignatureInterpreter {
      * @return The SignatureVerification object if the signature is valid, otherwise an error
      */
     override def validate(t: SignatureVerification): F[Either[QuivrRuntimeError, SignatureVerification]] = t match {
-      case SignatureVerification(Some(VerificationKey(vk, _)), Some(Witness(sig, _)), Some(Message(msg, _)), _) =>
+      case SignatureVerification(VerificationKey(vk, _), Witness(sig, _), Message(msg, _), _) =>
         if ((new Ed25519).verify(ByteVector(sig.toByteArray), ByteVector(msg.toByteArray), ByteVector(vk.toByteArray)))
           Either.right[QuivrRuntimeError, SignatureVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionAuthorizationInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionAuthorizationInterpreter.scala
@@ -118,7 +118,7 @@ object TransactionAuthorizationInterpreter {
         context:      DynamicContext[F, String, Datum]
       )(implicit verifier: Verifier[F, Datum]): F[Either[TransactionAuthorizationError, Boolean]] =
         if (threshold === 0) true.asRight[TransactionAuthorizationError].pure[F]
-        else if (threshold >= propositions.size)
+        else if (threshold > propositions.size)
           Either
             .left[TransactionAuthorizationError, Boolean](TransactionAuthorizationError.AuthorizationFailed())
             .pure[F]

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxError.scala
@@ -1,8 +1,8 @@
 package co.topl.brambl.validation
 
-import co.topl.brambl.models.KnownIdentifier
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.transaction.{Attestation, Schedule}
+import co.topl.brambl.models.transaction.Schedule
 import quivr.models.{Proof, Proposition}
 
 sealed abstract class TransactionSyntaxError extends ValidationError
@@ -17,7 +17,7 @@ object TransactionSyntaxError {
   /**
    * A Syntax error indicating that this transaction multiple inputs referring to the same KnownIdentifier.
    */
-  case class DuplicateInput(knownIdentifier: KnownIdentifier) extends TransactionSyntaxError
+  case class DuplicateInput(knownIdentifier: TransactionOutputAddress) extends TransactionSyntaxError
 
   /**
    * A Syntax error indicating that this transaction contains too many outputs.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -107,7 +107,8 @@ object TransactionSyntaxInterpreter {
     transaction.outputs
       .foldMap[ValidatedNec[TransactionSyntaxError, Unit]](output =>
         (output.value.value match {
-          case Value.Value.Token(Value.Token(Int128(q, _), _))       => BigInt(q.toByteArray).some
+          case Value.Value.Lvl(v)                                    => BigInt(v.quantity.value.toByteArray).some
+          case Value.Value.Topl(v)                                   => BigInt(v.quantity.value.toByteArray).some
           case Value.Value.Asset(Value.Asset(_, Int128(q, _), _, _)) => BigInt(q.toByteArray).some
           case _                                                     => none
         }).foldMap((quantity: BigInt) =>
@@ -153,7 +154,8 @@ object TransactionSyntaxInterpreter {
   ): ValidatedNec[TransactionSyntaxError, Unit] =
     NonEmptyChain(
       // Extract all Token values and their quantities
-      f { case Value.Value.Token(Value.Token(Int128(q, _), _)) => BigInt(q.toByteArray) },
+      f { case Value.Value.Lvl(v) => BigInt(v.quantity.value.toByteArray) },
+      f { case Value.Value.Topl(v) => BigInt(v.quantity.value.toByteArray) },
       // Extract all Asset values and their quantities
       f { case Value.Value.Asset(Value.Asset(_, Int128(q, _), _, _)) => BigInt(q.toByteArray) }
     ).appendChain(

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -54,7 +54,7 @@ object TransactionSyntaxInterpreter {
     NonEmptyChain
       .fromSeq(
         transaction.inputs
-          .groupBy(_.knownIdentifier)
+          .groupBy(_.address)
           .collect {
             case (knownIdentifier, inputs) if inputs.size > 1 =>
               TransactionSyntaxError.DuplicateInput(knownIdentifier)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -100,7 +100,7 @@ object CredentiallerInterpreter {
       input: SpentTransactionOutput,
       msg:   SignableBytes
     ): F[SpentTransactionOutput] = {
-      val idx: Option[Indices] = dataApi.getIndicesByKnownIdentifier(input.knownIdentifier)
+      val idx: Option[Indices] = None // TODO dataApi.getIndicesByKnownIdentifier(input.address)
       val attestation: F[Attestation] = input.attestation.value match {
         case Attestation.Value.Predicate(Attestation.Predicate(predLock, _, _)) =>
           predLock.challenges
@@ -110,7 +110,7 @@ object CredentiallerInterpreter {
         // TODO: We are not handling other types of Attestations at this moment in time
         case _ => ???
       }
-      attestation.map(SpentTransactionOutput(input.knownIdentifier, _, input.value, input.datum, input.opts))
+      attestation.map(SpentTransactionOutput(input.address, _, input.value))
     }
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -100,7 +100,7 @@ object CredentiallerInterpreter {
       input: SpentTransactionOutput,
       msg:   SignableBytes
     ): F[SpentTransactionOutput] = {
-      val idx: Option[Indices] = None // TODO dataApi.getIndicesByKnownIdentifier(input.address)
+      val idx: Option[Indices] = dataApi.getIndicesByKnownIdentifier(input.address)
       val attestation: F[Attestation] = input.attestation.value match {
         case Attestation.Value.Predicate(Attestation.Predicate(predLock, _, _)) =>
           predLock.challenges

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -76,7 +76,7 @@ object CredentiallerInterpreter {
             .flatMap(r =>
               idx
                 .flatMap(i => dataApi.getKeyPair(i, r))
-                .flatMap(keyPair => keyPair.sk)
+                .map(keyPair => keyPair.sk)
                 .map(sk => Prover.signatureProver[F].prove(r.sign(sk, msg), msg))
             )
             .getOrElse(Proof().pure[F])

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -35,7 +35,7 @@ object MockDataApi extends DataApi with MockHelpers {
     .get(id)
     .flatMap(idxToLocks.get)
     .map(Lock().withPredicate(_))
-    .map(Box(_, Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))))
+    .map(Box(_, Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))))
 
   override def getPreimage(idx: Indices): Option[Preimage] =
     if (

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -1,15 +1,11 @@
 package co.topl.brambl
 
-import cats.Id
-import co.topl.brambl.common.ContainsEvidence._
-import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.dataApi.DataApi
 import co.topl.brambl.models._
-import co.topl.brambl.models.box.{Box, Lock, Value}
-import co.topl.brambl.models.transaction.{IoTransaction, Schedule}
-import co.topl.brambl.routines.digests.Blake2b256Digest
-import co.topl.brambl.routines.signatures.{Ed25519Signature, Signing}
-import co.topl.quivr.api.Proposer
+import co.topl.brambl.models.box.Box
+import co.topl.brambl.models.box.Lock
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.routines.signatures.Signing
 import com.google.protobuf.ByteString
 import quivr.models._
 
@@ -24,14 +20,11 @@ object MockDataApi extends DataApi with MockHelpers {
     Indices(0, 0, 0) -> inLockFull
   )
 
-  val idToIdx: Map[KnownIdentifier, Indices] = Map(
+  val idToIdx: Map[TransactionOutputAddress, Indices] = Map(
     dummyTxIdentifier -> Indices(0, 0, 0)
-  ).map { case (o32, v) =>
-    KnownIdentifier().withTransactionOutput32(o32) -> v
-  }
-  override def getIndicesByKnownIdentifier(id: KnownIdentifier): Option[Indices] = idToIdx.get(id)
+  )
 
-  override def getBoxByKnownIdentifier(id: KnownIdentifier): Option[Box] = idToIdx
+  override def getBoxByKnownIdentifier(id: TransactionOutputAddress): Option[Box] = idToIdx
     .get(id)
     .flatMap(idxToLocks.get)
     .map(Lock().withPredicate(_))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -24,6 +24,9 @@ object MockDataApi extends DataApi with MockHelpers {
     dummyTxIdentifier -> Indices(0, 0, 0)
   )
 
+  override def getIndicesByKnownIdentifier(id: TransactionOutputAddress): Option[Indices] =
+    idToIdx.get(id)
+
   override def getBoxByKnownIdentifier(id: TransactionOutputAddress): Option[Box] = idToIdx
     .get(id)
     .flatMap(idxToLocks.get)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -11,7 +11,6 @@ import co.topl.brambl.models.box.{Lock, Value}
 import co.topl.brambl.models.transaction._
 import co.topl.brambl.routines.digests.Blake2b256Digest
 import co.topl.brambl.routines.signatures.Ed25519Signature
-import co.topl.proto.models.Proof
 import co.topl.quivr.api.{Proposer, Prover}
 import com.google.protobuf.ByteString
 import quivr.models.{Int128, Preimage, SignableBytes, SmallData}
@@ -44,7 +43,7 @@ trait MockHelpers {
     Datum.SpentOutput(Event.SpentTransactionOutput(SmallData(ByteString.copyFrom("metadata".getBytes))))
 
   val value: Value =
-    Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))
+    Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))
 
   val trivialOutLock: Lock =
     Lock().withPredicate(Lock.Predicate(List(Proposer.tickProposer[Id].propose(5, 15)), 1))
@@ -71,7 +70,7 @@ trait MockHelpers {
           (
             // Hardcoding Ed25519Signature
             Ed25519Signature.routine,
-            Ed25519Signature.createKeyPair(MockSecret).vk.get // Get will be removed once validation rules are in place
+            Ed25519Signature.createKeyPair(MockSecret).vk // Get will be removed once validation rules are in place
           )
         ),
       Proposer.heightProposer[Id].propose(("header", 0, 100)),

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -72,7 +72,7 @@ trait MockHelpers {
           (
             // Hardcoding Ed25519Signature
             Ed25519Signature.routine,
-            Ed25519Signature.createKeyPair(MockSecret).vk // Get will be removed once validation rules are in place
+            Ed25519Signature.createKeyPair(MockSecret).vk
           )
         ),
       Proposer.heightProposer[Id].propose(("header", 0, 100)),

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -24,8 +24,6 @@ trait MockHelpers {
     Event
       .IoTransaction(
         Schedule(3, 50, 100),
-        List(),
-        List(),
         SmallData(ByteString.copyFrom("metadata".getBytes))
       )
   )
@@ -33,8 +31,13 @@ trait MockHelpers {
   // Arbitrary Transaction that any new transaction can reference
   val dummyTx: IoTransaction = IoTransaction(datum = txDatum)
 
-  val dummyTxIdentifier: KnownIdentifier.TransactionOutput32 =
-    KnownIdentifier.TransactionOutput32(0, 0, 0, Identifier.IoTransaction32(dummyTx.sized32Evidence))
+  val dummyTxIdentifier: TransactionOutputAddress =
+    TransactionOutputAddress(
+      0,
+      0,
+      0,
+      TransactionOutputAddress.Id.IoTransaction32(Identifier.IoTransaction32(dummyTx.sized32Evidence))
+    )
 
   val outDatum: Datum.UnspentOutput =
     Datum.UnspentOutput(Event.UnspentTransactionOutput(SmallData(ByteString.copyFrom("metadata".getBytes))))
@@ -48,9 +51,8 @@ trait MockHelpers {
   val trivialOutLock: Lock =
     Lock().withPredicate(Lock.Predicate(List(Proposer.tickProposer[Id].propose(5, 15)), 1))
 
-  val address: Address =
-    Address(0, 0, Identifier().withLock32(Identifier.Lock32(trivialOutLock.sized32Evidence)))
-  val knownId: KnownIdentifier = KnownIdentifier().withTransactionOutput32(dummyTxIdentifier)
+  val lockAddress: LockAddress =
+    LockAddress(0, 0, LockAddress.Id.Lock32(Identifier.Lock32(trivialOutLock.sized32Evidence)))
 
   val inLockFull: Lock.Predicate = Lock.Predicate(
     List(
@@ -91,12 +93,12 @@ trait MockHelpers {
     )
   )
 
-  val output: UnspentTransactionOutput = UnspentTransactionOutput(address, value, outDatum)
+  val output: UnspentTransactionOutput = UnspentTransactionOutput(lockAddress, value)
 
   val attFull: Attestation = Attestation().withPredicate(Attestation.Predicate(inLockFull, List()))
 
   val inputFull: SpentTransactionOutput =
-    SpentTransactionOutput(knownId, attFull, value, inDatum, List())
+    SpentTransactionOutput(dummyTxIdentifier, attFull, value)
 
   val txFull: IoTransaction = IoTransaction(List(inputFull), List(output), txDatum)
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
@@ -1,12 +1,22 @@
 package co.topl.brambl.generators
 
+import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.Lock
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.Attestation
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.{Datum, Event, Evidence, Identifier}
 import co.topl.brambl.models.transaction.Schedule
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.quivr.generators.ModelGenerators.{arbitraryDigest32, arbitraryDigest64}
 import com.google.protobuf.ByteString
 import org.scalacheck.{Arbitrary, Gen}
+import quivr.models.Int128
+import quivr.models.Proof
+
+import java.util.Random
 
 trait EvidenceGenerator {
 
@@ -84,6 +94,18 @@ trait IdentifierGenerator extends EvidenceGenerator {
     )
 }
 
+trait LockAddressGenerator extends IdentifierGenerator {
+
+  implicit val arbitraryLockAddress: Arbitrary[LockAddress] =
+    Arbitrary(
+      for {
+        network <- Gen.chooseNum(0, 50)
+        ledger  <- Gen.chooseNum(0, 50)
+        id      <- arbitraryLock32.arbitrary
+      } yield LockAddress(network, ledger, LockAddress.Id.Lock32(id))
+    )
+}
+
 trait TransactionOutputAddressGenerator extends IdentifierGenerator {
 
   implicit val arbitraryTransactionOutputAddress: Arbitrary[TransactionOutputAddress] =
@@ -98,7 +120,47 @@ trait TransactionOutputAddressGenerator extends IdentifierGenerator {
 
 }
 
-trait EventGenerator extends TransactionGenerator with TransactionOutputAddressGenerator {
+trait LockGenerator {
+
+  implicit val arbitraryPredicateLock: Arbitrary[Lock.Predicate] =
+    Arbitrary(
+      Gen.const(
+        Lock.Predicate.defaultInstance // TODO
+      )
+    )
+}
+
+trait ProofGenerator {
+
+  implicit val arbitraryProof: Arbitrary[Proof] =
+    Arbitrary(
+      Gen.const(
+        Proof.defaultInstance // TODO
+      )
+    )
+}
+
+trait AttestationGenerator extends LockGenerator with ProofGenerator {
+
+  implicit val arbitraryAttestation: Arbitrary[Attestation] =
+    Arbitrary(
+      for {
+        lock      <- arbitraryPredicateLock.arbitrary
+        responses <- Gen.listOf(arbitraryProof.arbitrary)
+      } yield Attestation().withPredicate(Attestation.Predicate(lock, responses))
+    )
+}
+
+trait EventGenerator extends TransactionOutputAddressGenerator {
+
+  implicit val arbitrarySchedule: Arbitrary[Schedule] =
+    Arbitrary(
+      for {
+        min       <- Gen.chooseNum(0L, 50L)
+        max       <- Gen.chooseNum(0L, 50L)
+        timestamp <- Gen.chooseNum(0L, 50L)
+      } yield Schedule.of(min, min + max, timestamp)
+    )
 
   implicit val arbitraryEventEon: Arbitrary[Event.Eon] =
     Arbitrary(
@@ -198,19 +260,57 @@ trait DatumGenerator extends EventGenerator {
 
 }
 
-trait TransactionGenerator {
+trait ValueGenerator {
 
-  implicit val arbitrarySchedule: Arbitrary[Schedule] =
+  implicit val arbitraryInt128: Arbitrary[Int128] =
+    Arbitrary(
+      Gen.uuid
+        .map(_ => BigInt(127, new Random()))
+        .map(_.toByteArray)
+        .map(ByteString.copyFrom)
+        .map(Int128(_))
+    )
+
+  implicit val arbitraryValue: Arbitrary[Value] =
     Arbitrary(
       for {
-        min       <- Gen.chooseNum(0L, 50L)
-        max       <- Gen.chooseNum(0L, 50L)
-        timestamp <- Gen.chooseNum(0L, 50L)
-      } yield Schedule.of(min, max, timestamp)
+        quantity <- arbitraryInt128.arbitrary
+      } yield Value(Value.Value.Lvl(Value.LVL(quantity)))
+    )
+}
+
+trait TransactionGenerator
+    extends DatumGenerator
+    with LockAddressGenerator
+    with ValueGenerator
+    with TransactionOutputAddressGenerator
+    with AttestationGenerator {
+
+  implicit val arbitraryUnspentTransactionOutput: Arbitrary[UnspentTransactionOutput] =
+    Arbitrary(
+      for {
+        lockAddress <- arbitraryLockAddress.arbitrary
+        value       <- arbitraryValue.arbitrary
+      } yield UnspentTransactionOutput(lockAddress, value)
+    )
+
+  implicit val arbitrarySpentTransactionOutput: Arbitrary[SpentTransactionOutput] =
+    Arbitrary(
+      for {
+        address     <- arbitraryTransactionOutputAddress.arbitrary
+        attestation <- arbitraryAttestation.arbitrary
+        value       <- arbitraryValue.arbitrary
+      } yield SpentTransactionOutput(address, attestation, value)
     )
 
   implicit val arbitraryIoTransaction: Arbitrary[IoTransaction] =
-    Arbitrary(Gen.const(???)) // TODO
+    Arbitrary(
+      for {
+        inputs  <- Gen.listOf(arbitrarySpentTransactionOutput.arbitrary)
+        outputs <- Gen.listOf(arbitraryUnspentTransactionOutput.arbitrary)
+        datum   <- genDatumIoTransaction
+      } yield IoTransaction(inputs, outputs, datum)
+    ) // TODO
 }
 
 trait ModelGenerators

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
@@ -80,7 +80,7 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("validate positive output quantities") {
-    val negativeValue: Value = Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
+    val negativeValue: Value = Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator
@@ -91,8 +91,8 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("validate sufficient input funds") {
-    val tokenValueIn: Value = Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(100).toByteArray))))
-    val tokenValueOut: Value = Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(101).toByteArray))))
+    val tokenValueIn: Value = Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(100).toByteArray))))
+    val tokenValueOut: Value = Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(101).toByteArray))))
     val assetValueIn: Value =
       Value().withAsset(Value.Asset("label", Int128(ByteString.copyFrom(BigInt(100).toByteArray)), SmallData()))
     val assetValueOut: Value =

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
@@ -30,7 +30,7 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
     val result = validator
       .validate(testTx)
       .swap
-      .exists(_.toList.contains(TransactionSyntaxError.DuplicateInput(inputFull.knownIdentifier)))
+      .exists(_.toList.contains(TransactionSyntaxError.DuplicateInput(inputFull.address)))
     assertEquals(result, true)
   }
 
@@ -163,8 +163,6 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
           Event
             .IoTransaction(
               Schedule(3, 50, 100),
-              List(),
-              List(),
               SmallData(invalidData)
             )
         )
@@ -188,8 +186,6 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
             Event
               .IoTransaction(
                 Schedule(3, 50, 100),
-                List(),
-                List(),
                 SmallData()
               )
           )
@@ -208,8 +204,6 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
               Event
                 .IoTransaction(
                   Schedule(3, 50, 100),
-                  List(),
-                  List(),
                   SmallData(invalidData)
                 )
             )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -5,7 +5,6 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.{Context, MockDataApi, MockHelpers}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
-import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.validation.TransactionAuthorizationError.AuthorizationFailed
 import co.topl.brambl.validation.TransactionSyntaxError

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -53,7 +53,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("validate: Single Input Transaction with Attestation.Predicate > Validation failed") {
     val negativeValue: Value =
-      Value.defaultInstance.withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
+      Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val credentialler = CredentiallerInterpreter.make[Id](MockDataApi)
     val provenTx: IoTransaction = credentialler.prove(testTx)
@@ -101,7 +101,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation failed") {
-    val negativeValue: Value = Value().withToken(Value.Token(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
+    val negativeValue: Value = Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val credentialler = CredentiallerInterpreter.make[Id](MockDataApi)
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val ctx = Context[Id](testTx, 500, _ => None) // Tick does not satisfies proposition

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -5,10 +5,10 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.{Context, MockDataApi, MockHelpers}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
-import co.topl.brambl.models.KnownIdentifier
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.validation.TransactionAuthorizationError.AuthorizationFailed
-import co.topl.brambl.validation.{TransactionAuthorizationError, TransactionSyntaxError}
+import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
   EvaluationAuthorizationFailed,
   LockedPropositionIsUnsatisfiable
@@ -30,9 +30,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("prove: Single Input Transaction with Attestation.Predicate > Unprovable propositions have empty proofs") {
     // Secrets are not available for this KnownIdentifier
-    val unknownKnownId =
-      KnownIdentifier().withTransactionOutput32(dummyTxIdentifier.copy(network = 1, ledger = 1, index = 1))
-    val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(knownIdentifier = unknownKnownId)))
+    val unknownKnownId = dummyTxIdentifier.copy(network = 1, ledger = 1, index = 1)
+    val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(address = unknownKnownId)))
     val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val crypto = project
     name := "crypto",
     commonSettings,
     publishSettings,
+    Test / publishArtifact := true,
     libraryDependencies ++=
       Dependencies.Crypto.sources ++
       Dependencies.Crypto.tests,

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ lazy val bramblSdk = project
     libraryDependencies ++=
       Dependencies.BramblSdk.sources ++
       Dependencies.BramblSdk.tests,
-    scalamacrosParadiseSettings
+    scalamacrosParadiseSettings,
+    dependencyOverrides ++= Dependencies.protobufSpecs
   )
   .dependsOn(crypto)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "0.1" // scala-steward:off
-    val protobufSpecsVersion = "f24c89f5" // scala-steward:off
+    val quivr4sVersion = "7280dd5" // scala-steward:off
+    val protobufSpecsVersion = "6343322" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 
@@ -63,13 +63,11 @@ object Dependencies {
   )
 
   val protobufSpecs: Seq[ModuleID] = Seq(
-    "co.topl" %% "protobuf-fs2" % protobufSpecsVersion
-//    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
+    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
   )
 
   val quivr4s: Seq[ModuleID] = Seq(
-//    "com.github.Topl" % "quivr4s" % quivr4sVersion
-    "co.topl" %% "quivr4s" % quivr4sVersion
+    "com.github.Topl" % "quivr4s" % quivr4sVersion
   )
 
   object Crypto {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "ef14fe2" // scala-steward:off
-    val protobufSpecsVersion = "e08d4b2" // scala-steward:off
+    val quivr4sVersion = "0.1" // scala-steward:off
+    val protobufSpecsVersion = "221e19a6" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 
@@ -63,11 +63,13 @@ object Dependencies {
   )
 
   val protobufSpecs: Seq[ModuleID] = Seq(
-    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
+    "co.topl" %% "protobuf-fs2" % protobufSpecsVersion
+//    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
   )
 
   val quivr4s: Seq[ModuleID] = Seq(
-    "com.github.Topl" % "quivr4s" % quivr4sVersion
+//    "com.github.Topl" % "quivr4s" % quivr4sVersion
+    "co.topl" %% "quivr4s" % quivr4sVersion
   )
 
   object Crypto {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
     val quivr4sVersion = "0.1" // scala-steward:off
-    val protobufSpecsVersion = "ceceba75" // scala-steward:off
+    val protobufSpecsVersion = "b56d2815" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
     val quivr4sVersion = "0.1" // scala-steward:off
-    val protobufSpecsVersion = "221e19a6" // scala-steward:off
+    val protobufSpecsVersion = "ceceba75" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
     val quivr4sVersion = "0.1" // scala-steward:off
-    val protobufSpecsVersion = "b56d2815" // scala-steward:off
+    val protobufSpecsVersion = "f24c89f5" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose
- Update protobuf-specs
- Removes usage of KnownIdentifier
- Adds a few more transaction-related generators
- Adds serialization for new Box Value types
## Approach
- Use new protobuf-specs version
- Replace KnownIdentifier with TransactionOutputAddress
## Testing
- preparePR
- Used in Bifrost
## Tickets
- BN-713