### PR TITLE
TSDK-333 Minor changes to align with new models/IoTransaction Model

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilder.scala
@@ -16,9 +16,7 @@ trait TransactionBuilder[F[_]] {
    *
    * @param data The data required to build a SpentTransactionOutput
    *             The data is an object with the following fields:
-   *             id: KnownIdentifier - Identifies an existing IoTransaction output for which the built input is spending.
-   *             metadata: Option[SmallData] - Optional metadata to include in the built SpentTransactionOutput
-   *             If not provided, the built SpentTransactionOutput's metadata will be empty data
+   *             address: TransactionOutputAddress - Identifies an existing IoTransaction output for which the built input is spending.
    * @return Either a InputBuilderError or the built SpentTransactionOutput
    */
   def constructUnprovenInput(data: InputBuildRequest): F[Either[BuilderError.InputBuilderError, SpentTransactionOutput]]
@@ -28,10 +26,8 @@ trait TransactionBuilder[F[_]] {
    *
    * @param data The data required to build an UnspentTransactionOutput
    *             The data is an object with the following fields:
-   *             lock: Lock - The lock for the built UnspentTransactionOutput. It will be encoded in the address
+   *             address: LockAddress - The address for the built UnspentTransactionOutput.
    *             value: Value - The value for the built UnspentTransactionOutput
-   *             metadata: Option[SmallData] - Optional metadata to include in the built UnspentTransactionOutput
-   *             If not provided, the built UnspentTransactionOutput's metadata will be empty data
    * @return Either a OutputBuilderError or the built UnspentTransactionOutput
    */
   def constructOutput(data: OutputBuildRequest): F[Either[BuilderError.OutputBuilderError, UnspentTransactionOutput]]
@@ -51,10 +47,6 @@ trait TransactionBuilder[F[_]] {
    *                 If not provided, the built transaction will have a default schedule with min set to 0, max set to
    *                 2147483647 and timestamp set to the current time.
    * TODO: when the slot number conversion is working, default min will be set to the current slot number and max set to the current slot number + 14400 (approximately 4 hours later)
-   * @param output32Refs A list of identifiers that refer to existing IoTransactions outputs using 32 byte evidences.
-   *                     Defaults to an empty list
-   * @param output64Refs A list of identifiers that refer to existing IoTransactions outputs using 64 byte evidences.
-   *                     Defaults to an empty list
    * @param metadata Optional metadata to include with the built transaction
    *                 If not provided, the built transaction's metadata will be empty data
    *

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -26,9 +26,9 @@ object TransactionBuilderInterpreter {
     override def constructUnprovenInput(
       data: InputBuildRequest
     ): F[Either[BuilderError.InputBuilderError, SpentTransactionOutput]] = {
-      val box = dataApi.getBoxByKnownIdentifier(data.address)
-      val attestation = box.map(_.lock).map(constructUnprovenAttestation)
-      val value = box.map(_.value)
+      val utxo = dataApi.getUtxoByTxoAddress(data.address)
+      val attestation = utxo.map(_.address).flatMap(dataApi.getLockByLockAddress).map(constructUnprovenAttestation)
+      val value = utxo.map(_.value)
       (attestation, value) match {
         case (Some(Right(att)), Some(boxVal)) =>
           SpentTransactionOutput(data.address, att, boxVal)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -1,8 +1,8 @@
 package co.topl.brambl.dataApi
 
-import co.topl.brambl.models.TransactionOutputAddress
-import co.topl.brambl.models.box.Box
-import co.topl.brambl.models.Indices
+import co.topl.brambl.models.{Indices, LockAddress, TransactionOutputAddress}
+import co.topl.brambl.models.box.{Box, Lock}
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.routines.signatures.Signing
 import quivr.models.{KeyPair, Preimage}
 
@@ -18,27 +18,37 @@ import quivr.models.{KeyPair, Preimage}
 trait DataApi {
 
   /**
-   * Return the indices associated to a known identifier.
-   * Simplifying assumption is that KnownIdentifier and Indices are 1 to 1
+   * Return the indices associated to a TransactionOutputAddress.
    *
-   * @param id The known identifier for which to retrieve the indices
+   * Simplifying assumption *for now* is that TransactionOutputAddress and Indices are 1 to 1. This assumption may
+   * change once more work is done to define the Cartesian Indexing scheme.
+   *
+   * TODO: Revisit this assumption once the Cartesian Indexing scheme is more fleshed out.
+   *
+   * @param address The TransactionOutputAddress for which to retrieve the indices
    * @return The indices associated to the known identifier if it exists. Else None
    */
-  def getIndicesByKnownIdentifier(id: TransactionOutputAddress): Option[Indices]
+  def getIndicesByTxoAddress(address: TransactionOutputAddress): Option[Indices]
 
   /**
-   * Return the box associated to a known identifier.
+   * Return the UTXO targeted by a TransactionOutputAddress.
    *
-   * A Box is created from a utxo. A KnownIdentifier combines an Identifier and an index. For the simple use-case,
-   * we are only considering the KnownIdentifiers that are already defined in our ecosystem; TransactionOutput32 and
-   * TransactionOutput64, both of which refer to a transaction output (i.e, utxo).
+   * A TransactionOutputAddress identifies an output (UTXO) of an existing transaction on the chain.
    *
-   * Therefore, we can make the simplifying assumption that Box and KnownIdentifier are 1 to 1
-   *
-   * @param id The known identifier for which to retrieve the box
-   * @return The box associated to the known identifier if it exists. Else None
+   * @param address The TransactionOutputAddress of the UTXO to retrieve
+   * @return The UTXO targeted by the given address, if it exists. Else None
    */
-  def getBoxByKnownIdentifier(id: TransactionOutputAddress): Option[Box]
+  def getUtxoByTxoAddress(address: TransactionOutputAddress): Option[UnspentTransactionOutput]
+
+  /**
+   * Return the Lock targeted by a LockAddress
+   *
+   * A LockAddress is meant to identify a Lock on chain.
+   *
+   * @param address The LockAddress for which to retrieve the Lock
+   * @return The Lock targeted by the given address, if it exists. Else None
+   */
+  def getLockByLockAddress(address: LockAddress): Option[Lock]
 
   /**
    * Return the preimage secret associated to indices.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -100,7 +100,8 @@ object CredentiallerInterpreter {
       input: SpentTransactionOutput,
       msg:   SignableBytes
     ): F[SpentTransactionOutput] = {
-      val idx: Option[Indices] = dataApi.getIndicesByKnownIdentifier(input.address)
+      // TODO: Revisit when Cartesian Indexing Scheme is more fleshed out
+      val idx: Option[Indices] = dataApi.getIndicesByTxoAddress(input.address)
       val attestation: F[Attestation] = input.attestation.value match {
         case Attestation.Value.Predicate(Attestation.Predicate(predLock, _, _)) =>
           predLock.challenges

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -2,15 +2,14 @@ package co.topl.brambl
 
 import co.topl.brambl.dataApi.DataApi
 import co.topl.brambl.models._
-import co.topl.brambl.models.box.Box
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.routines.signatures.Signing
 import com.google.protobuf.ByteString
 import quivr.models._
 
 /**
- * *
  * Mock Implementation of the DataApi
  */
 object MockDataApi extends DataApi with MockHelpers {
@@ -20,18 +19,27 @@ object MockDataApi extends DataApi with MockHelpers {
     Indices(0, 0, 0) -> inLockFull
   )
 
-  val idToIdx: Map[TransactionOutputAddress, Indices] = Map(
-    dummyTxIdentifier -> Indices(0, 0, 0)
+  val txoAddrToIdx: Map[TransactionOutputAddress, Indices] = Map(
+    dummyTxoAddress -> Indices(0, 0, 0)
   )
 
-  override def getIndicesByKnownIdentifier(id: TransactionOutputAddress): Option[Indices] =
-    idToIdx.get(id)
+  val txoAddrToTxo: Map[TransactionOutputAddress, UnspentTransactionOutput] = Map(
+    dummyTxoAddress -> UnspentTransactionOutput(
+      trivialInLockFullAddress,
+      Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))
+    )
+  )
 
-  override def getBoxByKnownIdentifier(id: TransactionOutputAddress): Option[Box] = idToIdx
-    .get(id)
-    .flatMap(idxToLocks.get)
-    .map(Lock().withPredicate(_))
-    .map(Box(_, Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))))
+  val lockAddrToLock: Map[LockAddress, Lock] = Map(
+    trivialInLockFullAddress -> Lock().withPredicate(inLockFull)
+  )
+
+  override def getIndicesByTxoAddress(address: TransactionOutputAddress): Option[Indices] = txoAddrToIdx.get(address)
+
+  override def getUtxoByTxoAddress(address: TransactionOutputAddress): Option[UnspentTransactionOutput] =
+    txoAddrToTxo.get(address)
+
+  override def getLockByLockAddress(address: LockAddress): Option[Lock] = lockAddrToLock.get(address)
 
   override def getPreimage(idx: Indices): Option[Preimage] =
     if (

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -38,21 +38,23 @@ trait MockHelpers {
   // Arbitrary Transaction that any new transaction can reference
   val dummyTx: IoTransaction = IoTransaction(datum = txDatum)
 
-  val dummyTxIdentifier: TransactionOutputAddress =
+  val dummyTxIdentifier: Identifier.IoTransaction32 = Identifier.IoTransaction32(dummyTx.sized32Evidence)
+
+  val dummyTxoAddress: TransactionOutputAddress =
     TransactionOutputAddress(
       0,
       0,
       0,
-      TransactionOutputAddress.Id.IoTransaction32(Identifier.IoTransaction32(dummyTx.sized32Evidence))
+      TransactionOutputAddress.Id.IoTransaction32(dummyTxIdentifier)
     )
 
   val value: Value =
-    Value().withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))
+    Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(1).toByteArray))))
 
   val trivialOutLock: Lock =
     Lock().withPredicate(Lock.Predicate(List(Challenge().withRevealed(Proposer.tickProposer[Id].propose(5, 15))), 1))
 
-  val lockAddress: LockAddress =
+  val trivialLockAddress: LockAddress =
     LockAddress(0, 0, LockAddress.Id.Lock32(Identifier.Lock32(trivialOutLock.sized32Evidence)))
 
   val inLockFull: Lock.Predicate = Lock.Predicate(
@@ -82,6 +84,10 @@ trait MockHelpers {
       .map(Challenge().withRevealed),
     3
   )
+
+  val trivialInLockFullAddress: LockAddress =
+    LockAddress(0, 0, LockAddress.Id.Lock32(Identifier.Lock32(inLockFull.sized32Evidence)))
+
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
 
   val nonEmptyAttestation: Attestation = Attestation().withPredicate(
@@ -95,12 +101,11 @@ trait MockHelpers {
     )
   )
 
-  val output: UnspentTransactionOutput = UnspentTransactionOutput(lockAddress, value)
+  val output: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value)
 
   val attFull: Attestation = Attestation().withPredicate(Attestation.Predicate(inLockFull, List()))
 
-  val inputFull: SpentTransactionOutput =
-    SpentTransactionOutput(dummyTxIdentifier, attFull, value)
+  val inputFull: SpentTransactionOutput = SpentTransactionOutput(dummyTxoAddress, attFull, value)
 
   val txFull: IoTransaction = IoTransaction(List(inputFull), List(output), txDatum)
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -1,0 +1,28 @@
+package co.topl.brambl.builders
+
+import cats.Id
+import co.topl.brambl.{MockDataApi, MockHelpers}
+import co.topl.brambl.models.builders.{InputBuildRequest, OutputBuildRequest}
+import co.topl.brambl.models.transaction.IoTransaction
+
+class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers {
+
+  test("simplest case: 1 input, 1 output. Input and Tx data are available in DataApi") {
+    // both LockAddress and Value are trivial for this test
+    val outputRequests = List(OutputBuildRequest(trivialLockAddress, value))
+    // Points to an existing Transaction Output that already has a lock and value associated with it
+    val inputRequests = List(InputBuildRequest(dummyTxoAddress))
+    val txBuilder: TransactionBuilder[Id] = TransactionBuilderInterpreter.make[Id](MockDataApi)
+    val unprovenTx = txBuilder.constructUnprovenTransaction(inputRequests, outputRequests)
+
+    // Verify no errors
+    assert(unprovenTx.isRight)
+    val res = unprovenTx.getOrElse(IoTransaction.defaultInstance)
+    // Verify the transaction has the correct number of inputs and outputs
+    assert(res.inputs.length == 1)
+    assert(res.outputs.length == 1)
+    // Verify the input has a lock and value
+    assert(res.inputs.head.value.value.isDefined)
+    assert(res.inputs.head.attestation.value.isDefined)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -15,7 +15,6 @@ import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
 import com.google.protobuf.ByteString
 import quivr.models.Int128
 
-// TODO: Replace/Update MockHelpers with the usage of ModelGenerators. TSDK-307
 class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("prove: Single Input Transaction with Attestation.Predicate > Provable propositions have non-empty proofs") {
@@ -28,8 +27,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("prove: Single Input Transaction with Attestation.Predicate > Unprovable propositions have empty proofs") {
-    // Secrets are not available for this KnownIdentifier
-    val unknownKnownId = dummyTxIdentifier.copy(network = 1, ledger = 1, index = 1)
+    // Secrets are not available for this TransactionOutputAddress
+    val unknownKnownId = dummyTxoAddress.copy(network = 1, ledger = 1, index = 1)
     val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(address = unknownKnownId)))
     val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate


### PR DESCRIPTION
## Purpose

Recently there have been many changes to PB w.r.t Addresses, KnownIdentifiers, and Propositions. Most of Brambl has been updated to align with the changes in PR: https://github.com/Topl/BramblSc/pull/27 . 

A few remaining changes were addressed in this PR.

## Approach

A few minor changes were done in this PR.  Notably, 
- some function names and descriptions were updated to not reference KnownIdentifier
- Updated some functions in the preliminary DataApi. Specifically,  getUtxoByTxoAddress and getLockByLockAddress instead of getBoxesByTransactionOutputAddres/KnownIdentifier
- Updated MockDataApi and MockHelpers (for tests) to match
- Added sanity test for TransactionBuilderInterpreter

## Testing

- Ensured everything compiled
- Ensured all existing tests pass
- Added a sanity test for TransactionBuilderInterpreter since none existed before.

## Tickets
* Closes TSDK-333 
