### PR TITLE
TSDK-356 Add AES and SCrypt

### DIFF
--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -1,19 +1,57 @@
 package co.topl.crypto.encryption.cipher
 
+import org.bouncycastle.crypto.engines.AESEngine
+
 /**
  * AES encryption.
  * Aes is a symmetric block cipher that can encrypt and decrypt data using the same key.
  * @see [[https://en.wikipedia.org/wiki/Advanced_Encryption_Standard]]
  */
 class Aes extends Cipher[Aes.AesParams]{
-  override def encrypt(plainText: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
 
-  override def decrypt(cipherText: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+  /**
+   * Encrypt data.
+   *
+   * @note AES block size is a multiple of 16, so the data must have a length multiple of 16.
+   *       Simply padding the bytes would make it impossible to determine the initial data bytes upon encryption.
+   *       The length of plaintext is prepended to the plaintext, and _then_ it is padded.
+   *
+   * @param plainText data to encrypt
+   * @param key encryption key
+   * @param params cipher parameters
+   * @return encrypted data
+   */
+  override def encrypt(plainText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+
+  /**
+   * Decrypt data.
+   *
+   * @note The outputText consists of [dataLength] ++ [data] ++ [padding]
+   *
+   * @param cipherText data to decrypt
+   * @param key encryption key
+   * @param params cipher parameters
+   * @return decrypted data
+   */
+  override def decrypt(cipherText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+
 }
 
 object Aes {
+  /**
+   * AES parameters.
+   */
   trait AesParams extends Params {
     val iv: Array[Byte] // initialization vector
-    val key : Array[Byte] // the key
+  }
+
+  /**
+   * Generate a random initialization vector.
+   * @return a random initialization vector
+   */
+  def generateIv: Array[Byte] = {
+    val iv = new Array[Byte](16)
+    new java.util.Random().nextBytes(iv)
+    iv
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -1,6 +1,9 @@
 package co.topl.crypto.encryption.cipher
 
+import org.bouncycastle.crypto.BufferedBlockCipher
 import org.bouncycastle.crypto.engines.AESEngine
+import org.bouncycastle.crypto.modes.SICBlockCipher
+import org.bouncycastle.crypto.params.{KeyParameter, ParametersWithIV}
 
 /**
  * AES encryption.
@@ -14,30 +17,52 @@ class Aes extends Cipher[Aes.AesParams]{
    *
    * @note AES block size is a multiple of 16, so the data must have a length multiple of 16.
    *       Simply padding the bytes would make it impossible to determine the initial data bytes upon encryption.
-   *       The length of plaintext is prepended to the plaintext, and _then_ it is padded.
+   *       The amount padded to the plaintext is prepended to the plaintext. Since we know the amount padded is
+   *       <16, only one byte is needed to store the amount padded.
    *
    * @param plainText data to encrypt
    * @param key encryption key
    * @param params cipher parameters
    * @return encrypted data
    */
-  override def encrypt(plainText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+  override def encrypt(plainText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = {
+    // + 1 to account for the byte storing the amount padded. This value is guaranteed to be <16
+    val amountPadded = (Aes.BlockSize - ((plainText.length + 1) % Aes.BlockSize)) % Aes.BlockSize
+    val paddedBytes = amountPadded.toByte +: plainText ++: Array.fill[Byte](amountPadded)(0)
+    processAes(paddedBytes, key, params.iv, encrypt = true)
+  }
 
   /**
    * Decrypt data.
    *
-   * @note The outputText consists of [dataLength] ++ [data] ++ [padding]
+   * @note The preImage consists of [paddedAmount] ++ [data] ++ [padding]
    *
    * @param cipherText data to decrypt
    * @param key encryption key
    * @param params cipher parameters
    * @return decrypted data
    */
-  override def decrypt(cipherText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+  override def decrypt(cipherText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = {
+    val preImage = processAes(cipherText, key, params.iv, encrypt = false)
+    val paddedAmount = preImage.head.toInt
+    val paddedBytes = preImage.tail
+    paddedBytes.slice(1, paddedBytes.length - paddedAmount)
+  }
+
+  private def processAes(input:Array[Byte], key:Array[Byte], iv:Array[Byte], encrypt:Boolean): Array[Byte] = {
+    val cipherParams = new ParametersWithIV(new KeyParameter(key), iv)
+    val aesCtr = new BufferedBlockCipher(new SICBlockCipher(new AESEngine))
+    aesCtr.init(encrypt, cipherParams)
+    val output = Array.fill[Byte](input.length)(1: Byte)
+    aesCtr.processBytes(input, 0, input.length, output, 0)
+    aesCtr.doFinal(output, 0)
+    output
+  }
 
 }
 
 object Aes {
+  val BlockSize: Int = 16
   /**
    * AES parameters.
    */
@@ -50,7 +75,7 @@ object Aes {
    * @return a random initialization vector
    */
   def generateIv: Array[Byte] = {
-    val iv = new Array[Byte](16)
+    val iv = new Array[Byte](BlockSize)
     new java.util.Random().nextBytes(iv)
     iv
   }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -1,0 +1,19 @@
+package co.topl.crypto.encryption.cipher
+
+/**
+ * AES encryption.
+ * Aes is a symmetric block cipher that can encrypt and decrypt data using the same key.
+ * @see [[https://en.wikipedia.org/wiki/Advanced_Encryption_Standard]]
+ */
+class Aes extends Cipher[Aes.AesParams]{
+  override def encrypt(plainText: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+
+  override def decrypt(cipherText: Array[Byte], params: Aes.AesParams): Array[Byte] = ???
+}
+
+object Aes {
+  trait AesParams extends Params {
+    val iv: Array[Byte] // initialization vector
+    val key : Array[Byte] // the key
+  }
+}

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -10,7 +10,7 @@ import org.bouncycastle.crypto.params.{KeyParameter, ParametersWithIV}
  * Aes is a symmetric block cipher that can encrypt and decrypt data using the same key.
  * @see [[https://en.wikipedia.org/wiki/Advanced_Encryption_Standard]]
  */
-class Aes extends Cipher[Aes.AesParams]{
+class Aes extends Cipher[Aes.AesParams] {
 
   /**
    * Encrypt data.
@@ -49,7 +49,7 @@ class Aes extends Cipher[Aes.AesParams]{
     paddedBytes.slice(1, paddedBytes.length - paddedAmount)
   }
 
-  private def processAes(input:Array[Byte], key:Array[Byte], iv:Array[Byte], encrypt:Boolean): Array[Byte] = {
+  private def processAes(input: Array[Byte], key: Array[Byte], iv: Array[Byte], encrypt: Boolean): Array[Byte] = {
     val cipherParams = new ParametersWithIV(new KeyParameter(key), iv)
     val aesCtr = new BufferedBlockCipher(new SICBlockCipher(new AESEngine))
     aesCtr.init(encrypt, cipherParams)
@@ -63,6 +63,7 @@ class Aes extends Cipher[Aes.AesParams]{
 
 object Aes {
   val BlockSize: Int = 16
+
   /**
    * AES parameters.
    */

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -40,7 +40,7 @@ object Aes extends Cipher[AesParams] {
    *       <16, only one byte is needed to store the amount padded.
    *
    * @param plainText data to encrypt
-   * @param key encryption key
+   * @param key the symmetric key for encryption and decryption
    *            Must be 128/192/256 bits or 16/24/32 bytes.
    * @param params cipher parameters
    * @return encrypted data
@@ -58,7 +58,7 @@ object Aes extends Cipher[AesParams] {
    * @note The preImage consists of [paddedAmount] ++ [data] ++ [padding]
    *
    * @param cipherText data to decrypt
-   * @param key encryption key
+   * @param key the symmetric key for encryption and decryption
    *            Must be 128/192/256 bits or 16/24/32 bytes.
    * @param params cipher parameters
    * @return decrypted data

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/Aes.scala
@@ -6,11 +6,30 @@ import org.bouncycastle.crypto.modes.SICBlockCipher
 import org.bouncycastle.crypto.params.{KeyParameter, ParametersWithIV}
 
 /**
+ * AES parameters.
+ *
+ * @param iv initialization vector
+ */
+case class AesParams(iv: Array[Byte]) extends Params
+
+/**
  * AES encryption.
  * Aes is a symmetric block cipher that can encrypt and decrypt data using the same key.
  * @see [[https://en.wikipedia.org/wiki/Advanced_Encryption_Standard]]
  */
-class Aes extends Cipher[Aes.AesParams] {
+object Aes extends Cipher[AesParams] {
+  val BlockSize: Int = 16
+
+  /**
+   * Generate a random initialization vector.
+   *
+   * @return a random initialization vector
+   */
+  def generateIv: Array[Byte] = {
+    val iv = new Array[Byte](BlockSize)
+    new java.util.Random().nextBytes(iv)
+    iv
+  }
 
   /**
    * Encrypt data.
@@ -22,10 +41,11 @@ class Aes extends Cipher[Aes.AesParams] {
    *
    * @param plainText data to encrypt
    * @param key encryption key
+   *            Must be 128/192/256 bits or 16/24/32 bytes.
    * @param params cipher parameters
    * @return encrypted data
    */
-  override def encrypt(plainText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = {
+  override def encrypt(plainText: Array[Byte], key: Array[Byte], params: AesParams): Array[Byte] = {
     // + 1 to account for the byte storing the amount padded. This value is guaranteed to be <16
     val amountPadded = (Aes.BlockSize - ((plainText.length + 1) % Aes.BlockSize)) % Aes.BlockSize
     val paddedBytes = amountPadded.toByte +: plainText ++: Array.fill[Byte](amountPadded)(0)
@@ -39,14 +59,15 @@ class Aes extends Cipher[Aes.AesParams] {
    *
    * @param cipherText data to decrypt
    * @param key encryption key
+   *            Must be 128/192/256 bits or 16/24/32 bytes.
    * @param params cipher parameters
    * @return decrypted data
    */
-  override def decrypt(cipherText: Array[Byte], key: Array[Byte], params: Aes.AesParams): Array[Byte] = {
+  override def decrypt(cipherText: Array[Byte], key: Array[Byte], params: AesParams): Array[Byte] = {
     val preImage = processAes(cipherText, key, params.iv, encrypt = false)
     val paddedAmount = preImage.head.toInt
     val paddedBytes = preImage.tail
-    paddedBytes.slice(1, paddedBytes.length - paddedAmount)
+    paddedBytes.slice(0, paddedBytes.length - paddedAmount)
   }
 
   private def processAes(input: Array[Byte], key: Array[Byte], iv: Array[Byte], encrypt: Boolean): Array[Byte] = {
@@ -59,25 +80,4 @@ class Aes extends Cipher[Aes.AesParams] {
     output
   }
 
-}
-
-object Aes {
-  val BlockSize: Int = 16
-
-  /**
-   * AES parameters.
-   */
-  trait AesParams extends Params {
-    val iv: Array[Byte] // initialization vector
-  }
-
-  /**
-   * Generate a random initialization vector.
-   * @return a random initialization vector
-   */
-  def generateIv: Array[Byte] = {
-    val iv = new Array[Byte](BlockSize)
-    new java.util.Random().nextBytes(iv)
-    iv
-  }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
@@ -5,14 +5,17 @@ package co.topl.crypto.encryption
  * @see [[https://en.wikipedia.org/wiki/Cipher]]
  */
 package object cipher {
+
   /**
    * Cipher parameters.
    */
   trait Params
+
   /**
    * A Cipher.
    */
   trait Cipher[P <: Params] {
+
     /**
      * Encrypt data.
      * @param plainText data to encrypt
@@ -21,6 +24,7 @@ package object cipher {
      * @return encrypted data
      */
     def encrypt(plainText: Array[Byte], key: Array[Byte], params: P): Array[Byte]
+
     /**
      * Decrypt data.
      * @param cipherText data to decrypt

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
@@ -1,0 +1,13 @@
+package co.topl.crypto.encryption
+
+/**
+ * Ciphers are used to encrypt and decrypt data.
+ * @see [[https://en.wikipedia.org/wiki/Cipher]]
+ */
+package object cipher {
+  trait Params
+  trait Cipher[P <: Params] {
+    def encrypt(plainText: Array[Byte], params: P): Array[Byte]
+    def decrypt(cipherText: Array[Byte], params: P): Array[Byte]
+  }
+}

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
@@ -5,9 +5,29 @@ package co.topl.crypto.encryption
  * @see [[https://en.wikipedia.org/wiki/Cipher]]
  */
 package object cipher {
+  /**
+   * Cipher parameters.
+   */
   trait Params
+  /**
+   * A Cipher.
+   */
   trait Cipher[P <: Params] {
-    def encrypt(plainText: Array[Byte], params: P): Array[Byte]
-    def decrypt(cipherText: Array[Byte], params: P): Array[Byte]
+    /**
+     * Encrypt data.
+     * @param plainText data to encrypt
+     * @param key encryption key
+     * @param params cipher parameters
+     * @return encrypted data
+     */
+    def encrypt(plainText: Array[Byte], key: Array[Byte], params: P): Array[Byte]
+    /**
+     * Decrypt data.
+     * @param cipherText data to decrypt
+     * @param key encryption key
+     * @param params cipher parameters
+     * @return decrypted data
+     */
+    def decrypt(cipherText: Array[Byte], key: Array[Byte], params: P): Array[Byte]
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/cipher/cipher.scala
@@ -28,7 +28,7 @@ package object cipher {
     /**
      * Decrypt data.
      * @param cipherText data to decrypt
-     * @param key encryption key
+     * @param key decryption key
      * @param params cipher parameters
      * @return decrypted data
      */

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
@@ -1,0 +1,19 @@
+package co.topl.crypto.encryption.kdf
+
+/**
+ * Scrypt is a key derivation function.
+ * @see [[https://en.wikipedia.org/wiki/Scrypt]]
+ */
+class Scrypt extends Kdf[Scrypt.ScryptParams] {
+  override def deriveKey(secret: Array[Byte], params: Scrypt.ScryptParams): Array[Byte] = ???
+}
+
+object Scrypt {
+  trait ScryptParams extends Params {
+    val salt : Array[Byte] // salt
+    val n: Int // CPU/memory cost parameter
+    val r: Int // block size parameter
+    val p: Int // parallelization parameter
+    val dkLen: Int // length of derived key
+  }
+}

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
@@ -7,6 +7,7 @@ import org.bouncycastle.crypto.generators.SCrypt
  * @see [[https://en.wikipedia.org/wiki/Scrypt]]
  */
 class Scrypt extends Kdf[Scrypt.ScryptParams] {
+
   /**
    * Derive a key from a secret.
    * @param secret secret to derive key from
@@ -18,12 +19,13 @@ class Scrypt extends Kdf[Scrypt.ScryptParams] {
 }
 
 object Scrypt {
+
   /**
    * Scrypt parameters.
    */
   trait ScryptParams extends Params {
     // salt
-    val salt : Array[Byte]
+    val salt: Array[Byte]
     // CPU/Memory cost parameter. Must be larger than 1, a power of 2 and less than 2^(128 * r / 8)
     val n: Int = scala.math.pow(2, 18).toInt
     // the block size, must be >= 1.

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
@@ -3,10 +3,41 @@ package co.topl.crypto.encryption.kdf
 import org.bouncycastle.crypto.generators.SCrypt
 
 /**
+ * Scrypt parameters.
+ *
+ * @param salt  salt
+ * @param n     CPU/Memory cost parameter.
+ *              Must be larger than 1, a power of 2 and less than 2^(128 * r / 8)^. Defaults to 2^18^.
+ * @param r     the block size.
+ *              Must be &gt;= 1. Defaults to 8.
+ * @param p     Parallelization parameter.
+ *              Must be a positive integer less than or equal to Integer.MAX_VALUE / (128 * r * 8). Defaults to 1.
+ * @param dkLen length of derived key. Defaults to 32.
+ */
+case class ScryptParams(
+  salt:  Array[Byte],
+  n:     Int = scala.math.pow(2, 18).toInt,
+  r:     Int = 8,
+  p:     Int = 1,
+  dkLen: Int = 32
+) extends Params
+
+/**
  * Scrypt is a key derivation function.
  * @see [[https://en.wikipedia.org/wiki/Scrypt]]
  */
-class Scrypt extends Kdf[Scrypt.ScryptParams] {
+object Scrypt extends Kdf[ScryptParams] {
+
+  /**
+   * Generate a random salt.
+   *
+   * @return a random salt of 32 bytes
+   */
+  def generateSalt: Array[Byte] = {
+    val salt = new Array[Byte](32)
+    new java.util.Random().nextBytes(salt)
+    salt
+  }
 
   /**
    * Derive a key from a secret.
@@ -14,35 +45,6 @@ class Scrypt extends Kdf[Scrypt.ScryptParams] {
    * @param params KDF parameters
    * @return derived key
    */
-  override def deriveKey(secret: Array[Byte], params: Scrypt.ScryptParams): Array[Byte] =
+  override def deriveKey(secret: Array[Byte], params: ScryptParams): Array[Byte] =
     SCrypt.generate(secret, params.salt, params.n, params.r, params.p, params.dkLen)
-}
-
-object Scrypt {
-
-  /**
-   * Scrypt parameters.
-   */
-  trait ScryptParams extends Params {
-    // salt
-    val salt: Array[Byte]
-    // CPU/Memory cost parameter. Must be larger than 1, a power of 2 and less than 2^(128 * r / 8)
-    val n: Int = scala.math.pow(2, 18).toInt
-    // the block size, must be >= 1.
-    val r: Int = 8
-    // Parallelization parameter. Must be a positive integer less than or equal to Integer.MAX_VALUE / (128 * r * 8).
-    val p: Int = 1
-    // length of derived key
-    val dkLen: Int = 32
-  }
-
-  /**
-   * Generate a random salt.
-   * @return a random salt
-   */
-  def generateSalt: Array[Byte] = {
-    val salt = new Array[Byte](32)
-    new java.util.Random().nextBytes(salt)
-    salt
-  }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/Scrypt.scala
@@ -1,19 +1,46 @@
 package co.topl.crypto.encryption.kdf
 
+import org.bouncycastle.crypto.generators.SCrypt
+
 /**
  * Scrypt is a key derivation function.
  * @see [[https://en.wikipedia.org/wiki/Scrypt]]
  */
 class Scrypt extends Kdf[Scrypt.ScryptParams] {
-  override def deriveKey(secret: Array[Byte], params: Scrypt.ScryptParams): Array[Byte] = ???
+  /**
+   * Derive a key from a secret.
+   * @param secret secret to derive key from
+   * @param params KDF parameters
+   * @return derived key
+   */
+  override def deriveKey(secret: Array[Byte], params: Scrypt.ScryptParams): Array[Byte] =
+    SCrypt.generate(secret, params.salt, params.n, params.r, params.p, params.dkLen)
 }
 
 object Scrypt {
+  /**
+   * Scrypt parameters.
+   */
   trait ScryptParams extends Params {
-    val salt : Array[Byte] // salt
-    val n: Int // CPU/memory cost parameter
-    val r: Int // block size parameter
-    val p: Int // parallelization parameter
-    val dkLen: Int // length of derived key
+    // salt
+    val salt : Array[Byte]
+    // CPU/Memory cost parameter. Must be larger than 1, a power of 2 and less than 2^(128 * r / 8)
+    val n: Int = scala.math.pow(2, 18).toInt
+    // the block size, must be >= 1.
+    val r: Int = 8
+    // Parallelization parameter. Must be a positive integer less than or equal to Integer.MAX_VALUE / (128 * r * 8).
+    val p: Int = 1
+    // length of derived key
+    val dkLen: Int = 32
+  }
+
+  /**
+   * Generate a random salt.
+   * @return a random salt
+   */
+  def generateSalt: Array[Byte] = {
+    val salt = new Array[Byte](32)
+    new java.util.Random().nextBytes(salt)
+    salt
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
@@ -5,8 +5,20 @@ package co.topl.crypto.encryption
  * @see [[https://en.wikipedia.org/wiki/Key_derivation_function]]
  */
 package object kdf {
+  /**
+   * KDF parameters.
+   */
   trait Params
+  /**
+   * A KDF.
+   */
   trait Kdf[P <: Params] {
+    /**
+     * Derive a key from a secret.
+     * @param secret secret to derive key from
+     * @param params KDF parameters
+     * @return derived key
+     */
     def deriveKey(secret: Array[Byte], params: P): Array[Byte]
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
@@ -1,0 +1,12 @@
+package co.topl.crypto.encryption
+
+/**
+ * Key derivation functions (KDFs) are used to derive a key from a password or passphrase.
+ * @see [[https://en.wikipedia.org/wiki/Key_derivation_function]]
+ */
+package object kdf {
+  trait Params
+  trait Kdf[P <: Params] {
+    def deriveKey(secret: Array[Byte], params: P): Array[Byte]
+  }
+}

--- a/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/kdf/kdf.scala
@@ -5,14 +5,17 @@ package co.topl.crypto.encryption
  * @see [[https://en.wikipedia.org/wiki/Key_derivation_function]]
  */
 package object kdf {
+
   /**
    * KDF parameters.
    */
   trait Params
+
   /**
    * A KDF.
    */
   trait Kdf[P <: Params] {
+
     /**
      * Derive a key from a secret.
      * @param secret secret to derive key from

--- a/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
@@ -6,10 +6,90 @@ import org.scalatest.matchers.should.Matchers
 
 class AesSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
-  property("encrypt and decrypt is successful with the same key and iv") {
-    // Test with different sizes of plaintext, keys, and ivs
+  property("encrypting the same secret with different keys produces different ciphertexts") {
+    val params = AesParams(Aes.generateIv)
+    val encryptKey1 = "encryptKey1".getBytes.padTo(16, 0.toByte)
+    val encryptKey2 = "encryptKey2".getBytes.padTo(16, 0.toByte)
+    val message = "message".getBytes
+    val cipherText1 = Aes.encrypt(message, encryptKey1, params)
+    val cipherText2 = Aes.encrypt(message, encryptKey2, params)
+    (cipherText1 sameElements cipherText2) should not be true
   }
-  property("encrypt and decrypt is unsuccessful with a different key") {}
-  property("encrypt and decrypt is unsuccessful with a different iv") {}
-  property("encrypting the same secret with different keys and iv produces different ciphertexts") {}
+
+  property("encrypting the same secret with different key lengths produces different ciphertexts") {
+    val params = AesParams(Aes.generateIv)
+    val encryptKey1 = "encryptKey".getBytes.padTo(16, 0.toByte)
+    val encryptKey2 = "encryptKey".getBytes.padTo(32, 0.toByte)
+    val message = "message".getBytes
+    val cipherText1 = Aes.encrypt(message, encryptKey1, params)
+    val cipherText2 = Aes.encrypt(message, encryptKey2, params)
+    (cipherText1 sameElements cipherText2) should not be true
+  }
+
+  property("encrypting the same secret with different ivs produces different ciphertexts") {
+    val params1 = AesParams(Aes.generateIv)
+    var params2 = AesParams(Aes.generateIv)
+    while (params2.iv sameElements params1.iv)
+      params2 = AesParams(Aes.generateIv)
+    val key = "key".getBytes.padTo(16, 0.toByte)
+    val message = "message".getBytes
+    val cipherText1 = Aes.encrypt(message, key, params1)
+    val cipherText2 = Aes.encrypt(message, key, params2)
+    (cipherText1 sameElements cipherText2) should not be true
+  }
+
+  property("encrypt and decrypt is successful with the same key and iv") {
+    // Test with different sizes of keys
+    List(16, 24, 32).map("key".getBytes.padTo(_, 0.toByte)).foreach { key =>
+      val params = AesParams(Aes.generateIv)
+      val message = "message".getBytes
+      val cipherText = Aes.encrypt(message, key, params)
+      val decodedText = Aes.decrypt(cipherText, key, params)
+      (decodedText sameElements message) shouldBe true
+    }
+  }
+
+  property("encrypt and decrypt is successful with different sizes of messages") {
+    // The purpose is to test the padding of the message (to be a multiple of 16) and the removal of the padding when
+    // decrypting. We should test with different sizes of messages to ensure the padding is done correctly.
+    List(
+      7, // arbitrary < 16
+      15, // 1 less than 16
+      16, // a full block
+      17, // 1 more than 16
+      24, // arbitrary > 16 and < 32
+      31, // 1 less than 32
+      32, // a full multiple of a full block
+      33 // 1 more than 32
+    ).map("message".getBytes.padTo(_, 0.toByte)).foreach { message =>
+      val params = AesParams(Aes.generateIv)
+      val key = "key".getBytes.padTo(16, 0.toByte)
+      val cipherText = Aes.encrypt(message, key, params)
+      val decodedText = Aes.decrypt(cipherText, key, params)
+      (decodedText sameElements message) shouldBe true
+    }
+  }
+
+  property("encrypt and decrypt is unsuccessful with a different key") {
+    val params = AesParams(Aes.generateIv)
+    val encryptKey = "encryptKey".getBytes.padTo(16, 0.toByte)
+    val decryptKey = "decryptKey".getBytes.padTo(16, 0.toByte)
+    val message = "message".getBytes
+    val cipherText = Aes.encrypt(message, encryptKey, params)
+    val decodedText = Aes.decrypt(cipherText, decryptKey, params)
+    (decodedText sameElements message) should not be true
+  }
+
+  property("encrypt and decrypt is unsuccessful with a different iv") {
+    val encryptParams = AesParams(Aes.generateIv)
+    var decryptParams = AesParams(Aes.generateIv)
+    while (decryptParams.iv sameElements encryptParams.iv)
+      decryptParams = AesParams(Aes.generateIv)
+    val key = "key".getBytes.padTo(16, 0.toByte)
+    val message = "message".getBytes
+    val cipherText = Aes.encrypt(message, key, encryptParams)
+    val decodedText = Aes.decrypt(cipherText, key, decryptParams)
+
+    (decodedText sameElements message) should not be true
+  }
 }

--- a/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
@@ -54,13 +54,13 @@ class AesSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Match
     // decrypting. We should test with different sizes of messages to ensure the padding is done correctly.
     List(
       7, // arbitrary < 16
-      15, // 1 less than 16
-      16, // a full block
-      17, // 1 more than 16
+      Aes.BlockSize - 1, // 1 less than a block
+      Aes.BlockSize, // a full block
+      Aes.BlockSize + 1, // 1 more than a block
       24, // arbitrary > 16 and < 32
-      31, // 1 less than 32
-      32, // a full multiple of a full block
-      33 // 1 more than 32
+      (Aes.BlockSize * 2) - 1, // 1 less than 2 blocks
+      Aes.BlockSize * 2, // a multiple of a block (i.e, 2 blocks)
+      (Aes.BlockSize * 2) + 1 // 1 more than 2 blocks
     ).map("message".getBytes.padTo(_, 0.toByte)).foreach { message =>
       val params = AesParams(Aes.generateIv)
       val key = "key".getBytes.padTo(16, 0.toByte)

--- a/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/encryption/cipher/AesSpec.scala
@@ -1,0 +1,15 @@
+package co.topl.crypto.encryption.cipher
+
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatest.matchers.should.Matchers
+
+class AesSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  property("encrypt and decrypt is successful with the same key and iv") {
+    // Test with different sizes of plaintext, keys, and ivs
+  }
+  property("encrypt and decrypt is unsuccessful with a different key") {}
+  property("encrypt and decrypt is unsuccessful with a different iv") {}
+  property("encrypting the same secret with different keys and iv produces different ciphertexts") {}
+}

--- a/crypto/src/test/scala/co/topl/crypto/encryption/kdf/SCryptSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/encryption/kdf/SCryptSpec.scala
@@ -1,0 +1,13 @@
+package co.topl.crypto.encryption.kdf
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class SCryptSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  property("verify the same parameters create the same key") {
+    // Test with different sizes of secrets
+  }
+  property("verify changing the salt creates a different key") {}
+}

--- a/crypto/src/test/scala/co/topl/crypto/encryption/kdf/SCryptSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/encryption/kdf/SCryptSpec.scala
@@ -6,8 +6,31 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class SCryptSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
-  property("verify the same parameters create the same key") {
-    // Test with different sizes of secrets
+  property("verify the same parameters (salt) and the same secret create the same key") {
+    val params = ScryptParams(Scrypt.generateSalt)
+    val secret = "secret".getBytes
+    val derivedKey1 = Scrypt.deriveKey(secret, params)
+    val derivedKey2 = Scrypt.deriveKey(secret, params)
+    (derivedKey1 sameElements derivedKey2) shouldBe true
   }
-  property("verify changing the salt creates a different key") {}
+
+  property("verify different parameters (salt) for the same secret creates different keys") {
+    val params1 = ScryptParams(Scrypt.generateSalt)
+    var params2 = ScryptParams(Scrypt.generateSalt)
+    while (params2.salt sameElements params1.salt)
+      params2 = ScryptParams(Scrypt.generateSalt)
+    val secret = "secret".getBytes
+    val derivedKey1 = Scrypt.deriveKey(secret, params1)
+    val derivedKey2 = Scrypt.deriveKey(secret, params2)
+    (derivedKey1 sameElements derivedKey2) should not be true
+  }
+
+  property("verify different secrets for the same parameters (salt) creates different keys") {
+    val params = ScryptParams(Scrypt.generateSalt)
+    val secret1 = "secret".getBytes
+    val secret2 = "another-secret".getBytes.padTo(100, 0.toByte) // padding is arbitrary and shouldn't affect the result
+    val derivedKey1 = Scrypt.deriveKey(secret1, params)
+    val derivedKey2 = Scrypt.deriveKey(secret2, params)
+    (derivedKey1 sameElements derivedKey2) should not be true
+  }
 }


### PR DESCRIPTION
## Purpose

For Encrypting a Keyfile, we need to have an implementation of a Cipher and a KDF (see image below). We will use AES as the cipher, and SCrypt as the KDF for the initial implementation.

![image](https://user-images.githubusercontent.com/17934976/228046796-fb853ac0-78d0-40b7-8b1d-dd00e6524539.png)


## Approach

- Added `cipher` package with `Cipher` trait and `kdf` package with `Kdf` trait in a new `encryption` package. `Cipher` has `encrypt` and `decrypt` while `Kdf` has `deriveKey`. Since different implementations of ciphers and kdfs will have their own parameters, the `Param` trait in each is empty and will be extended by the specific implementations.
- Added `Aes` in the `encryption.cipher` package. 
- Added SCrypt in the `encryption.kdf` package. 
- The implementation details of both were informed by an older implementation of generating a KeyFile. See https://github.com/Topl/Bifrost/blob/42fcf1e7d4d68d1861b76720fc1007dbacfd8eae//brambl/src/main/scala/co/topl/credential/KeyFile.scala 
- These changes do not introduce any breaking changes to clients since it simply adds additional packages. No existing code was altered.

## Testing

I added unit tests for both Aes and Scrypt. 

## Tickets
* Closes TSDK-356