### PR TITLE
Fixed flaky tests involving ed25519

### DIFF
--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -65,18 +65,17 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     val provenAttestation = provenTx.inputs.head.attestation.getPredicate
     assert(errs.tail.head.isInstanceOf[AuthorizationFailed], "AuthorizationFailed error is expected")
+    val authErrs = errs.tail.head.asInstanceOf[AuthorizationFailed].errors
     assert(
-      errs.tail.head.asInstanceOf[AuthorizationFailed].errors.length == 3,
-      "AuthorizationFailed error expects exactly 3 errors"
+      authErrs.length == 3,
+      s"AuthorizationFailed error expects exactly 3 errors. Received ${authErrs.length} errors. ${authErrs}"
     )
     assert(
-      errs.tail.head.asInstanceOf[AuthorizationFailed].errors.contains(LockedPropositionIsUnsatisfiable),
-      s"AuthorizationFailed error expects errors Locked error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+      authErrs.contains(LockedPropositionIsUnsatisfiable),
+      s"AuthorizationFailed error expects errors Locked error. Received: ${authErrs}"
     )
     assert(
-      errs.tail.head
-        .asInstanceOf[AuthorizationFailed]
-        .errors
+      authErrs
         // TODO: fix .getRevealed
         .contains(
           EvaluationAuthorizationFailed(
@@ -84,12 +83,10 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
             provenAttestation.responses(3)
           )
         ),
-      s"AuthorizationFailed error expects Height error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+      s"AuthorizationFailed error expects Height error. Received: ${authErrs}"
     )
     assert(
-      errs.tail.head
-        .asInstanceOf[AuthorizationFailed]
-        .errors
+      authErrs
         // TODO: fix .getRevealed
         .contains(
           EvaluationAuthorizationFailed(
@@ -97,7 +94,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
             provenAttestation.responses(4)
           )
         ),
-      s"AuthorizationFailed error expects Tick error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+      s"AuthorizationFailed error expects Tick error. Received: ${authErrs}"
     )
   }
 

--- a/crypto/src/main/scala/co/topl/crypto/signing/Ed25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/Ed25519.scala
@@ -6,7 +6,7 @@ import Ed25519.{PublicKey, SecretKey}
  * Implementation of Ed25519 elliptic curve signature
  */
 class Ed25519 extends EllipticCurveSignatureScheme[SecretKey, PublicKey](Ed25519.SeedLength) {
-  private val impl = Ed25519.Impl
+  private val impl = new eddsa.Ed25519
   impl.precompute()
 
   /**
@@ -103,7 +103,6 @@ class Ed25519 extends EllipticCurveSignatureScheme[SecretKey, PublicKey](Ed25519
 
 object Ed25519 {
   private val Impl = new eddsa.Ed25519
-
   val SignatureLength: Int = Impl.SIGNATURE_SIZE
   val KeyLength: Int = Impl.SECRET_KEY_SIZE
   val PublicKeyLength: Int = Impl.PUBLIC_KEY_SIZE

--- a/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/ExtendedEd25519.scala
@@ -12,7 +12,7 @@ import java.nio.{ByteBuffer, ByteOrder}
  * Implementation of ExtendedEd25519 elliptic curve signature
  */
 class ExtendedEd25519 extends EllipticCurveSignatureScheme[SecretKey, PublicKey](ExtendedEd25519.SeedLength) {
-  private val impl = ExtendedEd25519.Impl
+  private val impl = new eddsa.Ed25519
   impl.precompute()
 
   /**


### PR DESCRIPTION
## Purpose

Tests involving Ed25519 were inconsistently failing. This issue came up before and was fixed in https://github.com/Topl/BramblSc/pull/22 (on the brambl side). However, due to the recent refactors in Ed25519 in crypto, the issue was re-introduced in the crypto library.

## Approach

- Initialize a new `new eddsa.Ed25519` within the Ed25519 and ExtendedEd25519 class (instead of the static object). This fixed the problem
- Updated the flaky brambl test to include more information to help debugging in the future

## Testing

- ran `checkPR` 10 times in a row, all of them passed.

## Tickets
* Closes TSDK-423
