### PR TITLE
Remove Singleton Ed25519 Instances

### DIFF
--- a/crypto/src/main/scala/co/topl/crypto/generation/EntropyToSeed.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/EntropyToSeed.scala
@@ -6,6 +6,7 @@ import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator
 import org.bouncycastle.crypto.params.KeyParameter
 
 import java.nio.charset.StandardCharsets
+import scala.language.implicitConversions
 
 trait EntropyToSeed {
   def toSeed(entropy: Entropy, password: Option[String]): Array[Byte]

--- a/crypto/src/main/scala/co/topl/crypto/signing/Ed25519.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/Ed25519.scala
@@ -6,7 +6,7 @@ import Ed25519.{PublicKey, SecretKey}
  * Implementation of Ed25519 elliptic curve signature
  */
 class Ed25519 extends EllipticCurveSignatureScheme[SecretKey, PublicKey](Ed25519.SeedLength) {
-  private val impl = Ed25519.Impl
+  private val impl = new eddsa.Ed25519
   impl.precompute()
 
   /**
@@ -102,11 +102,9 @@ class Ed25519 extends EllipticCurveSignatureScheme[SecretKey, PublicKey](Ed25519
 }
 
 object Ed25519 {
-  private val Impl = new eddsa.Ed25519
-
-  val SignatureLength: Int = Impl.SIGNATURE_SIZE
-  val KeyLength: Int = Impl.SECRET_KEY_SIZE
-  val PublicKeyLength: Int = Impl.PUBLIC_KEY_SIZE
+  val SignatureLength: Int = 64
+  val KeyLength: Int = 32
+  val PublicKeyLength: Int = 32
   val SeedLength: Int = 32
 
   case class SecretKey(bytes: Array[Byte]) extends SigningKey {
@@ -117,9 +115,11 @@ object Ed25519 {
     )
 
     override def equals(that: Any): Boolean = that match {
-      case that: SecretKey => bytes sameElements that.bytes
+      case that: SecretKey => java.util.Arrays.equals(bytes, that.bytes)
       case _               => false
     }
+
+    override def hashCode(): Int = java.util.Arrays.hashCode(bytes)
   }
 
   case class PublicKey(bytes: Array[Byte]) extends VerificationKey {
@@ -130,8 +130,10 @@ object Ed25519 {
     )
 
     override def equals(that: Any): Boolean = that match {
-      case that: PublicKey => bytes sameElements that.bytes
+      case that: PublicKey => java.util.Arrays.equals(bytes, that.bytes)
       case _               => false
     }
+
+    override def hashCode(): Int = java.util.Arrays.hashCode(bytes)
   }
 }


### PR DESCRIPTION
## Purpose
- All instances of the "public" Ed25519 share the same internal implementation instance.  This may lead to thread-safety issues in parallel environments
- The SecretKey and PublicKey classes were missing hashCode implementations which may confuse implementations of HashSet or HashMap
## Approach
- Remove the singleton instances of Ed25519 from the ExtendedEd25519 and Ed25519 companion objects.  Create new internal instances each time
- Add hashcodes to the public key and secret key classes
## Testing
- preparePR
## Tickets
N/A