### PR TITLE
TSDK-358 createNewWallet usecase

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -21,7 +21,7 @@ import quivr.models.SmallData
 
 object TransactionBuilderInterpreter {
 
-  def make[F[_]: Monad](dataApi: DataApi): TransactionBuilder[F] = new TransactionBuilder[F] {
+  def make[F[_]: Monad](dataApi: DataApi[F]): TransactionBuilder[F] = new TransactionBuilder[F] {
 
     override def constructUnprovenInput(
       data: InputBuildRequest

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -68,7 +68,20 @@ object ContainsImmutable {
       case e                    => throw new MatchError(e)
     }
 
-    implicit val verificationKeyImmutable: ContainsImmutable[VerificationKey] = _.value.immutable
+    implicit val verificationKeyImmutable: ContainsImmutable[VerificationKey] = _.value match {
+      case VerificationKey.Value.Ed25519(v)         => v.immutable
+      case VerificationKey.Value.ExtendedEd25519(v) => v.immutable
+      case e                                        => throw new MatchError(e)
+    }
+
+    implicit val ed25519VerificationKeyImmutable: ContainsImmutable[VerificationKey.Ed25519VerificationKey] =
+      _.value.immutable
+
+    implicit val extendedEd25519VerificationKeyImmutable
+      : ContainsImmutable[VerificationKey.ExtendedEd25519VerificationKey] =
+      (vkey: VerificationKey.ExtendedEd25519VerificationKey) =>
+        vkey.vk.immutable ++
+        vkey.chainCode.immutable
 
     implicit val witnessImmutable: ContainsImmutable[Witness] = _.value.immutable
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -18,8 +18,7 @@ import quivr.models.{KeyPair, Preimage}
  */
 trait DataApi[F[_]] {
 
-  abstract class DataApiException(msg: String, cause: Option[Throwable] = None)
-      extends RuntimeException(msg, cause.orNull)
+  abstract class DataApiException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
 
   /**
    * Return the indices associated to a TransactionOutputAddress.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -4,6 +4,7 @@ import co.topl.brambl.models.{Indices, LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.box.{Box, Lock}
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.routines.signatures.Signing
+import co.topl.crypto.encryption.VaultStore
 import quivr.models.{KeyPair, Preimage}
 
 /**
@@ -15,7 +16,8 @@ import quivr.models.{KeyPair, Preimage}
  *
  * TODO: Design and replace this interface with the actual interface that will be used by the rest of the system.
  */
-trait DataApi {
+trait DataApi[F[_]] {
+  abstract class DataApiException(msg: String, cause: Option[Throwable] = None) extends RuntimeException(msg, cause.orNull)
 
   /**
    * Return the indices associated to a TransactionOutputAddress.
@@ -66,4 +68,18 @@ trait DataApi {
    * @return The key pair associated to the indices if it exists. Else None
    */
   def getKeyPair(idx: Indices, routine: Signing): Option[KeyPair]
+
+  /**
+   * Persist a VaultStore for the Topl Main Secret Key.
+   *
+   * @param mainKeyVaultStore The VaultStore to persist
+   * @return nothing if successful. If persisting fails due to an underlying cause, return a DataApiException
+   */
+  def saveMainKeyVaultStore(mainKeyVaultStore: VaultStore[F]): F[Either[DataApiException, Unit]]
+  /**
+   * Return the VaultStore for the Topl Main Secret Key.
+   *
+   * @return The VaultStore for the Topl Main Secret Key if it exists. If retrieving fails due to an underlying cause, return a DataApiException
+   */
+  def getMainKeyVaultStore: F[Either[DataApiException, VaultStore[F]]]
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -74,6 +74,8 @@ trait DataApi[F[_]] {
   /**
    * Persist a VaultStore for the Topl Main Secret Key.
    *
+   * note: We are only supporting one Main Key VaultStore.
+   *
    * @param mainKeyVaultStore The VaultStore to persist
    * @return nothing if successful. If persisting fails due to an underlying cause, return a DataApiException
    */

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -17,7 +17,9 @@ import quivr.models.{KeyPair, Preimage}
  * TODO: Design and replace this interface with the actual interface that will be used by the rest of the system.
  */
 trait DataApi[F[_]] {
-  abstract class DataApiException(msg: String, cause: Option[Throwable] = None) extends RuntimeException(msg, cause.orNull)
+
+  abstract class DataApiException(msg: String, cause: Option[Throwable] = None)
+      extends RuntimeException(msg, cause.orNull)
 
   /**
    * Return the indices associated to a TransactionOutputAddress.
@@ -76,6 +78,7 @@ trait DataApi[F[_]] {
    * @return nothing if successful. If persisting fails due to an underlying cause, return a DataApiException
    */
   def saveMainKeyVaultStore(mainKeyVaultStore: VaultStore[F]): F[Either[DataApiException, Unit]]
+
   /**
    * Return the VaultStore for the Topl Main Secret Key.
    *

--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
@@ -7,7 +7,7 @@ import quivr.models.{KeyPair, SignableBytes, SigningKey, VerificationKey, Witnes
 import quivr.models.SigningKey.Ed25519SigningKey
 import quivr.models.VerificationKey.Ed25519VerificationKey
 
-// TODO: This whole file may be removed
+// TODO: The whole routines package may be removed in TSDK-437
 object Ed25519Signature extends Signing {
   override val routine: String = "ed25519"
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/signatures/Ed25519Signature.scala
@@ -4,23 +4,27 @@ import cats.implicits.catsSyntaxOptionId
 import co.topl.crypto.signing.Ed25519
 import com.google.protobuf.ByteString
 import quivr.models.{KeyPair, SignableBytes, SigningKey, VerificationKey, Witness}
+import quivr.models.SigningKey.Ed25519SigningKey
+import quivr.models.VerificationKey.Ed25519VerificationKey
 
+// TODO: This whole file may be removed
 object Ed25519Signature extends Signing {
   override val routine: String = "ed25519"
 
   override def createKeyPair(seed: Array[Byte]): KeyPair = {
     val instance = new Ed25519
     val keys = instance.deriveKeyPairFromSeed(seed.padTo(Ed25519.SeedLength, 0.toByte))
-    val skBytes = keys.signingKey.bytes
-    val vkBytes = keys.verificationKey.bytes
+    val sk = SigningKey.Value.Ed25519(Ed25519SigningKey(ByteString.copyFrom(keys.signingKey.bytes)))
+    val vk = VerificationKey.Value.Ed25519(Ed25519VerificationKey(ByteString.copyFrom(keys.verificationKey.bytes)))
     KeyPair(
-      VerificationKey(ByteString.copyFrom(vkBytes)),
-      SigningKey(ByteString.copyFrom(skBytes))
+      VerificationKey(vk),
+      SigningKey(sk)
     )
   }
 
   override def sign(sk: SigningKey, msg: SignableBytes): Witness = {
-    val privateKey = Ed25519.SecretKey(sk.value.toByteArray)
+    // TODO: Need to handle when sk.value.ed25519 is None...
+    val privateKey = Ed25519.SecretKey(sk.value.ed25519.get.value.toByteArray)
     val message = msg.value.toByteArray
     Witness(
       ByteString.copyFrom((new Ed25519).sign(privateKey, message))

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Ed25519SignatureInterpreter.scala
@@ -7,6 +7,7 @@ import co.topl.quivr.algebras.SignatureVerifier
 import co.topl.quivr.runtime.QuivrRuntimeError
 import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError
 import quivr.models.{Message, SignatureVerification, VerificationKey, Witness}
+import quivr.models.VerificationKey.{Ed25519VerificationKey, Value}
 
 /**
  * Validates that an Ed25519 signature is valid.
@@ -21,7 +22,12 @@ object Ed25519SignatureInterpreter {
      * @return The SignatureVerification object if the signature is valid, otherwise an error
      */
     override def validate(t: SignatureVerification): F[Either[QuivrRuntimeError, SignatureVerification]] = t match {
-      case SignatureVerification(VerificationKey(vk, _), Witness(sig, _), Message(msg, _), _) =>
+      case SignatureVerification(
+            VerificationKey(Value.Ed25519(Ed25519VerificationKey(vk, _)), _),
+            Witness(sig, _),
+            Message(msg, _),
+            _
+          ) =>
         if ((new Ed25519).verify(sig.toByteArray, msg.toByteArray, Ed25519.PublicKey(vk.toByteArray)))
           Either.right[QuivrRuntimeError, SignatureVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -21,7 +21,7 @@ import co.topl.brambl.models.box.Attestation
 
 object CredentiallerInterpreter {
 
-  def make[F[_]: Monad](dataApi: DataApi): Credentialler[F] = new Credentialler[F] {
+  def make[F[_]: Monad](dataApi: DataApi[F]): Credentialler[F] = new Credentialler[F] {
 
     override def prove(unprovenTx: IoTransaction): F[IoTransaction] = {
       val signable = unprovenTx.signable

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -1,0 +1,74 @@
+package co.topl.brambl.wallet
+
+import co.topl.crypto.generation.mnemonic.{EntropyFailure, MnemonicSize, MnemonicSizes}
+import cats.{Applicative, Monad}
+import cats.implicits.{catsSyntaxApplicativeId, toFlatMapOps, toFunctorOps}
+import co.topl.brambl.dataApi.DataApi
+import co.topl.crypto.generation.{Bip32Index, Bip32Indexes, KeyInitializer}
+import co.topl.crypto.generation.mnemonic.{Entropy, EntropyFailure, MnemonicSize, MnemonicSizes}
+import KeyInitializer.Instances.extendedEd25519Initializer
+import co.topl.crypto.encryption.{Mac, VaultStore}
+import co.topl.crypto.encryption.kdf.Kdf
+import co.topl.crypto.encryption.kdf.SCrypt
+import co.topl.crypto.encryption.cipher.Cipher
+import co.topl.crypto.encryption.cipher.Aes
+import co.topl.crypto.signing.ExtendedEd25519
+
+
+/**
+ * Defines a Wallet API.
+ * A Wallet is responsible for managing the user's keys
+ */
+trait WalletApi[F[_]] {
+  /**
+   * Create a new wallet
+   *
+   * @param password   The password to encrypt the wallet with
+   * @param passphrase The passphrase to use to generate the main key from the mnemonic
+   * @param mLen       The length of the mnemonic to generate
+   * @return The mnemonic of the newly created wallet
+   */
+  def createNewWallet(password: Array[Byte], passphrase: Option[String], mLen: MnemonicSize= MnemonicSizes.words12): F[Either[EntropyFailure, String]]
+
+}
+
+object WalletApi {
+  /**
+   * Create an instance of the WalletAPI
+   *
+   * @note The wallet uses ExtendedEd25519 to generate the main secret key
+   * @note The wallet uses SCrypt as the KDF
+   * @note The wallet uses AES as the cipher
+   *
+   * @param dataApi The DataApi to use to store the generate wallet
+   * @return A new WalletAPI instance
+   */
+  def make[F[_]: Monad](dataApi: DataApi[F])(implicit extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519): WalletApi[F] = new WalletApi[F] {
+    final val Purpose = 1852
+    final val CoinType = 7091
+    override def createNewWallet(password: Array[Byte], passphrase: Option[String], mLen: MnemonicSize = MnemonicSizes.words12): F[Either[EntropyFailure, String]] = {
+      val entropy = Entropy.generate(mLen)
+      val mainKey:Array[Byte] = ((k: ExtendedEd25519.SecretKey) => k.leftKey ++ k.rightKey ++ k.chainCode)(entropyToMainSecretKey(entropy, passphrase))
+
+      val sCrypt = SCrypt.make[F](SCrypt.SCryptParams(SCrypt.generateSalt))
+      val aes = Aes.make[F](Aes.AesParams(Aes.generateIv))
+
+      for {
+        derivedKey: Array[Byte] <- sCrypt.deriveKey(password)
+        cipherText: Array[Byte] <- aes.encrypt(mainKey, derivedKey)
+        mac: Array[Byte] = Mac.make(derivedKey, cipherText).value
+      } yield VaultStore[F](sCrypt, aes, cipherText, mac)
+
+      // TODO: Store VaultStore in DataApi
+
+      Entropy.toMnemonicString(entropy).pure[F]
+    }
+
+    private def entropyToMainSecretKey(entropy: Entropy, passphrase: Option[String]): ExtendedEd25519.SecretKey = {
+      val rootKey: ExtendedEd25519.SecretKey = extendedEd25519Initializer.fromEntropy(entropy, passphrase)
+      val purpose: Bip32Index = Bip32Indexes.HardenedIndex (Purpose) // following CIP-1852
+      val coinType: Bip32Index = Bip32Indexes.HardenedIndex (CoinType) // Topl coin type registered with SLIP-0044
+      extendedEd25519Instance.deriveKeyPairFromChildPath (rootKey, List (purpose, coinType) ).signingKey
+    }
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -13,6 +13,11 @@ import co.topl.crypto.encryption.kdf.SCrypt
 import co.topl.crypto.encryption.cipher.Cipher
 import co.topl.crypto.encryption.cipher.Aes
 import co.topl.crypto.signing.ExtendedEd25519
+import co.topl.crypto.signing
+import com.google.protobuf.ByteString
+import quivr.models._
+
+import scala.language.implicitConversions
 
 /**
  * Defines a Wallet API.
@@ -53,6 +58,8 @@ object WalletApi {
   )(implicit extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519): WalletApi[F] = new WalletApi[F] {
     final val Purpose = 1852
     final val CoinType = 7091
+    val kdf: Kdf[F] = SCrypt.make[F](SCrypt.SCryptParams(SCrypt.generateSalt))
+    val cipher: Cipher[F] = Aes.make[F](Aes.AesParams(Aes.generateIv))
 
     override def createNewWallet(
       password:   Array[Byte],
@@ -60,29 +67,43 @@ object WalletApi {
       mLen:       MnemonicSize = MnemonicSizes.words12
     ): F[Either[EntropyFailure, String]] = {
       val entropy = Entropy.generate(mLen)
-      val mainKey: Array[Byte] = ((k: ExtendedEd25519.SecretKey) => k.leftKey ++ k.rightKey ++ k.chainCode)(
-        entropyToMainSecretKey(entropy, passphrase)
-      )
-
-      val sCrypt = SCrypt.make[F](SCrypt.SCryptParams(SCrypt.generateSalt))
-      val aes = Aes.make[F](Aes.AesParams(Aes.generateIv))
-
-      for {
-        derivedKey: Array[Byte] <- sCrypt.deriveKey(password)
-        cipherText: Array[Byte] <- aes.encrypt(mainKey, derivedKey)
-        mac: Array[Byte] = Mac.make(derivedKey, cipherText).value
-      } yield VaultStore[F](sCrypt, aes, cipherText, mac)
-
-      // TODO: Store VaultStore in DataApi
-
+      val mainKey: Array[Byte] = entropyToMainKey(entropy, passphrase).toByteArray
+      val vaultStore = buildMainKeyVaultStore(mainKey, password)
+      vaultStore.map(vs => dataApi.saveMainKeyVaultStore(vs))
       Entropy.toMnemonicString(entropy).pure[F]
     }
 
-    private def entropyToMainSecretKey(entropy: Entropy, passphrase: Option[String]): ExtendedEd25519.SecretKey = {
+    private def buildMainKeyVaultStore(mainKey: Array[Byte], password: Array[Byte]): F[VaultStore[F]] = for {
+      derivedKey: Array[Byte] <- kdf.deriveKey(password)
+      cipherText: Array[Byte] <- cipher.encrypt(mainKey, derivedKey)
+      mac: Array[Byte] = Mac.make(derivedKey, cipherText).value
+    } yield VaultStore[F](kdf, cipher, cipherText, mac)
+
+    private def entropyToMainKey(entropy: Entropy, passphrase: Option[String]): KeyPair = {
       val rootKey: ExtendedEd25519.SecretKey = extendedEd25519Initializer.fromEntropy(entropy, passphrase)
       val purpose: Bip32Index = Bip32Indexes.HardenedIndex(Purpose) // following CIP-1852
       val coinType: Bip32Index = Bip32Indexes.HardenedIndex(CoinType) // Topl coin type registered with SLIP-0044
-      extendedEd25519Instance.deriveKeyPairFromChildPath(rootKey, List(purpose, coinType)).signingKey
+      extendedEd25519Instance.deriveKeyPairFromChildPath(rootKey, List(purpose, coinType))
+    }
+
+    implicit private def cryptoToPbKeyPair(
+      keyPair: signing.KeyPair[ExtendedEd25519.SecretKey, ExtendedEd25519.PublicKey]
+    ): KeyPair = {
+      val skCrypto = keyPair.signingKey
+      val sk = SigningKey.ExtendedEd25519SigningKey(
+        ByteString.copyFrom(skCrypto.leftKey),
+        ByteString.copyFrom(skCrypto.rightKey),
+        ByteString.copyFrom(skCrypto.chainCode)
+      )
+      val vkCrypto = keyPair.verificationKey
+      val vk = VerificationKey.ExtendedEd25519VerificationKey(
+        VerificationKey.Ed25519VerificationKey(ByteString.copyFrom(vkCrypto.vk.bytes)),
+        ByteString.copyFrom(vkCrypto.chainCode)
+      )
+      KeyPair(
+        VerificationKey(VerificationKey.Value.ExtendedEd25519(vk)),
+        SigningKey(SigningKey.Value.ExtendedEd25519(sk))
+      )
     }
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -35,7 +35,7 @@ trait WalletApi[F[_]] {
    */
   def createNewWallet(
     password:   Array[Byte],
-    passphrase: Option[String],
+    passphrase: Option[String] = None,
     mLen:       MnemonicSize = MnemonicSizes.words12
   ): F[Either[EntropyFailure, String]]
 
@@ -63,7 +63,7 @@ object WalletApi {
 
     override def createNewWallet(
       password:   Array[Byte],
-      passphrase: Option[String],
+      passphrase: Option[String] = None,
       mLen:       MnemonicSize = MnemonicSizes.words12
     ): F[Either[EntropyFailure, String]] = {
       val entropy = Entropy.generate(mLen)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -14,12 +14,12 @@ import co.topl.crypto.encryption.cipher.Cipher
 import co.topl.crypto.encryption.cipher.Aes
 import co.topl.crypto.signing.ExtendedEd25519
 
-
 /**
  * Defines a Wallet API.
  * A Wallet is responsible for managing the user's keys
  */
 trait WalletApi[F[_]] {
+
   /**
    * Create a new wallet
    *
@@ -28,11 +28,16 @@ trait WalletApi[F[_]] {
    * @param mLen       The length of the mnemonic to generate
    * @return The mnemonic of the newly created wallet
    */
-  def createNewWallet(password: Array[Byte], passphrase: Option[String], mLen: MnemonicSize= MnemonicSizes.words12): F[Either[EntropyFailure, String]]
+  def createNewWallet(
+    password:   Array[Byte],
+    passphrase: Option[String],
+    mLen:       MnemonicSize = MnemonicSizes.words12
+  ): F[Either[EntropyFailure, String]]
 
 }
 
 object WalletApi {
+
   /**
    * Create an instance of the WalletAPI
    *
@@ -43,12 +48,21 @@ object WalletApi {
    * @param dataApi The DataApi to use to store the generate wallet
    * @return A new WalletAPI instance
    */
-  def make[F[_]: Monad](dataApi: DataApi[F])(implicit extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519): WalletApi[F] = new WalletApi[F] {
+  def make[F[_]: Monad](
+    dataApi: DataApi[F]
+  )(implicit extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519): WalletApi[F] = new WalletApi[F] {
     final val Purpose = 1852
     final val CoinType = 7091
-    override def createNewWallet(password: Array[Byte], passphrase: Option[String], mLen: MnemonicSize = MnemonicSizes.words12): F[Either[EntropyFailure, String]] = {
+
+    override def createNewWallet(
+      password:   Array[Byte],
+      passphrase: Option[String],
+      mLen:       MnemonicSize = MnemonicSizes.words12
+    ): F[Either[EntropyFailure, String]] = {
       val entropy = Entropy.generate(mLen)
-      val mainKey:Array[Byte] = ((k: ExtendedEd25519.SecretKey) => k.leftKey ++ k.rightKey ++ k.chainCode)(entropyToMainSecretKey(entropy, passphrase))
+      val mainKey: Array[Byte] = ((k: ExtendedEd25519.SecretKey) => k.leftKey ++ k.rightKey ++ k.chainCode)(
+        entropyToMainSecretKey(entropy, passphrase)
+      )
 
       val sCrypt = SCrypt.make[F](SCrypt.SCryptParams(SCrypt.generateSalt))
       val aes = Aes.make[F](Aes.AesParams(Aes.generateIv))
@@ -66,9 +80,9 @@ object WalletApi {
 
     private def entropyToMainSecretKey(entropy: Entropy, passphrase: Option[String]): ExtendedEd25519.SecretKey = {
       val rootKey: ExtendedEd25519.SecretKey = extendedEd25519Initializer.fromEntropy(entropy, passphrase)
-      val purpose: Bip32Index = Bip32Indexes.HardenedIndex (Purpose) // following CIP-1852
-      val coinType: Bip32Index = Bip32Indexes.HardenedIndex (CoinType) // Topl coin type registered with SLIP-0044
-      extendedEd25519Instance.deriveKeyPairFromChildPath (rootKey, List (purpose, coinType) ).signingKey
+      val purpose: Bip32Index = Bip32Indexes.HardenedIndex(Purpose) // following CIP-1852
+      val coinType: Bip32Index = Bip32Indexes.HardenedIndex(CoinType) // Topl coin type registered with SLIP-0044
+      extendedEd25519Instance.deriveKeyPairFromChildPath(rootKey, List(purpose, coinType)).signingKey
     }
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -1,18 +1,20 @@
 package co.topl.brambl
 
+import cats.Id
 import co.topl.brambl.dataApi.DataApi
 import co.topl.brambl.models._
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.routines.signatures.Signing
+import co.topl.crypto.encryption.VaultStore
 import com.google.protobuf.ByteString
 import quivr.models._
 
 /**
  * Mock Implementation of the DataApi
  */
-object MockDataApi extends DataApi with MockHelpers {
+object MockDataApi extends DataApi[Id] with MockHelpers {
 
   // Static mappings to provide the Wallet with data
   val idxToLocks: Map[Indices, Lock.Predicate] = Map(
@@ -53,4 +55,9 @@ object MockDataApi extends DataApi with MockHelpers {
       Some(routine.createKeyPair(MockSecret))
     } else None
 
+  override def saveMainKeyVaultStore(
+    mainKeyVaultStore: VaultStore[Id]
+  ): Id[Either[MockDataApi.DataApiException, Unit]] = ???
+
+  override def getMainKeyVaultStore: Id[Either[MockDataApi.DataApiException, VaultStore[Id]]] = ???
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -1,0 +1,34 @@
+package co.topl.brambl.wallet
+
+import cats.Id
+import co.topl.brambl.{MockDataApi, MockHelpers}
+import co.topl.crypto.encryption.VaultStore
+import co.topl.crypto.generation.mnemonic.MnemonicSizes
+import quivr.models.KeyPair
+
+class WalletApiSpec extends munit.FunSuite with MockHelpers {
+
+  test(
+    "createNewWallet: Creating a new wallet creates VaultStore that contains a Topl Main Key and a Mnemonic (default length 12)"
+  ) {
+    val walletApi = WalletApi.make[Id](MockDataApi)
+    val password = "password".getBytes
+    val res = walletApi.createNewWallet(password)
+    assert(res.isRight)
+    assert(res.toOption.get.split(" ").length == 12)
+    val vs = MockDataApi.getMainKeyVaultStore.toOption
+    assert(vs.isDefined)
+    val mainKey = vs.flatMap(VaultStore.decodeCipher[Id](_, password).toOption).map(KeyPair.parseFrom)
+    assert(mainKey.isDefined)
+    assert(mainKey.get.vk.value.extendedEd25519.isDefined)
+    assert(mainKey.get.sk.value.extendedEd25519.isDefined)
+  }
+
+  test("createNewWallet: Specifying a valid mnemonic length returns a mnemonic of correct length") {
+    val walletApi = WalletApi.make[Id](MockDataApi)
+    val password = "password".getBytes
+    val res = walletApi.createNewWallet(password, mLen = MnemonicSizes.words24)
+    assert(res.isRight)
+    assert(res.toOption.get.split(" ").length == 24)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "69c2605" // scala-steward:off
-    val protobufSpecsVersion = "951cead" // scala-steward:off
+    val quivr4sVersion = "a35d335" // scala-steward:off
+    val protobufSpecsVersion = "e25abb3" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose

- Updated usage of VerificationKey and SigningKey to reflect the PB changes (to support ExtendedEd25519)
- Add functionality to support createNewWallet use case

## Approach

- updated any usage of VerificationKey and SigningKey to conform to new structure
-  Add functionality to support createNewWallet use case => Created WalletApi and 2 new functions in DataApi
- Added basic tests (more tests will come when more functionality is added to WalletApi)
- Added a very basic in memory implementation of the VaultStore persistence to MockDataApi (for testing purposes)
- 
**Do not merge this PR until https://github.com/Topl/protobuf-specs/pull/51 and https://github.com/Topl/quivr4s/pull/37 are merged**
After the linked PRs are merged, the commit hash in Dependencies.scala must be updated

## Testing

- Added very basic unit tests
- Ensured all existing tests pass

## Tickets
* Part of TSDK-358
