### PR TITLE
Wallet fix

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -1,5 +1,6 @@
 package co.topl.brambl.dataApi
 
+import co.topl.brambl.dataApi.DataApi._
 import co.topl.brambl.models.{Indices, LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.box.{Box, Lock}
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
@@ -17,8 +18,6 @@ import quivr.models.{KeyPair, Preimage}
  * TODO: Design and replace this interface with the actual interface that will be used by the rest of the system.
  */
 trait DataApi[F[_]] {
-
-  abstract class DataApiException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
 
   /**
    * Return the indices associated to a TransactionOutputAddress.
@@ -90,4 +89,8 @@ trait DataApi[F[_]] {
    * @return The VaultStore for the Topl Main Secret Key if it exists. If retrieving fails due to an underlying cause, return a DataApiException
    */
   def getMainKeyVaultStore(name: String): F[Either[DataApiException, VaultStore[F]]]
+}
+
+object DataApi {
+  abstract class DataApiException(msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -43,7 +43,7 @@ trait WalletApi[F[_]] {
     passphrase: Option[String] = None,
     mLen:       MnemonicSize = MnemonicSizes.words12,
     name:       String = "default"
-  ): F[Either[EntropyFailure, String]]
+  ): F[Either[EntropyFailure, IndexedSeq[String]]]
 
 }
 
@@ -72,7 +72,7 @@ object WalletApi {
       passphrase: Option[String] = None,
       mLen:       MnemonicSize = MnemonicSizes.words12,
       name:       String = "default"
-    ): F[Either[EntropyFailure, String]] = {
+    ): F[Either[EntropyFailure, IndexedSeq[String]]] = {
       val entropy = Entropy.generate(mLen)
       val mainKey: Array[Byte] = entropyToMainKey(entropy, passphrase).toByteArray
       val vaultStore = buildMainKeyVaultStore(mainKey, password)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -3,6 +3,7 @@ package co.topl.brambl
 import cats.Id
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.dataApi.DataApi
+import co.topl.brambl.dataApi.DataApi.DataApiException
 import co.topl.brambl.models._
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
@@ -68,14 +69,14 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
   override def saveMainKeyVaultStore(
     mainKeyVaultStore: VaultStore[Id],
     name:              String = "default"
-  ): Id[Either[MockDataApi.DataApiException, Unit]] = {
+  ): Id[Either[DataApiException, Unit]] = {
     mainKeyVaultStoreInstance += (name -> mainKeyVaultStore.asJson)
     Right(())
   }
 
   override def getMainKeyVaultStore(
     name: String = "default"
-  ): Id[Either[MockDataApi.DataApiException, VaultStore[Id]]] =
+  ): Id[Either[DataApiException, VaultStore[Id]]] =
     if (mainKeyVaultStoreInstance.getOrElse(name, Json.Null).isNull)
       Left(MainKeyVaultStoreNotInitialized)
     else

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -9,14 +9,17 @@ import quivr.models.KeyPair
 class WalletApiSpec extends munit.FunSuite with MockHelpers {
 
   test(
-    "createNewWallet: Creating a new wallet creates VaultStore that contains a Topl Main Key and a Mnemonic (default length 12)"
+    "createAndSaveNewWallet: Creating a new wallet creates VaultStore that contains a Topl Main Key and a Mnemonic (default length 12)"
   ) {
     val walletApi = WalletApi.make[Id](MockDataApi)
     val password = "password".getBytes
-    val res = walletApi.createNewWallet(password)
+    val res = walletApi.createAndSaveNewWallet(password)
     assert(res.isRight)
     assert(res.toOption.get.mnemonic.length == 12)
     val vs = res.toOption.get.mainKeyVaultStore
+    val vsStored = MockDataApi.getMainKeyVaultStore().toOption
+    assert(vsStored.isDefined)
+    assert(vsStored.get == vs)
     val mainKey = VaultStore.decodeCipher[Id](vs, password).toOption.map(KeyPair.parseFrom)
     assert(mainKey.isDefined)
     assert(mainKey.get.vk.vk.extendedEd25519.isDefined)
@@ -29,5 +32,22 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val res = walletApi.createNewWallet(password, mLen = MnemonicSizes.words24)
     assert(res.isRight)
     assert(res.toOption.get.mnemonic.length == 24)
+  }
+
+  test("saveWallet: specifying a name other than 'default' saves the wallet under that name") {
+    val walletApi = WalletApi.make[Id](MockDataApi)
+    val w1 = walletApi.createNewWallet("password1".getBytes).toOption.get.mainKeyVaultStore
+    val w2 = walletApi.createNewWallet("password2".getBytes).toOption.get.mainKeyVaultStore
+    assert(w1 != w2)
+    val res1 = walletApi.saveWallet(w1, "w1")
+    val res2 = walletApi.saveWallet(w2, "w2")
+    assert(res1.isRight)
+    assert(res2.isRight)
+    val stored1 = MockDataApi.getMainKeyVaultStore("w1").toOption
+    assert(stored1.isDefined)
+    assert(stored1.get == w1)
+    val stored2 = MockDataApi.getMainKeyVaultStore("w2").toOption
+    assert(stored2.isDefined)
+    assert(stored2.get == w2)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -15,7 +15,7 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val password = "password".getBytes
     val res = walletApi.createNewWallet(password)
     assert(res.isRight)
-    assert(res.toOption.get.length == 12)
+    assert(res.toOption.get.mnemonic.length == 12)
     val vs = MockDataApi.getMainKeyVaultStore().toOption
     assert(vs.isDefined)
     val mainKey = vs.flatMap(VaultStore.decodeCipher[Id](_, password).toOption).map(KeyPair.parseFrom)
@@ -29,6 +29,6 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val password = "password".getBytes
     val res = walletApi.createNewWallet(password, mLen = MnemonicSizes.words24)
     assert(res.isRight)
-    assert(res.toOption.get.length == 24)
+    assert(res.toOption.get.mnemonic.length == 24)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -16,9 +16,8 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val res = walletApi.createNewWallet(password)
     assert(res.isRight)
     assert(res.toOption.get.mnemonic.length == 12)
-    val vs = MockDataApi.getMainKeyVaultStore().toOption
-    assert(vs.isDefined)
-    val mainKey = vs.flatMap(VaultStore.decodeCipher[Id](_, password).toOption).map(KeyPair.parseFrom)
+    val vs = res.toOption.get.mainKeyVaultStore
+    val mainKey = VaultStore.decodeCipher[Id](vs, password).toOption.map(KeyPair.parseFrom)
     assert(mainKey.isDefined)
     assert(mainKey.get.vk.vk.extendedEd25519.isDefined)
     assert(mainKey.get.sk.sk.extendedEd25519.isDefined)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -15,7 +15,7 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val password = "password".getBytes
     val res = walletApi.createNewWallet(password)
     assert(res.isRight)
-    assert(res.toOption.get.split(" ").length == 12)
+    assert(res.toOption.get.length == 12)
     val vs = MockDataApi.getMainKeyVaultStore().toOption
     assert(vs.isDefined)
     val mainKey = vs.flatMap(VaultStore.decodeCipher[Id](_, password).toOption).map(KeyPair.parseFrom)
@@ -29,6 +29,6 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     val password = "password".getBytes
     val res = walletApi.createNewWallet(password, mLen = MnemonicSizes.words24)
     assert(res.isRight)
-    assert(res.toOption.get.split(" ").length == 24)
+    assert(res.toOption.get.length == 24)
   }
 }

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
@@ -33,12 +33,14 @@ object Entropy {
    * @param language The language of the mnemonic string
    * @return
    */
-  def toMnemonicString(entropy: Entropy, language: Language = Language.English): Either[EntropyFailure, String] =
+  def toMnemonicString(
+    entropy:  Entropy,
+    language: Language = Language.English
+  ): Either[EntropyFailure, IndexedSeq[String]] =
     for {
       size   <- sizeFromEntropyLength(entropy.value.length.toInt)
       phrase <- Phrase.fromEntropy(entropy, size, language).leftMap(EntropyFailures.PhraseToEntropyFailure)
-      mnemonicString = phrase.value.mkString(" ")
-    } yield mnemonicString
+    } yield phrase.value
 
   /**
    * Instantiates an 'Entropy' value from a string by validating the string to a mnemonic phrase and then deriving

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
@@ -111,7 +111,7 @@ object Entropy {
     }
 }
 
-sealed trait EntropyFailure
+sealed trait EntropyFailure extends RuntimeException
 
 /**
  * Enumeration of errors that can be produced when creating a mnemonic from entropy.

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/EntropySpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/EntropySpec.scala
@@ -48,6 +48,7 @@ class EntropySpec
       val entropy1 = Entropy.generate(mnemonicSize)
       val entropy2 = Entropy
         .toMnemonicString(entropy1, Language.English)
+        .map(_.mkString(" "))
         .flatMap { mnemonicString =>
           Entropy.fromMnemonicString(mnemonicString, Language.English)
         }


### PR DESCRIPTION
## Purpose

Update WalletApi.createNewWallet based on some recent feedback

## Approach

- When returning the mnemonic, return IndexedSeq[String] instead of a single String
- Use `for` comprehension in `createNewWallet`
- Update return type such that both types of errors will return (previously if a DataApi error occurs, the caller will not know)
- Update return type such that the VaultStore is also returned as well (in addition to mnemonic)

## Testing

- Ensured all existing tests will pass
- ran `checkPR`

## Tickets
* N/A