### PR TITLE
TSDK-413 Removed all remaining usages of Scodec

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/routines/digests/Blake2b256Digest.scala
@@ -3,15 +3,14 @@ package co.topl.brambl.routines.digests
 import co.topl.crypto.hash.Blake2b256
 import com.google.protobuf.ByteString
 import quivr.models.{Digest, Preimage}
-import scodec.bits.ByteVector
 
 object Blake2b256Digest extends Hash {
   override val routine: String = "blake2b256"
 
   override def hash(preimage: Preimage): Digest = {
-    val digest = (new Blake2b256).hash(ByteVector(preimage.input.toByteArray ++ preimage.salt.toByteArray))
+    val digest = (new Blake2b256).hash(preimage.input.toByteArray ++ preimage.salt.toByteArray)
     Digest().withDigest32(
-      Digest.Digest32(ByteString.copyFrom(digest.toArray))
+      Digest.Digest32(ByteString.copyFrom(digest))
     )
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
@@ -6,7 +6,6 @@ import co.topl.quivr.algebras.DigestVerifier
 import co.topl.quivr.runtime.QuivrRuntimeError
 import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError
 import quivr.models.{Digest, DigestVerification, Preimage}
-import scodec.bits.ByteVector
 import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherObject}
 
 /**
@@ -23,9 +22,9 @@ object Blake2b256DigestInterpreter {
      */
     override def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] = t match {
       case DigestVerification(Digest(Digest.Value.Digest32(d), _), Preimage(p, salt, _), _) =>
-        val testHash: ByteVector = (new Blake2b256).hash(ByteVector(p.toByteArray ++ salt.toByteArray))
-        val expectedHash = ByteVector(d.value.toByteArray)
-        if (testHash === expectedHash)
+        val testHash: Array[Byte] = (new Blake2b256).hash(p.toByteArray ++ salt.toByteArray)
+        val expectedHash: Array[Byte] = d.value.toByteArray
+        if (java.util.Arrays.equals(testHash, expectedHash))
           Either.right[QuivrRuntimeError, DigestVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.
           Either.left[QuivrRuntimeError, DigestVerification](ValidationError.LockedPropositionIsUnsatisfiable).pure[F]

--- a/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
+++ b/crypto/src/main/scala/co/topl/crypto/accumulators/merkle/MerkleTree.scala
@@ -4,9 +4,9 @@ import co.topl.crypto.accumulators.{LeafData, Side}
 import co.topl.crypto.hash.Hash
 import co.topl.crypto.hash.digest.Digest
 import co.topl.crypto.hash.digest.implicits._
-import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ArraySeq
 
 /* Forked from https://github.com/input-output-hk/scrypto */
 
@@ -14,7 +14,7 @@ import scala.annotation.tailrec
 /* NOTE: Use of mutable.WrappedArray.ofByte for Scala 2.12 compatibility */
 class MerkleTree[H, D: Digest](
   topNode:           Option[Node[D]],
-  elementsHashIndex: Map[ByteVector, Int]
+  elementsHashIndex: Map[ArraySeq[Byte], Int]
 )(implicit h: Hash[H, D]) {
 
   private lazy val emptyRootHash: D = Digest[D].empty
@@ -29,7 +29,7 @@ class MerkleTree[H, D: Digest](
   def proofByElement(element: Leaf[H, D]): Option[MerkleProof[H, D]] = proofByElementHash(element.hash)
 
   def proofByElementHash(hash: D): Option[MerkleProof[H, D]] =
-    elementsHashIndex.get(ByteVector(hash.bytes)).flatMap(i => proofByIndex(i))
+    elementsHashIndex.get(ArraySeq.from(hash.bytes)).flatMap(i => proofByIndex(i))
 
   def proofByIndex(index: Int): Option[MerkleProof[H, D]] = if (index >= 0 && index < length) {
 
@@ -83,8 +83,8 @@ object MerkleTree {
 
     val elementsToIndex =
       leafs.zipWithIndex
-        .foldLeft(Map[ByteVector, Int]()) { case (elements, (leaf, leafIndex)) =>
-          elements + (ByteVector(leaf.hash.bytes) -> leafIndex)
+        .foldLeft(Map[ArraySeq[Byte], Int]()) { case (elements, (leaf, leafIndex)) =>
+          elements + (ArraySeq.from(leaf.hash.bytes) -> leafIndex)
         }
 
     val topNode = calcTopNode[H, D](leafs)

--- a/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
+++ b/crypto/src/main/scala/co/topl/crypto/hash/Blake2b.scala
@@ -2,7 +2,6 @@ package co.topl.crypto.hash
 
 import co.topl.crypto.hash.digest.Digest
 import org.bouncycastle.crypto.digests.Blake2bDigest
-import scodec.bits.ByteVector
 
 /**
  * Blake2b-* hashing scheme
@@ -44,11 +43,11 @@ abstract class Blake2bHash[D: Digest] extends Hash[Blake2b, D] {
 class Blake2b256 {
   private val digest = new Blake2bDigest(256)
 
-  def hash(bytes: ByteVector*): ByteVector = {
+  def hash(bytes: Array[Byte]*): Array[Byte] = {
     val out = new Array[Byte](32)
-    bytes.foreach(b => digest.update(b.toArray, 0, b.length.toInt))
+    bytes.foreach(b => digest.update(b, 0, b.length))
     digest.doFinal(out, 0)
-    ByteVector(out)
+    out
   }
 }
 
@@ -60,10 +59,10 @@ class Blake2b256 {
 class Blake2b512 {
   private val digest = new Blake2bDigest(512)
 
-  def hash(bytes: ByteVector*): ByteVector = {
+  def hash(bytes: Array[Byte]*): Array[Byte] = {
     val out = new Array[Byte](64)
-    bytes.foreach(b => digest.update(b.toArray, 0, b.length.toInt))
+    bytes.foreach(b => digest.update(b, 0, b.length))
     digest.doFinal(out, 0)
-    ByteVector(out)
+    out
   }
 }

--- a/crypto/src/test/scala/co/topl/crypto/utils/Generators.scala
+++ b/crypto/src/test/scala/co/topl/crypto/utils/Generators.scala
@@ -2,12 +2,9 @@ package co.topl.crypto.utils
 
 import co.topl.crypto.generation.mnemonic.{MnemonicSize, MnemonicSizes}
 import org.scalacheck.{Arbitrary, Gen}
-import scodec.bits.ByteVector
 
 object Generators {
   def genRandomlySizedByteArray: Gen[Array[Byte]] = Gen.listOf(Arbitrary.arbitrary[Byte]).map(_.toArray)
-
-  def genRandomlySizedBytes: Gen[ByteVector] = genRandomlySizedByteArray.map(ByteVector(_))
 
   def genByteArrayWithBoundedSize(minSize: Int, maxSize: Int): Gen[Array[Byte]] =
     Gen
@@ -15,9 +12,6 @@ object Generators {
       .flatMap(sz => Gen.listOfN(sz, Arbitrary.arbitrary[Byte]))
       .retryUntil(list => list.length >= minSize && list.length <= maxSize)
       .map(_.toArray)
-
-  def genBytesWithBoundedSize(minSize: Int, maxSize: Int): Gen[ByteVector] =
-    genByteArrayWithBoundedSize(minSize, maxSize).map(ByteVector(_))
 
   def genByteArrayOfSize(n: Int): Gen[Array[Byte]] =
     Gen.listOfN(n, Arbitrary.arbitrary[Byte]).retryUntil(_.length == n).map(_.toArray)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,12 +56,6 @@ object Dependencies {
     "org.typelevel" %% "simulacrum" % simulacrumVersion
   )
 
-  val scodec: Seq[ModuleID] = Seq(
-    "org.scodec" %% "scodec-core" % "1.11.10",
-    "org.scodec" %% "scodec-bits" % "1.1.37",
-    "org.scodec" %% "scodec-cats" % "1.2.0"
-  )
-
   val protobufSpecs: Seq[ModuleID] = Seq(
     "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
   )
@@ -75,7 +69,6 @@ object Dependencies {
     lazy val sources: Seq[ModuleID] =
       Seq("org.bouncycastle" % "bcprov-jdk18on" % "1.72") ++
       circe ++
-      scodec ++
       newType ++
       cats ++
       simulacrum


### PR DESCRIPTION
## Purpose

We no longer want to depend on Scodec

## Approach

Removed any remaining usages of Scodec and replaced with appropriate data types. Removed Scodec from dependencies

## Testing

- Any tests that depended on scodec were updated as well
- Ensured all existing tests pass 
- Ran `checkPR`, ensured it passed

## Tickets
* Part of TSDK-413 => Updates to Bifrost are still required

