### PR TITLE
Made WalletApiErrors extend RuntimeError

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -154,7 +154,7 @@ object WalletApi {
 
   case class NewWalletResult[F[_]](mnemonic: IndexedSeq[String], mainKeyVaultStore: VaultStore[F])
 
-  trait WalletApiFailure
-  case class FailedToInitializeWallet(err: Throwable = null) extends WalletApiFailure
-  case class FailedToSaveWallet(err: Throwable = null) extends WalletApiFailure
+  abstract class WalletApiFailure(err: Throwable = null) extends RuntimeException(err)
+  case class FailedToInitializeWallet(err: Throwable = null) extends WalletApiFailure(err)
+  case class FailedToSaveWallet(err: Throwable = null) extends WalletApiFailure(err)
 }


### PR DESCRIPTION
## Purpose

It is difficult to combine different operations because all the error types are different. A solution would be to make all the errors extend Throwable/RuntimeError.

## Approach

DataApiError already extends RuntimeError. This PR changes WalletApiError to also extend RuntimeError

## Testing

Ran `checkPR` and ensured was successful 

## Tickets
* n/a