### PR TITLE
TSDK-419 Update Wallet + Update Wallet's Password

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -79,6 +79,16 @@ trait DataApi[F[_]] {
    * @return The VaultStore for the Topl Main Secret Key if it exists. If retrieving fails due to an underlying cause, return a DataApiException
    */
   def getMainKeyVaultStore(name: String): F[Either[DataApiException, VaultStore[F]]]
+
+  /**
+   * Update a persisted VaultStore for the Topl Main Secret Key.
+   *
+   * @param name              The name identifier of the VaultStore to update. This is used to manage multiple wallet identities.
+   *                          Most commonly, only one wallet identity will be used. It is the responsibility of the dApp
+   *                          to manage the names of the wallet identities if multiple will be used.
+   * @return nothing if successful. If the update fails due to an underlying cause (for ex does not exist), return a DataApiException
+   */
+  def updateMainKeyVaultStore(mainKeyVaultStore: VaultStore[F], name: String): F[Either[DataApiException, Unit]]
 }
 
 object DataApi {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -23,11 +23,10 @@ import co.topl.crypto.generation.mnemonic.Entropy
 import co.topl.crypto.signing.ExtendedEd25519
 
 trait MockHelpers {
-  private val ExtendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519
   val MockIndices: Indices = Indices(0, 0, 0)
-  val MockMainKeyPair: KeyPair = ExtendedEd25519Instance.deriveKeyPairFromEntropy(Entropy.generate(), None)
+  val MockMainKeyPair: KeyPair = (new ExtendedEd25519).deriveKeyPairFromEntropy(Entropy.generate(), None)
 
-  val MockChildKeyPair: KeyPair = ExtendedEd25519Instance.deriveKeyPairFromChildPath(
+  val MockChildKeyPair: KeyPair = (new ExtendedEd25519).deriveKeyPairFromChildPath(
     pbKeyPairToCryotoKeyPair(MockMainKeyPair).signingKey,
     List(
       Bip32Indexes.HardenedIndex(MockIndices.x),

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -8,18 +8,22 @@ import quivr.models.KeyPair
 import cats.arrow.FunctionK
 import co.topl.brambl.models.Indices
 import co.topl.crypto.signing.ExtendedEd25519
+import io.circe.syntax.EncoderOps
+import co.topl.crypto.encryption.VaultStore.Codecs._
 
 class WalletApiSpec extends munit.FunSuite with MockHelpers {
+  implicit val idToId: FunctionK[Id, Id] = FunctionK.id[Id]
+  val walletApi: WalletApi[Id] = WalletApi.make[Id](MockDataApi)
+  val testMsg: Array[Byte] = "test message".getBytes
+
+  // Runs after each individual test.
+  override def afterEach(context: AfterEach): Unit =
+    MockDataApi.mainKeyVaultStoreInstance = Map() // Reset the MockDataApi persisted data
 
   test(
     "createAndSaveNewWallet: Creating a new wallet creates VaultStore that contains a Topl Main Key and a Mnemonic (default length 12)"
   ) {
-    val walletApi = WalletApi.make[Id](MockDataApi)
     val password = "password".getBytes
-    // import implicit instances for natural transformations
-    import cats.arrow._
-    import cats.~>
-    implicit val idToId = FunctionK.id[Id]
     val res = walletApi.createAndSaveNewWallet[Id](password)
     assert(res.isRight)
     assert(res.toOption.get.mnemonic.length == 12)
@@ -34,15 +38,12 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("createNewWallet: Specifying a valid mnemonic length returns a mnemonic of correct length") {
-    val walletApi = WalletApi.make[Id](MockDataApi)
-    val password = "password".getBytes
-    val res = walletApi.createNewWallet(password, mLen = MnemonicSizes.words24)
+    val res = walletApi.createNewWallet("password".getBytes, mLen = MnemonicSizes.words24)
     assert(res.isRight)
     assert(res.toOption.get.mnemonic.length == 24)
   }
 
   test("saveWallet and loadWallet: specifying a name other than 'default' saves the wallet under that name") {
-    val walletApi = WalletApi.make[Id](MockDataApi)
     val w1 = walletApi.createNewWallet("password1".getBytes).toOption.get.mainKeyVaultStore
     val w2 = walletApi.createNewWallet("password2".getBytes).toOption.get.mainKeyVaultStore
     assert(w1 != w2)
@@ -58,8 +59,15 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     assert(stored2.get == w2)
   }
 
+  test(
+    "loadWallet: if the wallet with the name does not exist, the correct error is returned"
+  ) {
+    val loadRes = walletApi.loadWallet("w1")
+    assert(loadRes.isLeft)
+    assert(loadRes.left.toOption.get == WalletApi.FailedToLoadWallet(MockDataApi.MainKeyVaultStoreNotInitialized))
+  }
+
   test("extractMainKey: ExtendedEd25519 Topl Main Key is returned") {
-    val walletApi = WalletApi.make[Id](MockDataApi)
     val password = "password".getBytes
     val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
     val mainKeyOpt = walletApi.extractMainKey(vaultStore, password)
@@ -76,17 +84,14 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
   test(
     "createAndSaveNewWallet and loadAndExtractMainKey: specifying a name other than 'default' extracts the Topl Main Key under that name"
   ) {
-    import cats.arrow._
-    import cats.~>
-    implicit val idToId = FunctionK.id[Id]
-    val walletApi = WalletApi.make[Id](MockDataApi)
+    val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
-    val res1 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase1"), name = "w3")
-    val res2 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase2"), name = "w4")
+    val res1 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase1"), name = "w1")
+    val res2 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase2"), name = "w2")
     assert(res1.isRight)
     assert(res2.isRight)
-    val kp1Either = walletApi.loadAndExtractMainKey[Id](password, "w3")
-    val kp2Either = walletApi.loadAndExtractMainKey[Id](password, "w4")
+    val kp1Either = walletApi.loadAndExtractMainKey[Id](password, "w1")
+    val kp2Either = walletApi.loadAndExtractMainKey[Id](password, "w2")
     assert(kp1Either.isRight)
     assert(kp2Either.isRight)
     val kp1 = kp1Either.toOption.get
@@ -95,27 +100,121 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     assert(kp1.sk.sk.extendedEd25519.isDefined)
     assert(kp2.vk.vk.extendedEd25519.isDefined)
     assert(kp2.sk.sk.extendedEd25519.isDefined)
-    val testMsg = "test message".getBytes
-    val signingInstance = new ExtendedEd25519
     val signature1 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp1).signingKey, testMsg)
     val signature2 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp2).signingKey, testMsg)
     assert(signingInstance.verify(signature1, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey))
     assert(signingInstance.verify(signature2, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey))
     assert(!signingInstance.verify(signature1, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey))
     assert(!signingInstance.verify(signature2, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey))
+  }
 
+  test(
+    "createAndSaveNewWallet: If the wallet is successfully created but not saved, the correct error is returned"
+  ) {
+    // DataApi mocked "error" to return an error when saving the wallet
+    val res = walletApi.createAndSaveNewWallet[Id]("password".getBytes, name = "error")
+    assert(res.isLeft)
+    assert(res.left.toOption.get == WalletApi.FailedToSaveWallet(MockDataApi.MainKeyVaultSaveFailure))
   }
 
   test("deriveChildKeys: Verify deriving path 4'/4/4 produces a valid child key pair") {
-    val walletApi = WalletApi.make[Id](MockDataApi)
+    val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
     val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
     val mainKey = walletApi.extractMainKey(vaultStore, password).toOption.get
     val idx = Indices(4, 4, 4)
     val childKey = walletApi.deriveChildKeys(mainKey, idx)
-    val testMsg = "test message".getBytes
-    val signingInstance = new ExtendedEd25519
     val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKey).signingKey, testMsg)
     assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(childKey).verificationKey))
+  }
+
+  test(
+    "buildMainKeyVaultStore: Build a VaultStore for a main key encrypted with a password."
+  ) {
+    val mainKey = "dummyKeyPair".getBytes
+    val password = "password".getBytes
+    // Using the same password should return the same VaultStore
+    val v1 = walletApi.buildMainKeyVaultStore(mainKey, password)
+    val v2 = walletApi.buildMainKeyVaultStore(mainKey, password)
+    assert(v1 == v2)
+    assert(
+      VaultStore.decodeCipher(v1, password).toOption.get sameElements VaultStore.decodeCipher(v2, password).toOption.get
+    )
+    // Using a different password should decode the VaultStore to the same key
+    val v3 = walletApi.buildMainKeyVaultStore(mainKey, "password2".getBytes)
+    assert(v1 != v3)
+    assert(
+      VaultStore.decodeCipher(v1, password).toOption.get sameElements VaultStore.decodeCipher(v2, password).toOption.get
+    )
+  }
+
+  test(
+    "updateWallet: Updating a wallet when a wallet of that name does not exist > Error"
+  ) {
+    val vs = walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+    val w1 = walletApi.updateWallet(vs, "name")
+    assert(w1.isLeft)
+    assert(w1.left.toOption.get == WalletApi.FailedToUpdateWallet(MockDataApi.MainKeyVaultStoreNotInitialized))
+  }
+
+  test(
+    "updateWallet: Updating a wallet > Verify old wallet no longer exists at the specified name"
+  ) {
+    val password = "password".getBytes
+    val oldWallet = walletApi.createAndSaveNewWallet[Id](password, name = "w1")
+    assert(oldWallet.isRight)
+    // same password, different key
+    val newWallet = walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, password)
+    val updateRes = walletApi.updateWallet(newWallet, "w1")
+    assert(updateRes.isRight)
+    val loadedWalletRes = walletApi.loadWallet("w1")
+    assert(loadedWalletRes.isRight)
+    val loadedWallet = loadedWalletRes.toOption.get
+    assert(loadedWallet != oldWallet.toOption.get.mainKeyVaultStore)
+    assert(loadedWallet == newWallet)
+  }
+
+  test(
+    "updateWalletPassword: Updating a wallet password > Same key stored but with a different password"
+  ) {
+    val oldPassword = "oldPassword".getBytes
+    val newPassword = "newPassword".getBytes
+    val oldWallet = walletApi.createAndSaveNewWallet[Id](oldPassword)
+    assert(oldWallet.isRight)
+    val oldVaultStore = oldWallet.toOption.get.mainKeyVaultStore
+    val mainKey = walletApi.extractMainKey(oldVaultStore, oldPassword).toOption.get
+    // verify old wallet has been saved
+    assert(walletApi.loadWallet().toOption.get == oldVaultStore)
+    val updateRes = walletApi.updateWalletPassword[Id](oldPassword, newPassword)
+    assert(updateRes.isRight)
+    val newVaultStore = updateRes.toOption.get
+    val loadedWallet = walletApi.loadWallet().toOption.get
+    // Verify the old wallet has been replaced
+    assert(loadedWallet != oldVaultStore)
+    assert(loadedWallet == newVaultStore)
+    // Verify the old password does not work for the loaded wallet
+    val decodeOldPassword = walletApi.extractMainKey(loadedWallet, oldPassword)
+    assert(decodeOldPassword.isLeft)
+    assert(decodeOldPassword.left.toOption.get == WalletApi.FailedToDecodeWallet(VaultStore.InvalidMac))
+    // Verify the new password works for the loaded wallet
+    val decodeNewPassword = walletApi.extractMainKey(loadedWallet, newPassword)
+    assert(decodeNewPassword.isRight)
+    assert(decodeNewPassword.toOption.get == mainKey)
+  }
+
+  test(
+    "updateWalletPassword: Failure saving > Wallet is accessible with the old password"
+  ) {
+    val password = "password".getBytes
+    val oldVaultStore = walletApi.createNewWallet(password).toOption.get.mainKeyVaultStore
+    // manually save the wallet to the mock data api with the error name
+    MockDataApi.mainKeyVaultStoreInstance += ("error" -> oldVaultStore.asJson)
+    val updateRes = walletApi.updateWalletPassword[Id](password, "newPassword".getBytes, "error")
+    assert(updateRes.isLeft)
+    println(updateRes.left.toOption.get)
+    assert(updateRes.left.toOption.get == WalletApi.FailedToUpdateWallet(MockDataApi.MainKeyVaultSaveFailure))
+    // verify the wallet is still accessible with the old password
+    val loadedWallet = walletApi.loadAndExtractMainKey[Id](password, "error")
+    assert(loadedWallet.isRight)
   }
 }


### PR DESCRIPTION
## Purpose
 
Made changes to WalletApi and DataApi to support the use case of updating a wallet's password

## Approach

- added `updateMainKeyVaultStore` to DataApi
- Changed WalletApi's private `buildMainKeyVaultStore` to be exposed in the Algebra. 
- Added 2 additional functions to WalletApi's algebra; `updateWallet` and `updateWalletPassword`. The latter is implemented in the trait. The former is implemented in `make` using the new `DataApi.updateMainKeyVaultStore`
- Updated MockDataApi for tests to reflect the change in DataApi. I also mocked a way to trigger a save failure in `saveMainKeyVaultStore`
- Updated MockHelpers to re-instantiate `new ExtendedEd25519` each time its used (to fix flaky tests)
- Added unit tests for all the new functions + added an `afterEach` cleanup function to reset the persisted data in MockDataApi

## Testing

- Added unit tests
- ensured all existing tests passed
- ran `checkPR` and ensured successful

## Tickets
* Closes TSDK-419