### PR TITLE
TransactionId, Remove 32/64 Types

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsEvidence.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsEvidence.scala
@@ -1,12 +1,12 @@
 package co.topl.brambl.common
 
-import cats.implicits._
 import co.topl.brambl.models.Evidence
 import co.topl.crypto.accumulators.LeafData
 import co.topl.crypto.accumulators.merkle.MerkleTree
-import co.topl.crypto.hash.digest.{Digest32, Digest64}
+import co.topl.crypto.hash.digest.Digest32
 import co.topl.crypto.hash.implicits._
-import co.topl.crypto.hash.{blake2b256, blake2b512, Blake2b}
+import co.topl.crypto.hash.Blake2b
+import co.topl.crypto.hash.blake2b256
 import com.google.protobuf.ByteString
 import quivr.models.Digest
 
@@ -14,88 +14,52 @@ import quivr.models.Digest
  * Contains signable bytes and has methods to get evidence of those bytes in the form of a 32 or 64 byte hash.
  */
 trait ContainsEvidence[T] {
-  def sized32Evidence(t: T): Evidence.Sized32
-  def sized64Evidence(t: T): Evidence.Sized64
+  def sizedEvidence(t: T): Evidence
 }
 
 object ContainsEvidence {
   def apply[T](implicit ev: ContainsEvidence[T]): ContainsEvidence[T] = ev
 
   implicit class Ops[T: ContainsEvidence](t: T) {
-    def sized32Evidence: Evidence.Sized32 = ContainsEvidence[T].sized32Evidence(t)
+    def sizedEvidence: Evidence = ContainsEvidence[T].sizedEvidence(t)
 
-    def sized64Evidence: Evidence.Sized64 = ContainsEvidence[T].sized64Evidence(t)
   }
 
   implicit def blake2bEvidenceFromImmutable[T: ContainsImmutable]: ContainsEvidence[T] =
     new ContainsEvidence[T] {
 
-      override def sized32Evidence(t: T): Evidence.Sized32 =
-        Evidence.Sized32(
-          Digest
-            .Digest32(
-              ByteString.copyFrom(
-                blake2b256
-                  .hash(
-                    ContainsImmutable[T].immutableBytes(t).value.toByteArray
-                  )
-                  .value
-              )
+      override def sizedEvidence(t: T): Evidence =
+        Evidence(
+          Digest(
+            ByteString.copyFrom(
+              blake2b256
+                .hash(
+                  ContainsImmutable[T].immutableBytes(t).value.toByteArray
+                )
+                .value
             )
-        )
-
-      override def sized64Evidence(t: T): Evidence.Sized64 =
-        Evidence.Sized64(
-          Digest
-            .Digest64(
-              ByteString.copyFrom(
-                blake2b512
-                  .hash(
-                    ContainsImmutable[T].immutableBytes(t).value.toByteArray
-                  )
-                  .value
-              )
-            )
+          )
         )
     }
 
   implicit def merkleRootFromBlake2bEvidence[T: ContainsImmutable]: ContainsEvidence[List[T]] =
     new ContainsEvidence[List[T]] {
 
-      override def sized32Evidence(list: List[T]): Evidence.Sized32 =
-        Evidence.Sized32(
-          Digest
-            .Digest32(
-              ByteString.copyFrom(
-                MerkleTree
-                  .apply[Blake2b, Digest32](
-                    list.zipWithIndex
-                      .map { case (item, index) =>
-                        LeafData(ContainsImmutable[T].immutableBytes(item).value.toByteArray)
-                      }
-                  )
-                  .rootHash
-                  .value
-              )
+      override def sizedEvidence(list: List[T]): Evidence =
+        Evidence(
+          Digest(
+            ByteString.copyFrom(
+              MerkleTree
+                .apply[Blake2b, Digest32](
+                  list.zipWithIndex
+                    .map { case (item, index) =>
+                      LeafData(ContainsImmutable[T].immutableBytes(item).value.toByteArray)
+                    }
+                )
+                .rootHash
+                .value
             )
-        )
-
-      override def sized64Evidence(list: List[T]): Evidence.Sized64 =
-        Evidence.Sized64(
-          Digest
-            .Digest64(
-              ByteString.copyFrom(
-                MerkleTree
-                  .apply[Blake2b, Digest64](
-                    list.zipWithIndex
-                      .map { case (item, index) =>
-                        LeafData(ContainsImmutable[T].immutableBytes(item).value.toByteArray)
-                      }
-                  )
-                  .rootHash
-                  .value
-              )
-            )
+          )
         )
     }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -63,11 +63,7 @@ object ContainsImmutable {
 
     implicit val smallDataImmutable: ContainsImmutable[SmallData] = _.value.immutable
 
-    implicit val rootImmutable: ContainsImmutable[Root] = _.value match {
-      case Root.Value.Root32(v) => v.immutable
-      case Root.Value.Root64(v) => v.immutable
-      case e                    => throw new MatchError(e)
-    }
+    implicit val rootImmutable: ContainsImmutable[Root] = _.value.immutable
 
     implicit val verificationKeyImmutable: ContainsImmutable[VerificationKey] = _.vk match {
       case Vk.Ed25519(v)         => v.immutable
@@ -131,74 +127,28 @@ object ContainsImmutable {
       case Value.Value.Empty           => Array[Byte](0).immutable
     }
 
-    implicit val addressImmutable: ContainsImmutable[Address] = (address: Address) =>
-      address.network.immutable ++
-      address.ledger.immutable ++
-      address.id.immutable
-
-    implicit val size32EvidenceImmutable: ContainsImmutable[Evidence.Sized32] =
+    implicit val evidenceImmutable: ContainsImmutable[Evidence] =
       ev => ev.digest.immutable
 
-    implicit val size64EvidenceImmutable: ContainsImmutable[Evidence.Sized64] =
-      ev => ev.digest.immutable
-
-    implicit val evidenceImmutable: ContainsImmutable[Evidence] = _.value match {
-      case Evidence.Value.Sized32(e) => size32EvidenceImmutable.immutableBytes(e)
-      case Evidence.Value.Sized64(e) => size64EvidenceImmutable.immutableBytes(e)
-      case e                         => throw new MatchError(e)
-    }
-
-    implicit val digest32Immutable: ContainsImmutable[Digest.Digest32] = _.value.immutable
-    implicit val digest64Immutable: ContainsImmutable[Digest.Digest64] = _.value.immutable
-
-    implicit val digestImmutable: ContainsImmutable[Digest] = _.value match {
-      case Digest.Value.Digest32(v) => v.immutable
-      case Digest.Value.Digest64(v) => v.immutable
-      case e                        => throw new MatchError(e)
-    }
+    implicit val digestImmutable: ContainsImmutable[Digest] = _.value.immutable
 
     implicit val preimageImmutable: ContainsImmutable[Preimage] = (pre: Preimage) =>
       pre.input.immutable ++ pre.salt.immutable
 
-    implicit val accumulatorRoot32IdentifierImmutable: ContainsImmutable[Identifier.AccumulatorRoot32] =
+    implicit val accumulatorRoot32IdentifierImmutable: ContainsImmutable[AccumulatorRootId] =
       id =>
         Tags.Identifier.AccumulatorRoot32.immutable ++
-        id.evidence.immutable
+        id.value.immutable
 
-    implicit val accumulatorRoot64IdentifierImmutable: ContainsImmutable[Identifier.AccumulatorRoot64] =
-      id =>
-        Tags.Identifier.AccumulatorRoot64.immutable ++
-        id.evidence.immutable
-
-    implicit val boxLock32IdentifierImmutable: ContainsImmutable[Identifier.Lock32] =
+    implicit val boxLock32IdentifierImmutable: ContainsImmutable[LockId] =
       id =>
         Tags.Identifier.Lock32.immutable ++
-        id.evidence.immutable
+        id.value.immutable
 
-    implicit val boxLock64IdentifierImmutable: ContainsImmutable[Identifier.Lock64] =
-      id =>
-        Tags.Identifier.Lock64.immutable ++
-        id.evidence.immutable
-
-    implicit val ioTransaction32IdentifierImmutable: ContainsImmutable[Identifier.IoTransaction32] =
+    implicit val transactionIdentifierImmutable: ContainsImmutable[TransactionId] =
       id =>
         Tags.Identifier.IoTransaction32.immutable ++
-        id.evidence.immutable
-
-    implicit val ioTransaction64IdentifierImmutable: ContainsImmutable[Identifier.IoTransaction64] =
-      id =>
-        Tags.Identifier.IoTransaction64.immutable ++
-        id.evidence.immutable
-
-    implicit val identifiersImmutable: ContainsImmutable[Identifier] = _.value match {
-      case Identifier.Value.AccumulatorRoot32(i) => accumulatorRoot32IdentifierImmutable.immutableBytes(i)
-      case Identifier.Value.AccumulatorRoot64(i) => accumulatorRoot64IdentifierImmutable.immutableBytes(i)
-      case Identifier.Value.Lock32(i)            => boxLock32IdentifierImmutable.immutableBytes(i)
-      case Identifier.Value.Lock64(i)            => boxLock64IdentifierImmutable.immutableBytes(i)
-      case Identifier.Value.IoTransaction32(i)   => ioTransaction32IdentifierImmutable.immutableBytes(i)
-      case Identifier.Value.IoTransaction64(i)   => ioTransaction64IdentifierImmutable.immutableBytes(i)
-      case e                                     => throw new MatchError(e)
-    }
+        id.value.immutable
 
     implicit val transactionOutputAddressImmutable: ContainsImmutable[TransactionOutputAddress] =
       v =>
@@ -207,23 +157,11 @@ object ContainsImmutable {
         v.index.immutable ++
         v.id.immutable
 
-    implicit val transactionOutputAddressIdImmutable: ContainsImmutable[TransactionOutputAddress.Id] = {
-      case TransactionOutputAddress.Id.IoTransaction32(id) => id.immutable
-      case TransactionOutputAddress.Id.IoTransaction64(id) => id.immutable
-      case e                                               => throw new MatchError(e)
-    }
-
     implicit val lockAddressImmutable: ContainsImmutable[LockAddress] =
       v =>
         v.network.immutable ++
         v.ledger.immutable ++
         v.id.immutable
-
-    implicit val lockAddressIdImmutable: ContainsImmutable[LockAddress.Id] = {
-      case LockAddress.Id.Lock32(id) => id.immutable
-      case LockAddress.Id.Lock64(id) => id.immutable
-      case e                         => throw new MatchError(e)
-    }
 
     implicit val lvlValueImmutable: ContainsImmutable[Value.LVL] =
       _.quantity.immutable
@@ -259,31 +197,20 @@ object ContainsImmutable {
       predicate.threshold.immutable ++
       predicate.challenges.immutable
 
-    implicit val image32LockImmutable: ContainsImmutable[Lock.Image32] = (image: Lock.Image32) =>
+    implicit val imageLockImmutable: ContainsImmutable[Lock.Image] = (image: Lock.Image) =>
       image.threshold.immutable ++
       image.leaves.immutable
 
-    implicit val image64LockImmutable: ContainsImmutable[Lock.Image64] = (image: Lock.Image64) =>
-      image.threshold.immutable ++
-      image.leaves.immutable
-
-    implicit val commitment32LockImmutable: ContainsImmutable[Lock.Commitment32] = (commitment: Lock.Commitment32) =>
-      commitment.threshold.immutable ++
-      commitment.root.size.immutable ++
-      commitment.root.immutable
-
-    implicit val commitment64LockImmutable: ContainsImmutable[Lock.Commitment64] = (commitment: Lock.Commitment64) =>
+    implicit val commitmentLockImmutable: ContainsImmutable[Lock.Commitment] = (commitment: Lock.Commitment) =>
       commitment.threshold.immutable ++
       commitment.root.size.immutable ++
       commitment.root.immutable
 
     implicit val lockImmutable: ContainsImmutable[Lock] = _.value match {
-      case Lock.Value.Predicate(l)    => predicateLockImmutable.immutableBytes(l)
-      case Lock.Value.Image32(l)      => image32LockImmutable.immutableBytes(l)
-      case Lock.Value.Image64(l)      => image64LockImmutable.immutableBytes(l)
-      case Lock.Value.Commitment32(l) => commitment32LockImmutable.immutableBytes(l)
-      case Lock.Value.Commitment64(l) => commitment64LockImmutable.immutableBytes(l)
-      case e                          => throw new MatchError(e)
+      case Lock.Value.Predicate(l)  => predicateLockImmutable.immutableBytes(l)
+      case Lock.Value.Image(l)      => imageLockImmutable.immutableBytes(l)
+      case Lock.Value.Commitment(l) => commitmentLockImmutable.immutableBytes(l)
+      case e                        => throw new MatchError(e)
     }
 
     implicit val predicateAttestationImmutable: ContainsImmutable[Attestation.Predicate] =
@@ -291,43 +218,23 @@ object ContainsImmutable {
         attestation.lock.immutable ++
         attestation.responses.immutable
 
-    implicit val image32AttestationImmutable: ContainsImmutable[Attestation.Image32] =
+    implicit val imageAttestationImmutable: ContainsImmutable[Attestation.Image] =
       attestation =>
         attestation.lock.immutable ++
         attestation.known.immutable ++
         attestation.responses.immutable
 
-    implicit val image64AttestationImmutable: ContainsImmutable[Attestation.Image64] =
-      attestation =>
-        attestation.lock.immutable ++
-        attestation.known.immutable ++
-        attestation.responses.immutable
-
-    implicit val commitment32AttestationImmutable: ContainsImmutable[Attestation.Commitment32] =
-      attestation =>
-        attestation.lock.immutable ++
-        attestation.known.immutable ++
-        attestation.responses.immutable
-
-    implicit val commitment64AttestationImmutable: ContainsImmutable[Attestation.Commitment64] =
+    implicit val commitmentAttestationImmutable: ContainsImmutable[Attestation.Commitment] =
       attestation =>
         attestation.lock.immutable ++
         attestation.known.immutable ++
         attestation.responses.immutable
 
     implicit val attestationImmutable: ContainsImmutable[Attestation] = _.value match {
-      case Attestation.Value.Predicate(a)    => predicateAttestationImmutable.immutableBytes(a)
-      case Attestation.Value.Image32(a)      => image32AttestationImmutable.immutableBytes(a)
-      case Attestation.Value.Image64(a)      => image64AttestationImmutable.immutableBytes(a)
-      case Attestation.Value.Commitment32(a) => commitment32AttestationImmutable.immutableBytes(a)
-      case Attestation.Value.Commitment64(a) => commitment64AttestationImmutable.immutableBytes(a)
-      case e                                 => throw new MatchError(e)
-    }
-
-    implicit val transactionInputAddressIdContainsImmutable: ContainsImmutable[TransactionInputAddress.Id] = {
-      case TransactionInputAddress.Id.IoTransaction32(id) => id.immutable
-      case TransactionInputAddress.Id.IoTransaction64(id) => id.immutable
-      case e                                              => throw new MatchError(e)
+      case Attestation.Value.Predicate(a)  => predicateAttestationImmutable.immutableBytes(a)
+      case Attestation.Value.Image(a)      => imageAttestationImmutable.immutableBytes(a)
+      case Attestation.Value.Commitment(a) => commitmentAttestationImmutable.immutableBytes(a)
+      case e                               => throw new MatchError(e)
     }
 
     implicit val transactionInputAddressContainsImmutable: ContainsImmutable[TransactionInputAddress] =

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsSignable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsSignable.scala
@@ -36,11 +36,9 @@ object ContainsSignable {
       stxo.copy(
         attestation = stxo.attestation.copy(
           value = stxo.attestation.value match {
-            case p: Attestation.Value.Predicate      => p.copy(p.value.copy(responses = Seq.empty))
-            case i32: Attestation.Value.Image32      => i32.copy(i32.value.copy(responses = Seq.empty))
-            case i64: Attestation.Value.Image64      => i64.copy(i64.value.copy(responses = Seq.empty))
-            case c32: Attestation.Value.Commitment32 => c32.copy(c32.value.copy(responses = Seq.empty))
-            case c64: Attestation.Value.Commitment64 => c64.copy(c64.value.copy(responses = Seq.empty))
+            case p: Attestation.Value.Predicate  => p.copy(p.value.copy(responses = Seq.empty))
+            case i: Attestation.Value.Image      => i.copy(i.value.copy(responses = Seq.empty))
+            case c: Attestation.Value.Commitment => c.copy(c.value.copy(responses = Seq.empty))
           }
         )
       )

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
@@ -19,7 +19,7 @@ trait LockSyntax {
 
 class LockSyntaxOps(val lock: Lock) extends AnyVal {
 
-  def address(network: Int, ledger: Int): LockAddress =
+  def lockAddress(network: Int, ledger: Int): LockAddress =
     LockAddress(
       network,
       ledger,
@@ -31,7 +31,7 @@ class LockSyntaxOps(val lock: Lock) extends AnyVal {
 
 class PredicateLockSyntaxOps(val lock: Lock.Predicate) extends AnyVal {
 
-  def address(network: Int, ledger: Int): LockAddress =
+  def lockAddress(network: Int, ledger: Int): LockAddress =
     LockAddress(
       network,
       ledger,

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/LockSyntax.scala
@@ -2,8 +2,8 @@ package co.topl.brambl.syntax
 
 import co.topl.brambl.common.ContainsEvidence
 import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
-import co.topl.brambl.models.Identifier
 import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.LockId
 import co.topl.brambl.models.box.Lock
 
 import scala.language.implicitConversions
@@ -20,21 +20,23 @@ trait LockSyntax {
 class LockSyntaxOps(val lock: Lock) extends AnyVal {
 
   def address(network: Int, ledger: Int): LockAddress =
-    LockAddress(network, ledger)
-      .withLock32(
-        Identifier.Lock32(
-          ContainsEvidence[Lock].sized32Evidence(lock)
-        )
+    LockAddress(
+      network,
+      ledger,
+      LockId(
+        ContainsEvidence[Lock].sizedEvidence(lock).digest.value
       )
+    )
 }
 
 class PredicateLockSyntaxOps(val lock: Lock.Predicate) extends AnyVal {
 
   def address(network: Int, ledger: Int): LockAddress =
-    LockAddress(network, ledger)
-      .withLock32(
-        Identifier.Lock32(
-          ContainsEvidence[Lock].sized32Evidence(Lock().withPredicate(lock))
-        )
+    LockAddress(
+      network,
+      ledger,
+      LockId(
+        ContainsEvidence[Lock].sizedEvidence(Lock().withPredicate(lock)).digest.value
       )
+    )
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionIdSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionIdSyntax.scala
@@ -1,18 +1,18 @@
 package co.topl.brambl.syntax
 
-import co.topl.brambl.models.Identifier
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.TransactionOutputAddress
 
 import scala.language.implicitConversions
 
 trait TransactionIdSyntax {
 
-  implicit def transactionIdAsIdSyntaxOps(id: Identifier.IoTransaction32): TransactionIdSyntaxOps =
+  implicit def transactionIdAsIdSyntaxOps(id: TransactionId): TransactionIdSyntaxOps =
     new TransactionIdSyntaxOps(id)
 }
 
-class TransactionIdSyntaxOps(val id: Identifier.IoTransaction32) extends AnyVal {
+class TransactionIdSyntaxOps(val id: TransactionId) extends AnyVal {
 
   def outputAddress(network: Int, ledger: Int, index: Int): TransactionOutputAddress =
-    TransactionOutputAddress(network, ledger, index, TransactionOutputAddress.Id.IoTransaction32(id))
+    TransactionOutputAddress(network, ledger, index, id)
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Blake2b256DigestInterpreter.scala
@@ -21,9 +21,9 @@ object Blake2b256DigestInterpreter {
      * @return The DigestVerification object if the digest is valid, otherwise an error
      */
     override def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] = t match {
-      case DigestVerification(Digest(Digest.Value.Digest32(d), _), Preimage(p, salt, _), _) =>
+      case DigestVerification(Digest(d, _), Preimage(p, salt, _), _) =>
         val testHash: Array[Byte] = (new Blake2b256).hash(p.toByteArray ++ salt.toByteArray)
-        val expectedHash: Array[Byte] = d.value.toByteArray
+        val expectedHash: Array[Byte] = d.toByteArray
         if (java.util.Arrays.equals(testHash, expectedHash))
           Either.right[QuivrRuntimeError, DigestVerification](t).pure[F]
         else // TODO: replace with correct error. Verification failed.

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -38,11 +38,9 @@ trait MockHelpers {
   private val MockSecret: Array[Byte] = "A mock secret".getBytes
   val MockPreimage: Preimage = Preimage(ByteString.copyFrom(MockSecret), ByteString.copyFromUtf8("salt"))
 
-  private val MockDigest = Digest().withDigest32(
-    Digest.Digest32(
-      ByteString.copyFrom(
-        (new Blake2b256).hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray)
-      )
+  private val MockDigest = Digest(
+    ByteString.copyFrom(
+      (new Blake2b256).hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray)
     )
   )
 
@@ -57,14 +55,14 @@ trait MockHelpers {
   // Arbitrary Transaction that any new transaction can reference
   val dummyTx: IoTransaction = IoTransaction(datum = txDatum)
 
-  val dummyTxIdentifier: Identifier.IoTransaction32 = Identifier.IoTransaction32(dummyTx.sized32Evidence)
+  val dummyTxIdentifier: TransactionId = TransactionId(dummyTx.sizedEvidence.digest.value)
 
   val dummyTxoAddress: TransactionOutputAddress =
     TransactionOutputAddress(
       0,
       0,
       0,
-      TransactionOutputAddress.Id.IoTransaction32(dummyTxIdentifier)
+      dummyTxIdentifier
     )
 
   val value: Value =
@@ -74,7 +72,7 @@ trait MockHelpers {
     Lock().withPredicate(Lock.Predicate(List(Challenge().withRevealed(Proposer.tickProposer[Id].propose(5, 15))), 1))
 
   val trivialLockAddress: LockAddress =
-    LockAddress(0, 0, LockAddress.Id.Lock32(Identifier.Lock32(trivialOutLock.sized32Evidence)))
+    LockAddress(0, 0, LockId(trivialOutLock.sizedEvidence.digest.value))
 
   val inLockFull: Lock.Predicate = Lock.Predicate(
     List(
@@ -93,7 +91,7 @@ trait MockHelpers {
   )
 
   val trivialInLockFullAddress: LockAddress =
-    LockAddress(0, 0, LockAddress.Id.Lock32(Identifier.Lock32(inLockFull.sized32Evidence)))
+    LockAddress(0, 0, LockId(inLockFull.sizedEvidence.digest.value))
 
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
@@ -1,20 +1,9 @@
 package co.topl.brambl.generators
 
-import co.topl.brambl.models.LockAddress
-import co.topl.brambl.models.TransactionOutputAddress
-import co.topl.brambl.models.box.Attestation
-import co.topl.brambl.models.box.Lock
-import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.models.transaction.Schedule
-import co.topl.brambl.models.transaction.SpentTransactionOutput
-import co.topl.brambl.models.transaction.UnspentTransactionOutput
-import co.topl.brambl.models.Datum
-import co.topl.brambl.models.Event
-import co.topl.brambl.models.Evidence
-import co.topl.brambl.models.Identifier
-import co.topl.quivr.generators.ModelGenerators.arbitraryDigest32
-import co.topl.quivr.generators.ModelGenerators.arbitraryDigest64
+import co.topl.brambl.models.box._
+import co.topl.brambl.models.transaction._
+import co.topl.brambl.models._
+import co.topl.quivr.generators.ModelGenerators.arbitraryDigest
 import com.google.protobuf.ByteString
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
@@ -25,63 +14,35 @@ import java.util.Random
 
 trait EvidenceGenerator {
 
-  implicit val arbitraryEvidenceSized32: Arbitrary[Evidence.Sized32] =
+  implicit val arbitraryEvidenceSized: Arbitrary[Evidence] =
     Arbitrary(
       for {
-        digest <- arbitraryDigest32.arbitrary
-      } yield Evidence.Sized32.of(digest)
-    )
-
-  implicit val arbitraryEvidenceSized64: Arbitrary[Evidence.Sized64] =
-    Arbitrary(
-      for {
-        digest <- arbitraryDigest64.arbitrary
-      } yield Evidence.Sized64.of(digest)
+        digest <- arbitraryDigest.arbitrary
+      } yield Evidence(digest)
     )
 }
 
 trait IdentifierGenerator extends EvidenceGenerator {
 
-  implicit val arbitraryLock32: Arbitrary[Identifier.Lock32] =
+  implicit val arbitraryLockId: Arbitrary[LockId] =
     Arbitrary(
       for {
-        evidence <- arbitraryEvidenceSized32.arbitrary
-      } yield Identifier.Lock32.of(evidence)
+        evidence <- arbitraryEvidenceSized.arbitrary
+      } yield LockId(evidence.digest.value)
     )
 
-  implicit val arbitraryLock64: Arbitrary[Identifier.Lock64] =
+  implicit val arbitraryTransactionId: Arbitrary[TransactionId] =
     Arbitrary(
       for {
-        evidence <- arbitraryEvidenceSized64.arbitrary
-      } yield Identifier.Lock64.of(evidence)
+        evidence <- arbitraryEvidenceSized.arbitrary
+      } yield TransactionId(evidence.digest.value)
     )
 
-  implicit val arbitraryIoTransaction32: Arbitrary[Identifier.IoTransaction32] =
+  implicit val arbitraryAccumulatorRootId: Arbitrary[AccumulatorRootId] =
     Arbitrary(
       for {
-        evidence <- arbitraryEvidenceSized32.arbitrary
-      } yield Identifier.IoTransaction32.of(evidence)
-    )
-
-  implicit val arbitraryIoTransaction64: Arbitrary[Identifier.IoTransaction64] =
-    Arbitrary(
-      for {
-        evidence <- arbitraryEvidenceSized64.arbitrary
-      } yield Identifier.IoTransaction64.of(evidence)
-    )
-
-  implicit val arbitraryAccumulatorRoot32: Arbitrary[Identifier.AccumulatorRoot32] =
-    Arbitrary(
-      for {
-        evidence <- arbitraryEvidenceSized32.arbitrary
-      } yield Identifier.AccumulatorRoot32.of(evidence)
-    )
-
-  implicit val arbitraryAccumulatorRoot64: Arbitrary[Identifier.AccumulatorRoot64] =
-    Arbitrary(
-      for {
-        evidence <- arbitraryEvidenceSized64.arbitrary
-      } yield Identifier.AccumulatorRoot64.of(evidence)
+        evidence <- arbitraryEvidenceSized.arbitrary
+      } yield AccumulatorRootId(evidence.digest.value)
     )
 }
 
@@ -92,8 +53,8 @@ trait LockAddressGenerator extends IdentifierGenerator {
       for {
         network <- Gen.chooseNum(0, 50)
         ledger  <- Gen.chooseNum(0, 50)
-        id      <- arbitraryLock32.arbitrary
-      } yield LockAddress(network, ledger, LockAddress.Id.Lock32(id))
+        id      <- arbitraryLockId.arbitrary
+      } yield LockAddress(network, ledger, id)
     )
 }
 
@@ -105,8 +66,8 @@ trait TransactionOutputAddressGenerator extends IdentifierGenerator {
         network <- Gen.chooseNum(0, 50)
         ledger  <- Gen.chooseNum(0, 50)
         index   <- Gen.chooseNum(0, 50)
-        id      <- arbitraryIoTransaction32.arbitrary
-      } yield TransactionOutputAddress(network, ledger, index, TransactionOutputAddress.Id.IoTransaction32(id))
+        id      <- arbitraryTransactionId.arbitrary
+      } yield TransactionOutputAddress(network, ledger, index, id)
     )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "8de3426" // scala-steward:off
-    val protobufSpecsVersion = "b745cb1" // scala-steward:off
+    val quivr4sVersion = "ef50d78" // scala-steward:off
+    val protobufSpecsVersion = "110e109" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 
@@ -57,7 +57,7 @@ object Dependencies {
   )
 
   val protobufSpecs: Seq[ModuleID] = Seq(
-    "com.github.Topl" % "protobuf-specs" % protobufSpecsVersion
+    "com.github.Topl.protobuf-specs" %% "protobuf-fs2" % protobufSpecsVersion
   )
 
   val quivr4s: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "1c87858" // scala-steward:off
+    val quivr4sVersion = "30bb9d2" // scala-steward:off
     val protobufSpecsVersion = "ba616f0" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "ef50d78" // scala-steward:off
-    val protobufSpecsVersion = "110e109" // scala-steward:off
+    val quivr4sVersion = "1c87858" // scala-steward:off
+    val protobufSpecsVersion = "ba616f0" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose
- protobuf-specs has been [updated](https://github.com/Topl/protobuf-specs/pull/54) to remove Identifier and Address super-types
- Also updated to remove separation of 32/64-length types
## Approach
- Update codecs and generators with new protobuf-specs types
## Testing
- Implemented in Bifrost
## Tickets
- #BN-963