### PR TITLE
TSDK-393 Import Wallet (not including recovery)

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -1,8 +1,6 @@
 package co.topl.brambl.wallet
 
-import cats._
 import cats.implicits.catsSyntaxApplicativeId
-import cats.implicits.toFlatMapOps
 import co.topl.crypto.generation.mnemonic.{Entropy, MnemonicSize, MnemonicSizes}
 import cats.Monad
 import cats.implicits.{toFlatMapOps, toFunctorOps}
@@ -26,7 +24,6 @@ import scala.language.implicitConversions
 import cats.data.EitherT
 import cats.arrow.FunctionK
 import co.topl.brambl.models.Indices
-import sun.security.util.Password
 
 import scala.util.Try
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -26,6 +26,7 @@ import scala.language.implicitConversions
 import cats.data.EitherT
 import cats.arrow.FunctionK
 import co.topl.brambl.models.Indices
+import sun.security.util.Password
 
 import scala.util.Try
 
@@ -210,7 +211,8 @@ trait WalletApi[F[_]] {
    *       and fund information for simple 1-of-1 signature transactions. For more complex transactions, the snapshot is
    *       required.
    *
-   * @param mainKey The main key of the wallet to recover
+   * @param mainKeyVaultStore The VaultStore containing the main key of the wallet to recover
+   * @param password The password to decrypt the VaultStore
    * @param name A name used to identify a wallet in the DataApi. Defaults to "default". Most commonly, only one
    *             wallet identity will be used. It is the responsibility of the dApp to keep track of the names of
    *             the wallet identities if multiple will be used.
@@ -218,9 +220,10 @@ trait WalletApi[F[_]] {
    * @return The wallet's VaultStore if import and save was successful. An error if unsuccessful.
    */
   def recoverWallet(
-    mainKey:  KeyPair,
-    name:     String = "default",
-    snapshot: Option[Any] = None
+    mainKeyVaultStore: VaultStore[F],
+    password:          Array[Byte],
+    name:              String = "default",
+    snapshot:          Option[Any] = None
   ): F[Either[WalletApi.WalletApiFailure, Unit]]
 
   /**
@@ -244,7 +247,7 @@ trait WalletApi[F[_]] {
     (for {
       walletRes  <- EitherT(toMonad(importWallet(mnemonic, password, passphrase)))
       saveRes    <- EitherT(toMonad(saveWallet(walletRes, name)))
-      recoverRes <- EitherT(toMonad(recoverWallet(name)))
+      recoverRes <- EitherT(toMonad(recoverWallet(walletRes, password, name)))
     } yield walletRes).value
   }
 
@@ -323,22 +326,60 @@ object WalletApi {
     } yield vaultStore).value
 
     override def recoverWallet(
-      mainKey:  KeyPair,
-      name:     String = "default",
-      snapshot: Option[Any] = None
+      mainKeyVaultStore: VaultStore[F],
+      password:          Array[Byte],
+      name:              String = "default",
+      snapshot:          Option[Any] = None
     ): F[Either[WalletApiFailure, Unit]] = (for {
       // recover 1-of-1 simple information (build lock addresses for each key pair in 0/0/z)
-      snapshotRes <- EitherT(snapshot.map(recoverFromSnapshot(_, name)).getOrElse(().asRight[WalletApiFailure].pure[F]))
-      // recover complex information from snapshot
+      mainKey    <- EitherT(extractMainKey(mainKeyVaultStore, password))
       recoverRes <- EitherT(recoverFromMainKey(mainKey, name))
+      // recover complex information from snapshot
+      snapshotRes <- EitherT(snapshot.map(recoverFromSnapshot(_, name)).getOrElse(().asRight[WalletApiFailure].pure[F]))
     } yield snapshotRes.combine(recoverRes)).value
 
+    /**
+     * Recover wallet information from a provided snapshot
+     *
+     * TODO: To be implemented when the recovery from snapshot process has been fleshed out
+     *
+     * At a high level, the snapshot should be parsed and then the contained information should be stored in the DataApi
+     * associated with the wallet of name `name`.
+     *
+     * TODO: What should the type of snapshot be?
+     *
+     * @param snapshot The snapshot to recover the wallet from
+     * @param name The name of the wallet to recover
+     * @return A unit value if the recovery was successful, otherwise a WalletApiFailure
+     */
     private def recoverFromSnapshot(snapshot: Any, name: String): F[Either[WalletApiFailure, Unit]] =
       ().asRight[WalletApiFailure].pure[F]
 
+    /**
+     * Recover partial wallet information from the main key
+     *
+     * TODO: Revisit this when the recovery process has been fleshed out and AddressBuilder is implemented
+     *
+     * @note This function only recovers information about 1-of-1 Signature Locks derived from the main key.
+     *
+     * @param mainKey The main key to recover the wallet from
+     * @param name The name of the wallet to recover
+     * @return A unit value if the recovery was successful, otherwise a WalletApiFailure
+     */
     private def recoverFromMainKey(mainKey: KeyPair, name: String): F[Either[WalletApiFailure, Unit]] = {
       require(mainKey.vk.vk.isExtendedEd25519, "keyPair must be an extended Ed25519 key")
       require(mainKey.sk.sk.isExtendedEd25519, "keyPair must be an extended Ed25519 key")
+
+      /**
+       * The process:
+       * 1. Iterate through children keys of the main key for related to 1-of-1 signature locks;
+       *    I.e, for all z in path 0/0/z
+       *    TODO: Do we need to iterate through all 2^32^? Can we assume if there is a big gap we can stop early?
+       * 2. For each child key, derive the 1-of-1 signature lock and it's address
+       *    TODO: This will be straightforward once AddressBuilder is implemented
+       * 3. For each address, query DataApi/Genus to see if for Txos to see if the address has been used
+       * 4. If the address has been used, store the address, the lock, with the indices to track the usage
+       */
       ().asRight[WalletApiFailure].pure[F]
     }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -211,10 +211,43 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     MockDataApi.mainKeyVaultStoreInstance += ("error" -> oldVaultStore.asJson)
     val updateRes = walletApi.updateWalletPassword[Id](password, "newPassword".getBytes, "error")
     assert(updateRes.isLeft)
-    println(updateRes.left.toOption.get)
     assert(updateRes.left.toOption.get == WalletApi.FailedToUpdateWallet(MockDataApi.MainKeyVaultSaveFailure))
     // verify the wallet is still accessible with the old password
     val loadedWallet = walletApi.loadAndExtractMainKey[Id](password, "error")
     assert(loadedWallet.isRight)
   }
+
+  test("importWallet: import using mnemonic from createNewWallet > Same Main Key") {
+    val oldPassword = "old-password".getBytes
+    val wallet = walletApi.createNewWallet(oldPassword).toOption.get
+    val mnemonic = wallet.mnemonic
+    val mainKey = walletApi.extractMainKey(wallet.mainKeyVaultStore, oldPassword).toOption.get
+    val newPassword = "new-password".getBytes
+    val importedWallet = walletApi.importWallet(mnemonic, newPassword)
+    assert(importedWallet.isRight)
+    assert(wallet.mainKeyVaultStore != importedWallet.toOption.get) // Should be different due to password
+    val importedMainKey = walletApi.extractMainKey(importedWallet.toOption.get, newPassword)
+    assert(importedMainKey.isRight)
+    val testMainKey = importedMainKey.toOption.get
+    // Verify the main key is the same
+    assert(mainKey == testMainKey)
+    val signingInstance: ExtendedEd25519 = new ExtendedEd25519
+    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(mainKey).signingKey, testMsg)
+    val testSignature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).signingKey, testMsg)
+    assert(java.util.Arrays.equals(signature, testSignature))
+
+    assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).verificationKey))
+    assert(signingInstance.verify(testSignature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(mainKey).verificationKey))
+
+  }
+
+  test("importWalletAndSave: verify a save failure returns the correct error") {
+    val password = "password".getBytes
+    val wallet = walletApi.createNewWallet(password).toOption.get
+    val importedWallet = walletApi.importWalletAndSave[Id](wallet.mnemonic, password, name = "error")
+    assert(importedWallet.isLeft)
+    assert(importedWallet.left.toOption.get == WalletApi.FailedToSaveWallet(MockDataApi.MainKeyVaultSaveFailure))
+  }
+
+  test("recoverWallet: TBD when recovery is fleshed out".ignore) {}
 }

--- a/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
+++ b/crypto/src/main/scala/co/topl/crypto/generation/mnemonic/Entropy.scala
@@ -51,7 +51,7 @@ object Entropy {
    */
   def fromMnemonicString(
     mnemonic: String,
-    language: Language
+    language: Language = Language.English
   ): Either[EntropyFailure, Entropy] =
     Phrase
       .validated(mnemonic, language)


### PR DESCRIPTION
## Purpose

Add API endpoint to import a wallet from a mnemonic

## Approach

- Added importWallet, recoverWallet, and importWalletAndSave
- importWallet returns a constructed VaultStore from the mnemonic. This mirrors createNewWallet
- recoverWallet is meant to handle recovering local wallet data from the main key in a VaultStore and optionally a snapshot object. This function needs to be fleshed out more and is added in this ticket/PR as a placeholder. Comments & TODOs were added
- importWalletAndSave imports the wallet as a VaultStore and then saves it to the dataApi (as well as recovers additional data). This mirrors createAndSaveNewWallet

## Testing

- Added new tests
- ran `checkPR` and ensured they all pass

## Tickets
* Closes TSDK-393