### PR TITLE
[BN-997]: TDSK Deployment Tooling

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## Pull Requests
+
+  $CHANGES

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,7 +1,8 @@
 name: Maven Central Release
 on:
   push:
-      branches: [ BN-997-tsdk-deployment-tooling ]
+    branches: [main]
+    tags: ["*"]
 
 jobs:
   maven_release:

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,18 +1,19 @@
 name: Maven Central Release
-on: [release, push]
-#  release:
-#    types: [released]
+on:
+  release:
+    types: [published]
 
 jobs:
   maven_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true
-      - uses: olafurpg/setup-scala@v10
+
+      - uses: olafurpg/setup-scala@v14
       - uses: olafurpg/setup-gpg@v3
 
       - name: Publish artifacts to Maven Central

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,7 +1,7 @@
 name: Maven Central Release
 on:
-  release:
-    types: [published]
+  push:
+      branches: [ BN-997-tsdk-deployment-tooling ]
 
 jobs:
   maven_release:

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   push:
-    branches: [ BN-997-tsdk-deployment-tooling ]
+    branches: [ main ]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [ BN-997-tsdk-deployment-tooling ]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
Enable publishing TSDK tooling to Maven.

## Approach
Enable the existing Maven release workflow, and add additional workflows following the [sbt-ci-release](https://github.com/sbt/sbt-ci-release/tree/main#github-actions) repo.

High level overview:
* Each PR merged to main triggers the [release-drafter](https://github.com/marketplace/actions/release-drafter) workflow which creates a draft release and/or adds a link to the PR under a changes section.
* When we are ready to release, publish the draft which will push tags to the main repo.
* The Maven Release workflow triggers when tags are pushed to main, which publishes

## Testing
* Ran the Maven publish workflow targeting my branch: https://github.com/Topl/BramblSc/actions/runs/4813348677

I can't test the release drafter workflow since it requites the `./github/release-drafter.yml` file to exist in the main branch. I will verify this works after the changes are merged.

## Tickets
* closes [BN-997](https://topl.atlassian.net/browse/BN-997) *


[BN-997]: https://topl.atlassian.net/browse/BN-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ