### PR TITLE
TSDK-460: Update how Credentialler retrieves information

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
@@ -6,7 +6,7 @@ package co.topl.brambl.builders
  *
  * @param message The error message
  */
-abstract class BuilderError(val message: String)
+abstract class BuilderError(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
 
 object BuilderError {
 
@@ -17,7 +17,7 @@ object BuilderError {
    *
    * @param message The error message indicating why the build is unsuccessful
    */
-  case class InputBuilderError(override val message: String) extends BuilderError(message)
+  case class InputBuilderError(message: String, cause: Throwable = null) extends BuilderError(message, cause)
 
   /**
    * A Builder error indicating that a IoTransaction's output
@@ -26,5 +26,5 @@ object BuilderError {
    *
    * @param message The error message indicating why the build is unsuccessful
    */
-  case class OutputBuilderError(override val message: String) extends BuilderError(message)
+  case class OutputBuilderError(message: String, cause: Throwable = null) extends BuilderError(message, cause)
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -29,7 +29,7 @@ object TransactionBuilderInterpreter {
       (
         for {
           utxo <- EitherT(dataApi.getUtxoByTxoAddress(data.address))
-          lock <- EitherT(dataApi.getLock(utxo.address.id))
+          lock <- EitherT(dataApi.getLockByLockAddress(utxo.address))
         } yield (constructUnprovenAttestation(lock), utxo.value)
       ).value map {
         case Left(err) =>

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -33,7 +33,7 @@ object TransactionBuilderInterpreter {
         } yield (constructUnprovenAttestation(lock), utxo.value)
       ).value map {
         case Left(err) =>
-          BuilderError.InputBuilderError("Unable to construct Attestation", err).asLeft[SpentTransactionOutput]
+          BuilderError.InputBuilderError("Unable to construct proven input", err).asLeft[SpentTransactionOutput]
         case Right((Left(err), _)) => err.asLeft[SpentTransactionOutput]
         case Right((Right(att), value)) =>
           SpentTransactionOutput(data.address, att, value).asRight[BuilderError.InputBuilderError]

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -25,25 +25,19 @@ object TransactionBuilderInterpreter {
 
     override def constructUnprovenInput(
       data: InputBuildRequest
-    ): F[Either[BuilderError.InputBuilderError, SpentTransactionOutput]] = {
-      val utxo = dataApi.getUtxoByTxoAddress(data.address)
-      val attestation = utxo.map(_.address).flatMap(dataApi.getLockByLockAddress).map(constructUnprovenAttestation)
-      val value = utxo.map(_.value)
-      (attestation, value) match {
-        case (Some(Right(att)), Some(boxVal)) =>
-          SpentTransactionOutput(data.address, att, boxVal)
-            .asRight[BuilderError.InputBuilderError]
-            .pure[F]
-        case (Some(Left(err)), _) => err.asLeft[SpentTransactionOutput].pure[F]
-        case _ =>
-          BuilderError
-            .InputBuilderError(
-              s"Could not construct input. Id=${data.address}, Attestation=${attestation}, Value=${value}"
-            )
-            .asLeft[SpentTransactionOutput]
-            .pure[F]
+    ): F[Either[BuilderError.InputBuilderError, SpentTransactionOutput]] =
+      (
+        for {
+          utxo <- EitherT(dataApi.getUtxoByTxoAddress(data.address))
+          lock <- EitherT(dataApi.getLock(utxo.address.id))
+        } yield (constructUnprovenAttestation(lock), utxo.value)
+      ).value map {
+        case Left(err) =>
+          BuilderError.InputBuilderError("Unable to construct Attestation", err).asLeft[SpentTransactionOutput]
+        case Right((Left(err), _)) => err.asLeft[SpentTransactionOutput]
+        case Right((Right(att), value)) =>
+          SpentTransactionOutput(data.address, att, value).asRight[BuilderError.InputBuilderError]
       }
-    }
 
     override def constructOutput(
       data: OutputBuildRequest

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.dataApi
 
 import co.topl.brambl.dataApi.DataApi._
-import co.topl.brambl.models.{Evidence, Indices, LockId, TransactionOutputAddress}
+import co.topl.brambl.models.{Evidence, Indices, LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.crypto.encryption.VaultStore
@@ -29,14 +29,14 @@ trait DataApi[F[_]] {
   def getUtxoByTxoAddress(address: TransactionOutputAddress): F[Either[DataApiException, UnspentTransactionOutput]]
 
   /**
-   * Return the Lock targeted by a LockId. A LockId is the evidence of a Lock's immutable nytes/
+   * Return the Lock targeted by a LockAddress.
    *
    * A LockAddress is meant to identify a Lock on chain.
    *
-   * @param lockId The LockId for which to retrieve the Lock
-   * @return The Lock targeted by the given lockId, if it exists. Else a DataApiException
+   * @param address The LockAddress for which to retrieve the Lock
+   * @return The Lock targeted by the given address, if it exists. Else a DataApiException
    */
-  def getLock(lockId: LockId): F[Either[DataApiException, Lock]]
+  def getLockByLockAddress(address: LockAddress): F[Either[DataApiException, Lock]]
 
   /**
    * Return the preimage secret associated to a digest proposition.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -5,7 +5,7 @@ import co.topl.brambl.models.{Evidence, Indices, LockAddress, TransactionOutputA
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.crypto.encryption.VaultStore
-import quivr.models.Preimage
+import quivr.models.{Preimage, Proposition}
 
 /**
  * Defines a storage API for fetching and storing keys and states.
@@ -41,20 +41,20 @@ trait DataApi[F[_]] {
   /**
    * Return the preimage secret associated to a digest proposition.
    *
-   * @param propositionEvidence The evidence of the Digest Proposition for which to retrieve the preimage secret for
-   * @return The preimage secret associated to the Digest Proposition evidence if it exists. Else a DataApiException
+   * @param digestProposition The Digest Proposition for which to retrieve the preimage secret for
+   * @return The preimage secret associated to the Digest Proposition if it exists. Else a DataApiException
    */
-  def getPreimage(propositionEvidence: Evidence): F[Either[DataApiException, Preimage]]
+  def getPreimage(digestProposition: Proposition.Digest): F[Either[DataApiException, Preimage]]
 
   /**
    * Return the indices (x/y/z) associated to a signature proposition. A Signature Proposition is created with a
    * verification and must be signed with the corresponding signing key. The verification and signing key pair is
    * derived from the indices.
    *
-   * @param propositionEvidence The evidence of the Signature Proposition for which to retrieve the indices for
-   * @return The indices associated to the Signature Proposition evidence if it exists. Else a DataApiException
+   * @param signatureProposition The Signature Proposition for which to retrieve the indices for
+   * @return The indices associated to the Signature Proposition if it exists. Else a DataApiException
    */
-  def getIndices(propositionEvidence: Evidence): F[Either[DataApiException, Indices]]
+  def getIndices(signatureProposition: Proposition.DigitalSignature): F[Either[DataApiException, Indices]]
 
   /**
    * Persist a VaultStore for the Topl Main Secret Key.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -70,11 +70,11 @@ object CredentiallerInterpreter {
       case _: Proposition.Value.Digest =>
         dataApi
           .getPreimage(proposition.sizedEvidence)
-          .map(_.toOption.map(preimage => Prover.digestProver[F].prove(preimage, msg)).getOrElse(Proof().pure[F]))
+          .flatMap(_.toOption.map(preimage => Prover.digestProver[F].prove(preimage, msg)).getOrElse(Proof().pure[F]))
       case Proposition.Value.DigitalSignature(Proposition.DigitalSignature(routine, _, _)) =>
         dataApi
           .getIndices(proposition.sizedEvidence)
-          .map(_.toOption.map(idx => getSignatureProof(routine, idx, msg)).getOrElse(Proof().pure[F]))
+          .flatMap(_.toOption.map(idx => getSignatureProof(routine, idx, msg)).getOrElse(Proof().pure[F]))
       case _: Proposition.Value.HeightRange => Prover.heightProver[F].prove((), msg)
       case _: Proposition.Value.TickRange   => Prover.tickProver[F].prove((), msg)
       case _                                => Proof().pure[F]

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -33,11 +33,11 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
   val lockAddrToLock: Map[LockAddress, Lock] = Map(inLockFullAddress -> inLockFull)
 
   val propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
-    MockDigestProposition.sizedEvidence -> MockPreimage
+    MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
   )
 
   val propEvidenceToIdx: Map[Evidence, Indices] = Map(
-    MockSignatureProposition.sizedEvidence -> MockIndices
+    MockSignatureProposition.value.digitalSignature.get.sizedEvidence -> MockIndices
   )
 
   override def getUtxoByTxoAddress(
@@ -48,11 +48,11 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
   override def getLockByLockAddress(address: LockAddress): Either[DataApiException, Lock] =
     lockAddrToLock.get(address).toRight(LockNotFound)
 
-  override def getPreimage(propositionEvidence: Evidence): Either[DataApiException, Preimage] =
-    propEvidenceToPreimage.get(propositionEvidence).toRight(PreimageNotFound)
+  override def getPreimage(digestProposition: Proposition.Digest): Either[DataApiException, Preimage] =
+    propEvidenceToPreimage.get(digestProposition.sizedEvidence).toRight(PreimageNotFound)
 
-  override def getIndices(propositionEvidence: Evidence): Either[DataApiException, Indices] =
-    propEvidenceToIdx.get(propositionEvidence).toRight(IndicesNotFound)
+  override def getIndices(signatureProposition: Proposition.DigitalSignature): Either[DataApiException, Indices] =
+    propEvidenceToIdx.get(signatureProposition.sizedEvidence).toRight(IndicesNotFound)
 
   override def saveMainKeyVaultStore(
     mainKeyVaultStore: VaultStore[Id],

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -30,7 +30,7 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
     )
   )
 
-  val lockIdToLock: Map[LockId, Lock] = Map(inLockFullId -> inLockFull)
+  val lockAddrToLock: Map[LockAddress, Lock] = Map(inLockFullAddress -> inLockFull)
 
   val propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
     MockDigestProposition.sizedEvidence -> MockPreimage
@@ -45,7 +45,8 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
   ): Either[DataApiException, UnspentTransactionOutput] =
     txoAddrToTxo.get(address).toRight(UnspentTransactionOutputNotFound)
 
-  override def getLock(lockId: LockId): Either[DataApiException, Lock] = lockIdToLock.get(lockId).toRight(LockNotFound)
+  override def getLockByLockAddress(address: LockAddress): Either[DataApiException, Lock] =
+    lockAddrToLock.get(address).toRight(LockNotFound)
 
   override def getPreimage(propositionEvidence: Evidence): Either[DataApiException, Preimage] =
     propEvidenceToPreimage.get(propositionEvidence).toRight(PreimageNotFound)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -89,8 +89,7 @@ trait MockHelpers {
   )
 
   val inLockFull: Lock = Lock().withPredicate(inPredicateLockFull)
-  val inLockFullId: LockId = LockId(inLockFull.sizedEvidence.digest.value)
-  val inLockFullAddress: LockAddress = LockAddress(0, 0, inLockFullId)
+  val inLockFullAddress: LockAddress = LockAddress(0, 0, LockId(inLockFull.sizedEvidence.digest.value))
 
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -25,7 +25,7 @@ import co.topl.crypto.signing.ExtendedEd25519
 trait MockHelpers {
   val MockIndices: Indices = Indices(0, 0, 0)
   // Hardcoding ExtendedEd25519
-  val MockMainKeyPair: KeyPair = (new ExtendedEd25519).deriveKeyPairFromEntropy(Entropy.generate(), None)
+  val MockMainKeyPair: KeyPair = (new ExtendedEd25519).deriveKeyPairFromSeed(Array.fill(96)(0: Byte))
 
   val MockChildKeyPair: KeyPair = (new ExtendedEd25519).deriveKeyPairFromChildPath(
     pbKeyPairToCryotoKeyPair(MockMainKeyPair).signingKey,
@@ -42,7 +42,7 @@ trait MockHelpers {
   val MockPreimage: Preimage = Preimage(ByteString.copyFrom("secret".getBytes), ByteString.copyFromUtf8("salt"))
 
   // Hardcoding Blake2b256
-  private val MockDigest =
+  val MockDigest: Digest =
     Digest(ByteString.copyFrom((new Blake2b256).hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray)))
   val MockDigestProposition: Id[Proposition] = Proposer.digestProposer[Id].propose(("Blake2b256", MockDigest))
 


### PR DESCRIPTION
## Purpose

Previously the Credentialler was under the assumption that indices (x/y/z) were associated to a UTXO. We know now that this is not the case as indices are associated to a Key Pair which can map to one or more SignaturePropositions and a UTXO's lock may contain many SignaturePropositions.

## Approach

This PR contains changes to Credentialler, TransactionBuilder, and DataApi. At a high level, instead of the Credentialler retrieving the indices for a utxo, the Credentialler will retrieve the individual secrets needed for each proposition.

Specifically: 
- A SignatureProposition will map to Indices in the DataApi
- A DigestProposition will map to a Preimage in the DataApi

DataApi was updated to include functions to support this:
- Remvoed `getIndicesByTxoAddress`  since a UTXO/STXO is not directly associated with indices
- Changed return types to be F[Either[XX, YY]]] instead of Option[YY] to utilize the F context as well as to be consistent with  the return types of the other DataApi functions
- Added functions `getPreimage` and `getIndices` to support the functionality needed in Credentialler

Additionally, TransactionBuilder.constructUnprovenInput was modified as well to conform with the updated DataApi signatures.

## Testing

- Added a new test for TransactionBuilder to ensure failures are captured properly and updated a test for Credentialler. Lots of changes to MockHelpers and MockDataApi were needed
- Ran `checkPR` and ensure was successful

## Tickets
* Closes TSDK-460
