### PR TITLE
TransactionSyntax ID 

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderInterpreter.scala
@@ -80,7 +80,7 @@ object TransactionBuilderInterpreter {
               metadata.getOrElse(SmallData())
             )
           )
-          IoTransaction(i, o, datum).asRight[List[BuilderError]]
+          IoTransaction.defaultInstance.withInputs(i).withOutputs(o).withDatum(datum).asRight[List[BuilderError]]
         case (Validated.Invalid(errsI), Validated.Invalid(errsO)) =>
           (errsI.toList ++ errsO.toList).asLeft[IoTransaction]
         case (Validated.Invalid(errs), _) => errs.toList.asLeft[IoTransaction]

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TransactionSyntax.scala
@@ -1,0 +1,55 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.common.ContainsEvidence
+import co.topl.brambl.common.ContainsImmutable
+import co.topl.brambl.common.ContainsSignable
+import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.common.ImmutableBytes
+import co.topl.brambl.models.transaction.IoTransaction
+
+import scala.language.implicitConversions
+
+trait TransactionSyntax {
+
+  implicit def ioTransactionAsTransactionSyntaxOps(transaction: IoTransaction): TransactionSyntaxOps =
+    new TransactionSyntaxOps(transaction)
+}
+
+class TransactionSyntaxOps(val transaction: IoTransaction) extends AnyVal {
+
+  /**
+   * The ID of this transaction.  If an ID was pre-computed and saved in the Transaction, it is restored.
+   * Otherwise, a new ID is computed (but not saved in the Transaction).
+   */
+  def id: TransactionId =
+    transaction.transactionId.getOrElse(computeId)
+
+  /**
+   * Computes what the ID _should_ be for this Transaction.
+   */
+  def computeId: TransactionId = {
+    import TransactionSyntaxOps._
+    val signableBytes = ContainsSignable[IoTransaction].signableBytes(transaction)
+    val immutable = ImmutableBytes(signableBytes.value)
+    val evidence = ContainsEvidence[ImmutableBytes].sizedEvidence(immutable)
+    TransactionId(evidence.digest.value)
+  }
+
+  /**
+   * Compute a new ID and return a copy of this Transaction with the new ID embedded.
+   * Any previous value will be overwritten in the new copy.
+   */
+  def embedId: IoTransaction =
+    transaction.copy(transactionId = Some(computeId))
+
+  /**
+   * Returns true if this Transaction contains a valid embedded ID.
+   */
+  def containsValidId: Boolean =
+    transaction.transactionId.contains(computeId)
+}
+
+object TransactionSyntaxOps {
+  implicit private val immutableContainsImmutable: ContainsImmutable[ImmutableBytes] = identity
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
@@ -1,3 +1,3 @@
 package co.topl.brambl
 
-package object syntax extends LockSyntax with TransactionIdSyntax {}
+package object syntax extends LockSyntax with TransactionIdSyntax with TransactionSyntax {}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -29,7 +29,7 @@ object CredentiallerInterpreter {
       unprovenTx.inputs
         .map(proveInput(_, signable))
         .sequence
-        .map(IoTransaction(_, unprovenTx.outputs, unprovenTx.datum))
+        .map(IoTransaction.defaultInstance.withInputs(_).withOutputs(unprovenTx.outputs).withDatum(unprovenTx.datum))
     }
 
     override def validate(tx: IoTransaction, ctx: Context[F]): F[List[ValidationError]] = for {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -116,5 +116,6 @@ trait MockHelpers {
 
   val inputFull: SpentTransactionOutput = SpentTransactionOutput(dummyTxoAddress, attFull, value)
 
-  val txFull: IoTransaction = IoTransaction(List(inputFull), List(output), txDatum)
+  val txFull: IoTransaction =
+    IoTransaction.defaultInstance.withInputs(List(inputFull)).withOutputs(List(output)).withDatum(txDatum)
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/generators/ModelGenerators.scala
@@ -225,7 +225,7 @@ trait TransactionGenerator
         inputs  <- Gen.listOf(arbitrarySpentTransactionOutput.arbitrary)
         outputs <- Gen.listOf(arbitraryUnspentTransactionOutput.arbitrary)
         datum   <- genDatumIoTransaction
-      } yield IoTransaction(inputs, outputs, datum)
+      } yield IoTransaction.defaultInstance.withInputs(inputs).withOutputs(outputs).withDatum(datum)
     ) // TODO
 }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TransactionSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TransactionSyntaxSpec.scala
@@ -1,0 +1,31 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.common.ContainsEvidence
+import co.topl.brambl.common.ContainsImmutable
+import co.topl.brambl.common.ContainsSignable
+import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.models.TransactionId
+import co.topl.brambl.models.common.ImmutableBytes
+import co.topl.brambl.models.transaction.IoTransaction
+
+class TransactionSyntaxSpec extends munit.FunSuite with MockHelpers {
+
+  test("TransactionSyntax creates and embeds IDs") {
+    val transaction = dummyTx
+    assertEquals(transaction.transactionId, None)
+    val expectedId = {
+      implicit val immutableContainsImmutable: ContainsImmutable[ImmutableBytes] = identity
+      val signableBytes = ContainsSignable[IoTransaction].signableBytes(transaction)
+      val immutable = ImmutableBytes(signableBytes.value)
+      val evidence = ContainsEvidence[ImmutableBytes].sizedEvidence(immutable)
+      TransactionId(evidence.digest.value)
+    }
+    assertEquals(transaction.computeId, expectedId)
+    assertEquals(transaction.id, expectedId)
+    val withEmbeddedId = transaction.embedId
+    assertEquals(withEmbeddedId.transactionId, Some(expectedId))
+    assertEquals(withEmbeddedId.id, expectedId)
+    assertEquals(withEmbeddedId.containsValidId, true)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
     val quivr4sVersion = "1e48130" // scala-steward:off
-    val protobufSpecsVersion = "36a496f" // scala-steward:off
+    val protobufSpecsVersion = "e7b3bec" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
     val quivr4sVersion = "1e48130" // scala-steward:off
-    val protobufSpecsVersion = "ba616f0" // scala-steward:off
+    val protobufSpecsVersion = "36a496f" // scala-steward:off
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose
- The IoTransaction message now includes a transactionId field
- This PR adds helpers for populating that field
## Approach
- TransactionSyntax ops helper
## Testing
- New unit tests for TransactionSyntax
## Tickets
- #BN-995