### PR TITLE
TSDK-474 Support for proving already partially proven transactions

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -51,115 +51,6 @@ object CredentiallerInterpreter {
       } yield if (vErrs.isEmpty) provenTx.asRight else vErrs.asLeft
 
     /**
-     * Return a Proof that will satisfy a Proposition and signable bytes, if possible.
-     * Any unprovable leaf (non-composite) Propositions will result in a [[Proof.Value.Empty]].
-     * Leaf/Atomic/Non-composite Propositions are: Locked, Digest, Signature, Height, and Tick
-     * If there are valid existing proofs for any leaf Propositions, they should not be overwritten.
-     *
-     * It may not be possible to retrieve a proof if
-     * - The proposition type is not yet supported
-     *      (not one of Locked, Digest, Signature, Height, Tick, Threshold, And, Or, and Not)
-     * - The secret data required for the proof is not available (idx for signature, preimage for digest)
-     * - The signature routine is not supported (not ExtendedEd25519)
-     *
-     * @param msg         Signable bytes to bind to the proof
-     * @param proposition Proposition in which the Proof should satisfy
-     * @param existingProof    Existing proof of the proposition
-     * @return The Proof
-     */
-    private def getProof(msg: SignableBytes, proposition: Proposition, existingProof: Proof): F[Proof] =
-      proposition.value match {
-        // Atomic/leaf propositions; if a non-empty same type proof is provided, return it. If not, try to generate one
-        case Proposition.Value.Locked(_) =>
-          if (existingProof.value.isLocked) existingProof.pure[F] else Prover.lockedProver[F].prove((), msg)
-        case Proposition.Value.HeightRange(_) =>
-          if (existingProof.value.isHeightRange) existingProof.pure[F] else Prover.heightProver[F].prove((), msg)
-        case Proposition.Value.TickRange(_) =>
-          if (existingProof.value.isTickRange) existingProof.pure[F] else Prover.tickProver[F].prove((), msg)
-        case Proposition.Value.Digest(digest) =>
-          if (existingProof.value.isDigest) existingProof.pure[F]
-          else
-            dataApi
-              .getPreimage(digest)
-              .flatMap(
-                _.toOption.map(preimage => Prover.digestProver[F].prove(preimage, msg)).getOrElse(Proof().pure[F])
-              )
-        case Proposition.Value.DigitalSignature(signature) =>
-          if (existingProof.value.isDigitalSignature) existingProof.pure[F]
-          else
-            dataApi
-              .getIndices(signature)
-              .flatMap(_.toOption.map(idx => getSignatureProof(signature.routine, idx, msg)).getOrElse(Proof().pure[F]))
-        // Composite propositions; even if a correct-type outer proof is provided, the inner propositions may need to be proven
-        case Proposition.Value.Not(Proposition.Not(not, _)) =>
-          val innerProof = existingProof.value match {
-            case Proof.Value.Not(Proof.Not(_, p, _)) => p
-            case _                                   => Proof()
-          }
-          getProof(msg, not, innerProof).flatMap(Prover.notProver[F].prove(_, msg))
-        case Proposition.Value.And(Proposition.And(left, right, _)) =>
-          val (leftProof, rightProof) = existingProof.value match {
-            case Proof.Value.And(Proof.And(_, leftProof, rightProof, _)) => (leftProof, rightProof)
-            case _                                                       => (Proof(), Proof())
-          }
-          Applicative[F]
-            .map2(getProof(msg, left, leftProof), getProof(msg, right, rightProof))((leftProof, rightProof) =>
-              Prover.andProver[F].prove((leftProof, rightProof), msg)
-            )
-            .flatten
-        case Proposition.Value.Or(Proposition.Or(left, right, _)) =>
-          val (leftProof, rightProof) = existingProof.value match {
-            case Proof.Value.Or(Proof.Or(_, leftProof, rightProof, _)) => (leftProof, rightProof)
-            case _                                                     => (Proof(), Proof())
-          }
-          Applicative[F]
-            .map2(getProof(msg, left, leftProof), getProof(msg, right, rightProof))((leftProof, rightProof) =>
-              Prover.orProver[F].prove((leftProof, rightProof), msg)
-            )
-            .flatten
-        case Proposition.Value.Threshold(Proposition.Threshold(challenges, _, _)) =>
-          val responses = existingProof.value match {
-            case Proof.Value.Threshold(Proof.Threshold(_, responses, _)) => responses
-            case _                                                       => List.fill(challenges.length)(Proof())
-          }
-          challenges
-            .zip(responses)
-            .map(pair => getProof(msg, pair._1, pair._2))
-            .sequence
-            .flatMap(proofs => Prover.thresholdProver[F].prove(proofs.toSet, msg))
-        case _ => Proof().pure[F]
-      }
-
-    /**
-     * Return a Signature Proof that will satisfy a Signature Proposition, if possible.
-     * Otherwise return [[Proof.Value.Empty]]
-     *
-     * It may not be possible to generate a signature proof if the signature routine is not supported. We currently
-     * support only ExtendedEd25519.
-     *
-     * @param routine     Signature routine to use
-     * @param idx         Indices for which the proof's secret data can be obtained from
-     * @param msg         Signable bytes to bind to the proof
-     * @return The Proof
-     */
-    private def getSignatureProof(routine: String, idx: Indices, msg: SignableBytes): F[Proof] = routine match {
-      case "ExtendedEd25519" =>
-        WalletApi
-          .make[F](dataApi)
-          .deriveChildKeys(mainKey, idx)
-          .map(WalletApi.pbKeyPairToCryotoKeyPair)
-          .flatMap(kp =>
-            Prover
-              .signatureProver[F]
-              .prove(
-                Witness(ByteString.copyFrom((new ExtendedEd25519).sign(kp.signingKey, msg.value.toByteArray))),
-                msg
-              )
-          )
-      case _ => Proof().pure[F]
-    }
-
-    /**
      * Prove an input. That is, to prove all the propositions within the attestation.
      * If a proposition cannot be proven, it's proof will be [[Proof.Value.Empty]].
      *
@@ -186,6 +77,247 @@ object CredentiallerInterpreter {
         case _ => ???
       }
       attestation.map(SpentTransactionOutput(input.address, _, input.value))
+    }
+
+    /**
+     * Return a Proof that will satisfy a Proposition and signable bytes, if possible. Any unprovable leaf (non-composite)
+     * Propositions will result in a [[Proof.Value.Empty]].
+     * Leaf/Atomic/Non-composite Propositions are: Locked, Digest, Signature, Height, and Tick
+     * If there are valid existing proofs for any leaf Propositions, they should not be overwritten.
+     *
+     * It may not be possible to retrieve a proof if
+     * - The proposition type is not yet supported
+     * (not one of Locked, Digest, Signature, Height, Tick, Threshold, And, Or, and Not)
+     * - The secret data required for the proof is not available (idx for signature, preimage for digest)
+     * - The signature routine is not supported (not ExtendedEd25519)
+     *
+     * @param msg           Signable bytes to bind to the proof
+     * @param prop   Proposition in which the Proof should satisfy
+     * @param existingProof Existing proof of the proposition
+     * @return The Proof
+     */
+    private def getProof(msg: SignableBytes, prop: Proposition, existingProof: Proof): F[Proof] = prop.value match {
+      case Proposition.Value.Locked(_)                            => getLockedProof(existingProof, msg)
+      case Proposition.Value.HeightRange(_)                       => getHeightProof(existingProof, msg)
+      case Proposition.Value.TickRange(_)                         => getTickProof(existingProof, msg)
+      case Proposition.Value.Digest(digest)                       => getDigestProof(existingProof, msg, digest)
+      case Proposition.Value.DigitalSignature(signature)          => getSignatureProof(existingProof, msg, signature)
+      case Proposition.Value.Not(Proposition.Not(not, _))         => getNotProof(existingProof, msg, not)
+      case Proposition.Value.And(Proposition.And(left, right, _)) => getAndProof(existingProof, msg, left, right)
+      case Proposition.Value.Or(Proposition.Or(left, right, _))   => getOrProof(existingProof, msg, left, right)
+      case Proposition.Value.Threshold(Proposition.Threshold(challenges, _, _)) =>
+        getThresholdProof(existingProof, msg, challenges)
+      case _ => Proof().pure[F]
+    }
+
+    /**
+     * Return a Proof that will satisfy a Locked proposition and signable bytes.
+     * Since this is a non-composite (leaf) type, if there is a valid existing proof (non-empty and same type), it will
+     * be used. Otherwise, a new proof will be generated.
+     *
+     * @param existingProof Existing proof of the proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @return The Proof
+     */
+    private def getLockedProof(existingProof: Proof, msg: SignableBytes): F[Proof] =
+      if (existingProof.value.isLocked) existingProof.pure[F] else Prover.lockedProver[F].prove((), msg)
+
+    /**
+     * Return a Proof that will satisfy a Height Range proposition and signable bytes.
+     * Since this is a non-composite (leaf) type, if there is a valid existing proof (non-empty and same type), it will
+     * be used. Otherwise, a new proof will be generated.
+     *
+     * @param existingProof Existing proof of the proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @return The Proof
+     */
+    private def getHeightProof(existingProof: Proof, msg: SignableBytes): F[Proof] =
+      if (existingProof.value.isHeightRange) existingProof.pure[F] else Prover.heightProver[F].prove((), msg)
+
+    /**
+     * Return a Proof that will satisfy a Tick Range proposition and signable bytes.
+     * Since this is a non-composite (leaf) type, if there is a valid existing proof (non-empty and same type), it will
+     * be used. Otherwise, a new proof will be generated.
+     *
+     * @param existingProof Existing proof of the proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @return The Proof
+     */
+    private def getTickProof(existingProof: Proof, msg: SignableBytes): F[Proof] =
+      if (existingProof.value.isTickRange) existingProof.pure[F] else Prover.tickProver[F].prove((), msg)
+
+    /**
+     * Return a Proof that will satisfy a Digest proposition and signable bytes.
+     * Since this is a non-composite (leaf) type, if there is a valid existing proof (non-empty and same type), it will
+     * be used. Otherwise, a new proof will be generated. If the digest proposition is unable to be proven, an empty
+     * proof will be returned.
+     *
+     * @param existingProof Existing proof of the proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @param digest        The Digest Proposition to prove
+     * @return The Proof
+     */
+    private def getDigestProof(existingProof: Proof, msg: SignableBytes, digest: Proposition.Digest): F[Proof] =
+      if (existingProof.value.isDigest) existingProof.pure[F]
+      else
+        dataApi
+          .getPreimage(digest)
+          .flatMap(
+            _.toOption.map(preimage => Prover.digestProver[F].prove(preimage, msg)).getOrElse(Proof().pure[F])
+          )
+
+    /**
+     * Return a Proof that will satisfy a Digital Signature proposition and signable bytes.
+     * Since this is a non-composite (leaf) type, if there is a valid existing proof (non-empty and same type), it will
+     * be used. Otherwise, a new proof will be generated. If the signature proposition is unable to be proven, an empty
+     * proof will be returned.
+     *
+     * @param existingProof Existing proof of the proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @param signature     The Signature Proposition to prove
+     * @return The Proof
+     */
+    private def getSignatureProof(
+      existingProof: Proof,
+      msg:           SignableBytes,
+      signature:     Proposition.DigitalSignature
+    ): F[Proof] =
+      if (existingProof.value.isDigitalSignature) existingProof.pure[F]
+      else
+        dataApi
+          .getIndices(signature)
+          .flatMap(
+            _.toOption.map(idx => getSignatureProofForRoutine(signature.routine, idx, msg)).getOrElse(Proof().pure[F])
+          )
+
+    /**
+     * Return a Signature Proof for a given signing routine with a signature of msg using the signing key at idx, if
+     * possible. Otherwise return [[Proof.Value.Empty]]
+     *
+     * It may not be possible to generate a signature proof if the signature routine is not supported. We currently
+     * support only ExtendedEd25519.
+     *
+     * @param routine Signature routine to use
+     * @param idx     Indices for which the proof's secret data can be obtained from
+     * @param msg     Signable bytes to bind to the proof
+     * @return The Proof
+     */
+    private def getSignatureProofForRoutine(routine: String, idx: Indices, msg: SignableBytes): F[Proof] =
+      routine match {
+        case "ExtendedEd25519" =>
+          WalletApi
+            .make[F](dataApi)
+            .deriveChildKeys(mainKey, idx)
+            .map(WalletApi.pbKeyPairToCryotoKeyPair)
+            .flatMap(kp =>
+              Prover
+                .signatureProver[F]
+                .prove(
+                  Witness(ByteString.copyFrom((new ExtendedEd25519).sign(kp.signingKey, msg.value.toByteArray))),
+                  msg
+                )
+            )
+        case _ => Proof().pure[F]
+      }
+
+    /**
+     * Return a Proof that will satisfy a Not proposition and signable bytes.
+     * Since this is a composite type, even if a correct-type existing outer proof is provided, the inner proposition
+     * may need to be proven recursively.
+     *
+     * @param existingProof Existing proof of the Not proposition
+     * @param msg           Signable bytes to bind to the proof
+     * @param innerProposition  The inner Proposition contained in the Not Proposition to prove
+     * @return The Proof
+     */
+    private def getNotProof(existingProof: Proof, msg: SignableBytes, innerProposition: Proposition): F[Proof] = {
+      val innerProof = existingProof.value match {
+        case Proof.Value.Not(Proof.Not(_, p, _)) => p
+        case _                                   => Proof()
+      }
+      getProof(msg, innerProposition, innerProof).flatMap(Prover.notProver[F].prove(_, msg))
+    }
+
+    /**
+     * Return a Proof that will satisfy an And proposition and signable bytes.
+     * Since this is a composite type, even if a correct-type existing outer proof is provided, the inner propositions
+     * may need to be proven recursively.
+     *
+     * @param existingProof    Existing proof of the And proposition
+     * @param msg              Signable bytes to bind to the proof
+     * @param leftProposition  An inner Proposition contained in the And Proposition to prove
+     * @param rightProposition An inner Proposition contained in the And Proposition to prove
+     * @return The Proof
+     */
+    private def getAndProof(
+      existingProof:    Proof,
+      msg:              SignableBytes,
+      leftProposition:  Proposition,
+      rightProposition: Proposition
+    ): F[Proof] = {
+      val (leftProof, rightProof) = existingProof.value match {
+        case Proof.Value.And(Proof.And(_, leftProof, rightProof, _)) => (leftProof, rightProof)
+        case _                                                       => (Proof(), Proof())
+      }
+      Applicative[F]
+        .map2(getProof(msg, leftProposition, leftProof), getProof(msg, rightProposition, rightProof))(
+          (leftProof, rightProof) => Prover.andProver[F].prove((leftProof, rightProof), msg)
+        )
+        .flatten
+    }
+
+    /**
+     * Return a Proof that will satisfy an Or proposition and signable bytes.
+     * Since this is a composite type, even if a correct-type existing outer proof is provided, the inner propositions
+     * may need to be proven recursively.
+     *
+     * @param existingProof    Existing proof of the Or proposition
+     * @param msg              Signable bytes to bind to the proof
+     * @param leftProposition  An inner Proposition contained in the Or Proposition to prove
+     * @param rightProposition An inner Proposition contained in the Or Proposition to prove
+     * @return The Proof
+     */
+    private def getOrProof(
+      existingProof:    Proof,
+      msg:              SignableBytes,
+      leftProposition:  Proposition,
+      rightProposition: Proposition
+    ): F[Proof] = {
+      val (leftProof, rightProof) = existingProof.value match {
+        case Proof.Value.Or(Proof.Or(_, leftProof, rightProof, _)) => (leftProof, rightProof)
+        case _                                                     => (Proof(), Proof())
+      }
+      Applicative[F]
+        .map2(getProof(msg, leftProposition, leftProof), getProof(msg, rightProposition, rightProof))(
+          (leftProof, rightProof) => Prover.orProver[F].prove((leftProof, rightProof), msg)
+        )
+        .flatten
+    }
+
+    /**
+     * Return a Proof that will satisfy a Threshold proposition and signable bytes.
+     * Since this is a composite type, even if a correct-type existing outer proof is provided, the inner propositions
+     * may need to be proven recursively.
+     *
+     * @param existingProof     Existing proof of the Threshold proposition
+     * @param msg               Signable bytes to bind to the proof
+     * @param innerPropositions Inner Propositions contained in the Threshold Proposition to prove
+     * @return The Proof
+     */
+    private def getThresholdProof(
+      existingProof:     Proof,
+      msg:               SignableBytes,
+      innerPropositions: Seq[Proposition]
+    ): F[Proof] = {
+      val responses = existingProof.value match {
+        case Proof.Value.Threshold(Proof.Threshold(_, responses, _)) => responses
+        case _                                                       => List.fill(innerPropositions.length)(Proof())
+      }
+      innerPropositions
+        .zip(responses)
+        .map(pair => getProof(msg, pair._1, pair._2))
+        .sequence
+        .flatMap(proofs => Prover.thresholdProver[F].prove(proofs.toSet, msg))
     }
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -32,7 +32,7 @@ trait MockHelpers {
     List(
       Bip32Indexes.HardenedIndex(MockIndices.x),
       Bip32Indexes.SoftIndex(MockIndices.y),
-      Bip32Indexes.SoftIndex(MockIndices.y)
+      Bip32Indexes.SoftIndex(MockIndices.z)
     )
   )
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/common/ContainsSignableSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/common/ContainsSignableSpec.scala
@@ -5,21 +5,25 @@ import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
+import co.topl.brambl.models.box.Attestation
 
 import scala.language.implicitConversions
 
 class ContainsSignableSpec extends munit.FunSuite with MockHelpers {
 
   test("IoTransaction.signable should return the same bytes as IoTransaction.immutable minus the Proofs") {
+    // withProofs has non-empty proofs for all the proofs. noProofs has proofs stripped away
     val withProofs = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(attestation = nonEmptyAttestation)))
+    val emptyAttestation = Attestation().withPredicate(inPredicateLockFullAttestation.copy(responses = Seq.empty))
+    val noProofs = withProofs.copy(inputs = withProofs.inputs.map(stxo => stxo.copy(attestation = emptyAttestation)))
     val signableFull = withProofs.signable.value
     val immutableFull = withProofs.immutable.value
-    val immutableEmpty = txFull.immutable.value
+    val immutableNoProofs = noProofs.immutable.value
     // The only difference between immutableFull and immutableEmpty is the Proofs
-    val proofsImmutableSize = immutableFull.size - immutableEmpty.size
+    val proofsImmutableSize = immutableFull.size - immutableNoProofs.size
     assertEquals(proofsImmutableSize > 0, true)
     assertEquals(signableFull.size, immutableFull.size - proofsImmutableSize)
-    assertEquals(signableFull.size, immutableEmpty.size)
+    assertEquals(signableFull.size, immutableNoProofs.size)
   }
 
   test("The Proofs in an IoTransaction changing should not alter the transaction's signable bytes") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreterSpec.scala
@@ -42,6 +42,10 @@ class TransactionCostCalculatorInterpreterSpec extends munit.FunSuite with MockH
       1L +
       // Cost of locked proof
       1L +
+      // Cost of digest proof
+      50L + 50L +
+      // Cost of signature proof
+      50L + 100L +
       // Cost of height proof
       50L + 5L +
       // Cost of tick proof

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -16,7 +16,10 @@ import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
 import co.topl.quivr.api.Proposer
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
+  EvaluationAuthorizationFailed,
+  LockedPropositionIsUnsatisfiable
+}
 import com.google.protobuf.ByteString
 import quivr.models.{Int128, KeyPair, Preimage, Proof, Proposition}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
@@ -48,7 +51,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
           ),
           2
         ),
-        List()
+        List(Proof(), Proof())
       )
     )
     val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(attestation = testAttestation)))
@@ -176,7 +179,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -199,7 +202,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -220,7 +223,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -240,7 +243,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -262,7 +265,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -287,7 +290,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -310,7 +313,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -334,7 +337,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -360,7 +363,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -385,7 +388,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -410,7 +413,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -434,7 +437,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -458,7 +461,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List()))
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
         )
       )
     )
@@ -492,22 +495,36 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     val bobSignatureProposition = Proposer.signatureProposer[Id].propose(("ExtendedEd25519", bobChildKey.vk))
     // To Mock someone else's DataApi
-    object NewDataApi extends DataApi[Id]{
+    object NewDataApi extends DataApi[Id] {
       case object Invalid extends DataApi.DataApiException("Invalid Call. Should not reach here.")
 
       // The only relevant call is getIndices
-      override def getIndices(signatureProposition: Proposition.DigitalSignature): Id[Either[DataApi.DataApiException, Indices]] =
+      override def getIndices(
+        signatureProposition: Proposition.DigitalSignature
+      ): Id[Either[DataApi.DataApiException, Indices]] =
         Map(
           bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
         ).get(signatureProposition.sizedEvidence).toRight(Invalid)
 
-      override def getUtxoByTxoAddress(address: TransactionOutputAddress): Id[Either[DataApi.DataApiException, UnspentTransactionOutput]] = Invalid.asLeft[UnspentTransactionOutput]
-      override def getLockByLockAddress(address: LockAddress): Id[Either[DataApi.DataApiException, Lock]] = Invalid.asLeft[Lock]
-      override def getPreimage(digestProposition: Proposition.Digest): Id[Either[DataApi.DataApiException, Preimage]] = Invalid.asLeft[Preimage]
-      override def saveMainKeyVaultStore(mainKeyVaultStore: VaultStore[Id], name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
-      override def getMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, VaultStore[Id]]] = Invalid.asLeft[VaultStore[Id]]
-      override def updateMainKeyVaultStore(mainKeyVaultStore: VaultStore[Id], name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
-      override def deleteMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+      override def getUtxoByTxoAddress(
+        address: TransactionOutputAddress
+      ): Id[Either[DataApi.DataApiException, UnspentTransactionOutput]] = Invalid.asLeft[UnspentTransactionOutput]
+      override def getLockByLockAddress(address: LockAddress): Id[Either[DataApi.DataApiException, Lock]] =
+        Invalid.asLeft[Lock]
+      override def getPreimage(digestProposition: Proposition.Digest): Id[Either[DataApi.DataApiException, Preimage]] =
+        Invalid.asLeft[Preimage]
+      override def saveMainKeyVaultStore(
+        mainKeyVaultStore: VaultStore[Id],
+        name:              String
+      ): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+      override def getMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, VaultStore[Id]]] =
+        Invalid.asLeft[VaultStore[Id]]
+      override def updateMainKeyVaultStore(
+        mainKeyVaultStore: VaultStore[Id],
+        name:              String
+      ): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+      override def deleteMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, Unit]] =
+        Invalid.asLeft[Unit]
     }
     val aliceDataApi = MockDataApi
     val bobDataApi = NewDataApi
@@ -519,12 +536,20 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(
-            List(
-              Proposer.thresholdProposer[Id].propose((innerPropositions.toSet, innerPropositions.length)),
-              Proposer.thresholdProposer[Id].propose(((innerPropositions :+ bobSignatureProposition).toSet, innerPropositions.length + 1))
-            ).map(Challenge().withRevealed)
-            , 2), List.fill(2)(Proof())))
+          Attestation().withPredicate(
+            Attestation.Predicate(
+              Lock.Predicate(
+                List(
+                  Proposer.thresholdProposer[Id].propose((innerPropositions.toSet, innerPropositions.length)),
+                  Proposer
+                    .thresholdProposer[Id]
+                    .propose(((innerPropositions :+ bobSignatureProposition).toSet, innerPropositions.length + 1))
+                ).map(Challenge().withRevealed),
+                2
+              ),
+              List.fill(2)(Proof())
+            )
+          )
         )
       )
     )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -1,21 +1,28 @@
 package co.topl.brambl.wallet
 
 import cats.Id
-import co.topl.brambl.models.transaction.IoTransaction
+import cats.implicits._
+import co.topl.brambl.common.ContainsEvidence.Ops
+import co.topl.brambl.common.ContainsImmutable.instances._
+import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
 import co.topl.brambl.{Context, MockDataApi, MockHelpers}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
-import co.topl.brambl.models.{Datum, Event, Indices}
+import co.topl.brambl.dataApi.DataApi
+import co.topl.brambl.models.{Datum, Event, Indices, LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.box.{Attestation, Challenge, Lock, Value}
 import co.topl.brambl.validation.TransactionAuthorizationError.AuthorizationFailed
 import co.topl.brambl.validation.TransactionSyntaxError
+import co.topl.crypto.generation.Bip32Indexes
+import co.topl.crypto.signing.ExtendedEd25519
 import co.topl.quivr.api.Proposer
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
-  EvaluationAuthorizationFailed,
-  LockedPropositionIsUnsatisfiable
-}
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
 import com.google.protobuf.ByteString
-import quivr.models.{Int128, Proposition}
+import quivr.models.{Int128, KeyPair, Preimage, Proof, Proposition}
+import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
+import co.topl.crypto.encryption.VaultStore
+
+import scala.util.Random
 
 class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
@@ -466,5 +473,75 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     assert(notProof.value.isNot)
     assert(notProof.value.not.get.proof.value.isTickRange)
     assertEquals(provenTx.signable.value, testTx.signable.value)
+  }
+
+  test(
+    "prove: complex partially proven transaction"
+  ) {
+    val aliceSignatureProposition = MockSignatureProposition
+    val aliceMainKey = MockMainKeyPair
+    val bobMainKey: KeyPair = (new ExtendedEd25519).deriveKeyPairFromSeed(Random.nextBytes(96))
+    val bobIndices = Indices(8, 9, 10)
+    val bobChildKey: KeyPair = (new ExtendedEd25519).deriveKeyPairFromChildPath(
+      pbKeyPairToCryotoKeyPair(bobMainKey).signingKey,
+      List(
+        Bip32Indexes.HardenedIndex(bobIndices.x),
+        Bip32Indexes.SoftIndex(bobIndices.y),
+        Bip32Indexes.SoftIndex(bobIndices.z)
+      )
+    )
+    val bobSignatureProposition = Proposer.signatureProposer[Id].propose(("ExtendedEd25519", bobChildKey.vk))
+    // To Mock someone else's DataApi
+    object NewDataApi extends DataApi[Id]{
+      case object Invalid extends DataApi.DataApiException("Invalid Call. Should not reach here.")
+
+      // The only relevant call is getIndices
+      override def getIndices(signatureProposition: Proposition.DigitalSignature): Id[Either[DataApi.DataApiException, Indices]] =
+        Map(
+          bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
+        ).get(signatureProposition.sizedEvidence).toRight(Invalid)
+
+      override def getUtxoByTxoAddress(address: TransactionOutputAddress): Id[Either[DataApi.DataApiException, UnspentTransactionOutput]] = Invalid.asLeft[UnspentTransactionOutput]
+      override def getLockByLockAddress(address: LockAddress): Id[Either[DataApi.DataApiException, Lock]] = Invalid.asLeft[Lock]
+      override def getPreimage(digestProposition: Proposition.Digest): Id[Either[DataApi.DataApiException, Preimage]] = Invalid.asLeft[Preimage]
+      override def saveMainKeyVaultStore(mainKeyVaultStore: VaultStore[Id], name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+      override def getMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, VaultStore[Id]]] = Invalid.asLeft[VaultStore[Id]]
+      override def updateMainKeyVaultStore(mainKeyVaultStore: VaultStore[Id], name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+      override def deleteMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
+    }
+    val aliceDataApi = MockDataApi
+    val bobDataApi = NewDataApi
+    val innerPropositions = List(
+      Proposer.andProposer[Id].propose((MockTickProposition, aliceSignatureProposition)),
+      Proposer.orProposer[Id].propose((MockDigestProposition, MockLockedProposition)),
+      Proposer.notProposer[Id].propose(MockHeightProposition)
+    )
+    val testTx = txFull.copy(inputs =
+      List(
+        inputFull.copy(attestation =
+          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(
+            List(
+              Proposer.thresholdProposer[Id].propose((innerPropositions.toSet, innerPropositions.length)),
+              Proposer.thresholdProposer[Id].propose(((innerPropositions :+ bobSignatureProposition).toSet, innerPropositions.length + 1))
+            ).map(Challenge().withRevealed)
+            , 2), List.fill(2)(Proof())))
+        )
+      )
+    )
+    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
+    // the following is used to mimic the initial proving of the transaction by alice.
+    val credentialler1 = CredentiallerInterpreter.make[Id](aliceDataApi, aliceMainKey)
+    val partiallyProven = credentialler1.prove(testTx) // should create a partially proven tx
+    // Should not be validated since not sufficiently proven
+    val res1 = credentialler1.validate(partiallyProven, ctx)
+    assert(res1.length == 1)
+    assertEquals(partiallyProven.signable.value, testTx.signable.value)
+    // the following is used to mimic the second proving of the transaction by bob.
+    val credentialler2 = CredentiallerInterpreter.make[Id](bobDataApi, bobMainKey)
+    val completelyProven = credentialler2.prove(partiallyProven) // should create a completely proven tx
+    // Should be validated since sufficiently proven
+    val res2 = credentialler2.validate(completelyProven, ctx)
+    assert(res2.isEmpty)
+    assertEquals(completelyProven.signable.value, testTx.signable.value)
   }
 }


### PR DESCRIPTION
## Purpose

Previously the credentialler overides the existing proofs in a transaction that it is attempting to prove. This prevents any multi-participant usage since after the first participant proves the transaction (into a partially proven transaction), the proofs from participant 1 would get erased when participant 2 goes to prove the partially proven transaction. This PR adds support for keeping any existing valid proofs in the transaction and will only prove a proposition if it was not previously proven.

## Approach

- When proving a proposition, supply the existing proof from the attestation. If it is invalid (not the same type or empty) then we will generate a new proof and return that. Else, return the existing proof
- Broke and modularized `getProof` into multiple smaller functions (one for each type of proposition) since the function was becoming large and unreadable.

## Testing

- Added a unit test to test a 2 person complex lock; at least one of each type of proposition including composites. This complex scenario tests that existing proofs do not get overriden, but the previously unprovable challenges can become proven at a later time.
- Made other changes to MockHelpers and other tests (ContainsSignable and TransactionCost) that were affected to ensure they still pass. Notably, Now the credentialler expects that the number of proofs in an attestation matches the number of propositions exactly. Previously it did not matter as much since the proofs would be overridden
- ran `checkPR` and ensured was successful

## Tickets
* Closes TSDK-474