### PR TITLE
Bug address decoder

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/AddressCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/AddressCodecs.scala
@@ -25,8 +25,8 @@ object AddressCodecs {
       (network, ledgerAndId) = byteArray.splitAt(4)
       (ledger, id) = ledgerAndId.splitAt(4)
       lockAddress = LockAddress(
-        network.head,
-        ledger.head,
+        BigInt(network).toInt,
+        BigInt(ledger).toInt,
         LockId((ByteString.copyFrom(id)))
       )
     } yield lockAddress

--- a/brambl-sdk/src/test/scala/co/topl/brambl/codecs/AddressCodecsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/codecs/AddressCodecsSpec.scala
@@ -22,7 +22,17 @@ class AddressCodecsSpec extends munit.FunSuite with AddressCodecTestCases {
       .toByteArray()
       .zip(lockAddress.id.value.toByteArray())
       .map(x => x._1 == x._2)
-      .fold(true)(_ && _)
+      .fold(true)(_ && _) &&
+    AddressCodecs
+      .decodeAddress(address)
+      .toOption
+      .get
+      .ledger == lockAddress.ledger &&
+    AddressCodecs
+      .decodeAddress(address)
+      .toOption
+      .get
+      .network == lockAddress.network
 
   test("Main Network Main Ledger Zero Test") {
     assertEquals(


### PR DESCRIPTION
## Purpose

While doing testing with Fernando we found a bug where the newtwork and ledger Id were not correctly decoded.

## Approach

The bug was fixed

## Testing

The unit tests were not checking for that and were corrected.

## Tickets
* No ticket created, the fix took less than 5 minutes.
