### PR TITLE
TSDK-479 Implemented Lock and Proposition Templates

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/LockTemplate.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/LockTemplate.scala
@@ -1,0 +1,39 @@
+package co.topl.brambl.builders.locks
+
+import co.topl.brambl.builders.BuilderError
+import co.topl.brambl.models.box.{Challenge, Lock}
+import LockTemplate.LockType
+import cats.Monad
+import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherId, toFlatMapOps, toFunctorOps}
+import co.topl.brambl.builders.locks.PropositionTemplate.ThresholdTemplate
+import quivr.models.{Proposition, VerificationKey}
+
+trait LockTemplate[F[_]] {
+  val lockType: LockType
+  def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Lock]]
+}
+
+object LockTemplate {
+  sealed abstract class LockType(val label: String)
+
+  object types {
+    case object Predicate extends LockType("predicate")
+  }
+
+  case class PredicateTemplate[F[_]: Monad](innerTemplates: Seq[PropositionTemplate[F]], threshold: Int)
+      extends LockTemplate[F] {
+    override val lockType: LockType = types.Predicate
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Lock]] =
+      // A Predicate Lock is very similar to a Threshold Proposition
+      ThresholdTemplate[F](innerTemplates, threshold).build(entityVks).flatMap {
+        case Left(error) => error.asLeft[Lock].pure[F]
+        case Right(Proposition(Proposition.Value.Threshold(Proposition.Threshold(innerPropositions, _, _)), _)) =>
+          Lock()
+            .withPredicate(Lock.Predicate(innerPropositions.map(Challenge().withRevealed)))
+            .asRight[BuilderError]
+            .pure[F]
+      }
+  }
+
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/PropositionTemplate.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/PropositionTemplate.scala
@@ -1,0 +1,150 @@
+package co.topl.brambl.builders.locks
+
+import co.topl.brambl.builders.BuilderError
+import quivr.models.{Data, Digest, Proposition, VerificationKey}
+import PropositionTemplate.PropositionType
+import cats.implicits.{
+  catsSyntaxApplicativeId,
+  catsSyntaxEitherId,
+  catsSyntaxEitherObject,
+  catsSyntaxFlatten,
+  toFlatMapOps,
+  toFunctorOps,
+  toTraverseOps
+}
+import cats.{Applicative, Monad}
+import co.topl.quivr.api.Proposer
+
+trait PropositionTemplate[F[_]] {
+  val propositionType: PropositionType
+  def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]]
+}
+
+object PropositionTemplate {
+  sealed abstract class PropositionType(val label: String)
+
+  object types {
+    case object Locked extends PropositionType("locked")
+    case object Height extends PropositionType("height")
+    case object Tick extends PropositionType("tick")
+    case object Digest extends PropositionType("digest")
+    case object Signature extends PropositionType("signature")
+    case object And extends PropositionType("and")
+    case object Or extends PropositionType("or")
+    case object Not extends PropositionType("not")
+    case object Threshold extends PropositionType("threshold")
+  }
+
+  case class UnableToBuildPropositionTemplate(message: String, cause: Throwable = null)
+      extends BuilderError(message, cause)
+
+  case class LockedTemplate[F[_]: Monad](data: Option[Data]) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Locked
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Proposer.LockedProposer[F].propose(data).map(Right(_))
+  }
+
+  case class HeightTemplate[F[_]: Monad](chain: String, min: Long, max: Long) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Height
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Proposer.heightProposer[F].propose((chain, min, max)).map(Right(_))
+  }
+
+  case class TickTemplate[F[_]: Monad](min: Long, max: Long) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Tick
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Proposer.tickProposer[F].propose((min, max)).map(Right(_))
+  }
+
+  case class DigestTemplate[F[_]: Monad](routine: String, digest: Digest) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Digest
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Proposer.digestProposer[F].propose((routine, digest)).map(Right(_))
+  }
+
+  case class SignatureTemplate[F[_]: Monad](routine: String, entityIdx: Int) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Signature
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      if (entityIdx >= 0 && entityIdx < entityVks.length)
+        Proposer.signatureProposer[F].propose((routine, entityVks(entityIdx))).map(Right(_))
+      else
+        Either
+          .left[BuilderError, Proposition](
+            UnableToBuildPropositionTemplate(
+              s"Signature Proposition failed. Index: $entityIdx. Length of VKs: $entityVks"
+            )
+          )
+          .pure[F]
+  }
+
+  case class AndTemplate[F[_]: Monad](leftTemplate: PropositionTemplate[F], rightTemplate: PropositionTemplate[F])
+      extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.And
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Applicative[F]
+        .map2(leftTemplate.build(entityVks), rightTemplate.build(entityVks)) {
+          case (Right(leftProposition), Right(rightProposition)) =>
+            Proposer.andProposer[F].propose((leftProposition, rightProposition)).map(_.asRight[BuilderError])
+          case (Left(error), _) => error.asLeft[Proposition].pure[F]
+          case (_, Left(error)) => error.asLeft[Proposition].pure[F]
+        }
+        .flatten
+  }
+
+  case class OrTemplate[F[_]: Monad](leftTemplate: PropositionTemplate[F], rightTemplate: PropositionTemplate[F])
+      extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Or
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      Applicative[F]
+        .map2(leftTemplate.build(entityVks), rightTemplate.build(entityVks)) {
+          case (Right(leftProposition), Right(rightProposition)) =>
+            Proposer.orProposer[F].propose((leftProposition, rightProposition)).map(_.asRight[BuilderError])
+          case (Left(error), _) => error.asLeft[Proposition].pure[F]
+          case (_, Left(error)) => error.asLeft[Proposition].pure[F]
+        }
+        .flatten
+  }
+
+  case class NotTemplate[F[_]: Monad](innerTemplate: PropositionTemplate[F]) extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Not
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] =
+      innerTemplate.build(entityVks).flatMap {
+        case Right(proposition) => Proposer.notProposer[F].propose(proposition).map(_.asRight[BuilderError])
+        case Left(error)        => error.asLeft[Proposition].pure[F]
+      }
+  }
+
+  case class ThresholdTemplate[F[_]: Monad](innerTemplates: Seq[PropositionTemplate[F]], threshold: Int)
+      extends PropositionTemplate[F] {
+    override val propositionType: PropositionType = types.Threshold
+
+    override def build(entityVks: List[VerificationKey]): F[Either[BuilderError, Proposition]] = {
+      def recurseHelper(
+        templates:   Seq[PropositionTemplate[F]],
+        accumulator: Either[BuilderError, Seq[Proposition]]
+      ): F[Either[BuilderError, Seq[Proposition]]] = accumulator match {
+        case Left(err) => err.asLeft[Seq[Proposition]].pure[F] // Accumulator already encountered an error
+        case Right(accProps) =>
+          if (templates.isEmpty) accProps.asRight[BuilderError].pure[F] // All elements have been processed
+          else
+            templates.head.build(entityVks).flatMap { // < cannot do tailrec due to flattening of F
+              case Left(err)      => err.asLeft[Seq[Proposition]].pure[F] // Current element encountered an error
+              case Right(curProp) => recurseHelper(templates.tail, Right(accProps :+ curProp))
+            }
+      }
+      recurseHelper(innerTemplates, Right(Seq.empty)).flatMap {
+        case Left(err) => err.asLeft[Proposition].pure[F]
+        case Right(props) =>
+          Proposer.thresholdProposer[F].propose((props.toSet, threshold)).map(_.asRight[BuilderError])
+      }
+    }
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
@@ -1,0 +1,67 @@
+package co.topl.brambl.codecs
+
+import cats.Monad
+import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
+import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
+import io.circe.generic.codec.DerivedAsObjectCodec.deriveCodec
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+
+object LockTemplateCodecs {
+  def encodeLockTemplate[F[_]: Monad](template: LockTemplate[F]): Json = template.asJson
+
+  def decodeLockTemplate[F[_]: Monad](template: Json): Either[DecodingFailure, LockTemplate[F]] =
+    template.as[LockTemplate[F]]
+
+  /**
+   * JSON encoder for a Generic Lock Template
+   */
+  implicit def lockTemplateToJson[F[_]: Monad]: Encoder[LockTemplate[F]] = new Encoder[LockTemplate[F]] {
+
+    override def apply(a: LockTemplate[F]): Json =
+      Json
+        .obj("type" -> Json.fromString(a.lockType.label))
+        .deepMerge(a match {
+          case predicate: PredicateTemplate[F] => predicate.asJson
+          case _                               => Json.Null
+        })
+  }
+
+  /**
+   * JSON decoder for a generic Lock Template
+   */
+  implicit def lockTemplateFromJson[F[_]: Monad]: Decoder[LockTemplate[F]] = new Decoder[LockTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[LockTemplate[F]] =
+      c.downField("type").as[String] match {
+        case Right(LockTemplate.types.Predicate.label) => c.as[PredicateTemplate[F]]
+        case _                                         => Left(DecodingFailure("Unknown Lock Type", c.history))
+      }
+  }
+
+  /**
+   * JSON encoder for a Predicate Lock Template
+   */
+  implicit def predicateTemplateToJson[F[_]: Monad]: Encoder[PredicateTemplate[F]] = new Encoder[PredicateTemplate[F]] {
+
+    override def apply(a: PredicateTemplate[F]): Json =
+      Json.obj(
+        "threshold"      -> Json.fromInt(a.threshold),
+        "innerTemplates" -> Json.fromValues(a.innerTemplates.map(_.asJson))
+      )
+
+  }
+
+  /**
+   * JSON decoder for a Predicate Lock Template
+   */
+  implicit def predicateTemplateFromJson[F[_]: Monad]: Decoder[PredicateTemplate[F]] =
+    new Decoder[PredicateTemplate[F]] {
+
+      override def apply(c: HCursor): Decoder.Result[PredicateTemplate[F]] =
+        for {
+          threshold      <- c.downField("threshold").as[Int]
+          innerTemplates <- c.downField("innerTemplates").as[Seq[PropositionTemplate[F]]]
+        } yield PredicateTemplate[F](innerTemplates, threshold)
+    }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
@@ -3,8 +3,7 @@ package co.topl.brambl.codecs
 import cats.Monad
 import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
-import co.topl.brambl.codecs.PropositionTemplateCodecs.propositionTemplateToJson
-import io.circe.generic.codec.DerivedAsObjectCodec.deriveCodec
+import co.topl.brambl.codecs.PropositionTemplateCodecs._
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
 
@@ -24,7 +23,7 @@ object LockTemplateCodecs {
         .obj("type" -> Json.fromString(a.lockType.label))
         .deepMerge(a match {
           case predicate: PredicateTemplate[F] => predicate.asJson
-          case _                               => Json.Null
+          case _                               => Json.obj()
         })
   }
 
@@ -58,11 +57,6 @@ object LockTemplateCodecs {
    */
   implicit def predicateTemplateFromJson[F[_]: Monad]: Decoder[PredicateTemplate[F]] =
     new Decoder[PredicateTemplate[F]] {
-
-      implicit private val decodePropositionTemplateSeq: Decoder[Seq[PropositionTemplate[F]]] =
-        Decoder[Seq[PropositionTemplate[F]]].prepare(
-          _.downField("innerTemplates")
-        )
 
       override def apply(c: HCursor): Decoder.Result[PredicateTemplate[F]] =
         for {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/LockTemplateCodecs.scala
@@ -3,6 +3,7 @@ package co.topl.brambl.codecs
 import cats.Monad
 import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
+import co.topl.brambl.codecs.PropositionTemplateCodecs.propositionTemplateToJson
 import io.circe.generic.codec.DerivedAsObjectCodec.deriveCodec
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
@@ -57,6 +58,11 @@ object LockTemplateCodecs {
    */
   implicit def predicateTemplateFromJson[F[_]: Monad]: Decoder[PredicateTemplate[F]] =
     new Decoder[PredicateTemplate[F]] {
+
+      implicit private val decodePropositionTemplateSeq: Decoder[Seq[PropositionTemplate[F]]] =
+        Decoder[Seq[PropositionTemplate[F]]].prepare(
+          _.downField("innerTemplates")
+        )
 
       override def apply(c: HCursor): Decoder.Result[PredicateTemplate[F]] =
         for {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
@@ -65,7 +65,7 @@ object PropositionTemplateCodecs {
   implicit def lockedTemplateToJson[F[_]: Monad]: Encoder[LockedTemplate[F]] = new Encoder[LockedTemplate[F]] {
 
     override def apply(a: LockedTemplate[F]): Json =
-      if (a.data.isEmpty) Json.Null
+      if (a.data.isEmpty) Json.obj()
       else Json.obj("data" -> Json.fromString(a.data.get.value.toString))
   }
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
@@ -7,6 +7,7 @@ import co.topl.brambl.builders.locks.PropositionTemplate._
 import com.google.protobuf.ByteString
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+import org.bouncycastle.util.Strings
 import quivr.models.{Data, Digest}
 
 object PropositionTemplateCodecs {
@@ -136,7 +137,7 @@ object PropositionTemplateCodecs {
     override def apply(a: DigestTemplate[F]): Json =
       Json.obj(
         "routine" -> Json.fromString(a.routine),
-        "digest"  -> Json.fromString(a.digest.value.toString)
+        "digest"  -> Json.fromString(Strings.fromByteArray(a.digest.value.toByteArray))
       )
   }
 
@@ -149,7 +150,7 @@ object PropositionTemplateCodecs {
       for {
         routine <- c.downField("routine").as[String]
         digest  <- c.downField("digest").as[String]
-      } yield DigestTemplate[F](routine, Digest(ByteString.copyFrom(digest.getBytes)))
+      } yield DigestTemplate[F](routine, Digest(ByteString.copyFrom(Strings.toByteArray(digest))))
   }
 
   /**

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
@@ -1,0 +1,269 @@
+package co.topl.brambl.codecs
+
+import cats.Monad
+import cats.implicits.catsSyntaxEitherId
+import co.topl.brambl.builders.locks.PropositionTemplate
+import co.topl.brambl.builders.locks.PropositionTemplate._
+import com.google.protobuf.ByteString
+import io.circe.syntax.EncoderOps
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
+import quivr.models.{Data, Digest}
+
+object PropositionTemplateCodecs {
+  def encodePropositionTemplate[F[_]: Monad](template: PropositionTemplate[F]): Json = template.asJson
+
+  def decodePropositionTemplate[F[_]: Monad](template: Json): Either[DecodingFailure, PropositionTemplate[F]] =
+    template.as[PropositionTemplate[F]]
+
+  /**
+   * JSON encoder for a Generic Proposition Template
+   */
+  implicit def propositionTemplateToJson[F[_]: Monad]: Encoder[PropositionTemplate[F]] =
+    new Encoder[PropositionTemplate[F]] {
+
+      override def apply(a: PropositionTemplate[F]): Json =
+        Json
+          .obj("type" -> Json.fromString(a.propositionType.label))
+          .deepMerge(a match {
+            case locked: LockedTemplate[F]       => locked.asJson
+            case height: HeightTemplate[F]       => height.asJson
+            case tick: TickTemplate[F]           => tick.asJson
+            case digest: DigestTemplate[F]       => digest.asJson
+            case signature: SignatureTemplate[F] => signature.asJson
+            case and: AndTemplate[F]             => and.asJson
+            case or: OrTemplate[F]               => or.asJson
+            case not: NotTemplate[F]             => not.asJson
+            case threshold: ThresholdTemplate[F] => threshold.asJson
+            case _                               => Json.Null
+          })
+    }
+
+  /**
+   * JSON decoder for a generic Proposition Template
+   */
+  implicit def propositionTemplateFromJson[F[_]: Monad]: Decoder[PropositionTemplate[F]] =
+    new Decoder[PropositionTemplate[F]] {
+
+      override def apply(c: HCursor): Decoder.Result[PropositionTemplate[F]] =
+        c.downField("type").as[String] match {
+          case Right(PropositionTemplate.types.Locked.label)    => c.as[LockedTemplate[F]]
+          case Right(PropositionTemplate.types.Height.label)    => c.as[HeightTemplate[F]]
+          case Right(PropositionTemplate.types.Tick.label)      => c.as[TickTemplate[F]]
+          case Right(PropositionTemplate.types.Digest.label)    => c.as[DigestTemplate[F]]
+          case Right(PropositionTemplate.types.Signature.label) => c.as[SignatureTemplate[F]]
+          case Right(PropositionTemplate.types.And.label)       => c.as[AndTemplate[F]]
+          case Right(PropositionTemplate.types.Or.label)        => c.as[OrTemplate[F]]
+          case Right(PropositionTemplate.types.Not.label)       => c.as[NotTemplate[F]]
+          case Right(PropositionTemplate.types.Threshold.label) => c.as[ThresholdTemplate[F]]
+          case _ => Left(DecodingFailure("Unknown Proposition Type", c.history))
+        }
+    }
+
+  /**
+   * JSON encoder for a Locked Proposition Template
+   */
+  implicit def lockedTemplateToJson[F[_]: Monad]: Encoder[LockedTemplate[F]] = new Encoder[LockedTemplate[F]] {
+
+    override def apply(a: LockedTemplate[F]): Json =
+      if (a.data.isEmpty) Json.Null
+      else Json.obj("data" -> Json.fromString(a.data.get.value.toString))
+  }
+
+  /**
+   * JSON decoder for a Locked Proposition Template
+   */
+  implicit def lockedTemplateFromJson[F[_]: Monad]: Decoder[LockedTemplate[F]] = new Decoder[LockedTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[LockedTemplate[F]] = c.downField("data").as[String] match {
+      case Left(_)     => LockedTemplate[F](None).asRight
+      case Right(data) => LockedTemplate[F](Some(Data(ByteString.copyFrom(data.getBytes)))).asRight
+    }
+  }
+
+  /**
+   * JSON encoder for a Height Proposition Template
+   */
+  implicit def heightTemplateToJson[F[_]: Monad]: Encoder[HeightTemplate[F]] = new Encoder[HeightTemplate[F]] {
+
+    override def apply(a: HeightTemplate[F]): Json = Json.obj(
+      "chain" -> Json.fromString(a.chain),
+      "min"   -> Json.fromLong(a.min),
+      "max"   -> Json.fromLong(a.max)
+    )
+  }
+
+  /**
+   * JSON decoder for a Height Proposition Template
+   */
+  implicit def heightTemplateFromJson[F[_]: Monad]: Decoder[HeightTemplate[F]] = new Decoder[HeightTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[HeightTemplate[F]] =
+      for {
+        chain <- c.downField("chain").as[String]
+        min   <- c.downField("min").as[Long]
+        max   <- c.downField("max").as[Long]
+      } yield HeightTemplate[F](chain, min, max)
+  }
+
+  /**
+   * JSON encoder for a Tick Proposition Template
+   */
+  implicit def tickTemplateToJson[F[_]: Monad]: Encoder[TickTemplate[F]] = new Encoder[TickTemplate[F]] {
+
+    override def apply(a: TickTemplate[F]): Json = Json.obj(
+      "min" -> Json.fromLong(a.min),
+      "max" -> Json.fromLong(a.max)
+    )
+  }
+
+  /**
+   * JSON decoder for a Tick Proposition Template
+   */
+  implicit def tickTemplateFromJson[F[_]: Monad]: Decoder[TickTemplate[F]] = new Decoder[TickTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[TickTemplate[F]] =
+      for {
+        min <- c.downField("min").as[Long]
+        max <- c.downField("max").as[Long]
+      } yield TickTemplate[F](min, max)
+  }
+
+  /**
+   * JSON encoder for a Digest Proposition Template
+   */
+  implicit def digestTemplateToJson[F[_]: Monad]: Encoder[DigestTemplate[F]] = new Encoder[DigestTemplate[F]] {
+
+    override def apply(a: DigestTemplate[F]): Json =
+      Json.obj(
+        "routine" -> Json.fromString(a.routine),
+        "digest"  -> Json.fromString(a.digest.value.toString)
+      )
+  }
+
+  /**
+   * JSON decoder for a Digest Proposition Template
+   */
+  implicit def digestTemplateFromJson[F[_]: Monad]: Decoder[DigestTemplate[F]] = new Decoder[DigestTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[DigestTemplate[F]] =
+      for {
+        routine <- c.downField("routine").as[String]
+        digest  <- c.downField("digest").as[String]
+      } yield DigestTemplate[F](routine, Digest(ByteString.copyFrom(digest.getBytes)))
+  }
+
+  /**
+   * JSON encoder for a Signature Proposition Template
+   */
+  implicit def signatureTemplateToJson[F[_]: Monad]: Encoder[SignatureTemplate[F]] = new Encoder[SignatureTemplate[F]] {
+
+    override def apply(a: SignatureTemplate[F]): Json = Json.obj(
+      "routine"   -> Json.fromString(a.routine),
+      "entityIdx" -> Json.fromInt(a.entityIdx)
+    )
+  }
+
+  /**
+   * JSON decoder for a Signature Proposition Template
+   */
+  implicit def signatureTemplateFromJson[F[_]: Monad]: Decoder[SignatureTemplate[F]] =
+    new Decoder[SignatureTemplate[F]] {
+
+      override def apply(c: HCursor): Decoder.Result[SignatureTemplate[F]] =
+        for {
+          routine   <- c.downField("routine").as[String]
+          entityIdx <- c.downField("entityIdx").as[Int]
+        } yield SignatureTemplate[F](routine, entityIdx)
+    }
+
+  /**
+   * JSON encoder for a And Proposition Template
+   */
+  implicit def andTemplateToJson[F[_]: Monad]: Encoder[AndTemplate[F]] = new Encoder[AndTemplate[F]] {
+
+    override def apply(a: AndTemplate[F]): Json = Json.obj(
+      "left"  -> a.leftTemplate.asJson,
+      "right" -> a.rightTemplate.asJson
+    )
+  }
+
+  /**
+   * JSON decoder for a And Proposition Template
+   */
+  implicit def andTemplateFromJson[F[_]: Monad]: Decoder[AndTemplate[F]] = new Decoder[AndTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[AndTemplate[F]] =
+      for {
+        left  <- c.downField("left").as[PropositionTemplate[F]]
+        right <- c.downField("right").as[PropositionTemplate[F]]
+      } yield AndTemplate[F](left, right)
+  }
+
+  /**
+   * JSON encoder for a Or Proposition Template
+   */
+  implicit def orTemplateToJson[F[_]: Monad]: Encoder[OrTemplate[F]] = new Encoder[OrTemplate[F]] {
+
+    override def apply(a: OrTemplate[F]): Json = Json.obj(
+      "left"  -> a.leftTemplate.asJson,
+      "right" -> a.rightTemplate.asJson
+    )
+  }
+
+  /**
+   * JSON decoder for a Or Proposition Template
+   */
+  implicit def orTemplateFromJson[F[_]: Monad]: Decoder[OrTemplate[F]] = new Decoder[OrTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[OrTemplate[F]] =
+      for {
+        left  <- c.downField("left").as[PropositionTemplate[F]]
+        right <- c.downField("right").as[PropositionTemplate[F]]
+      } yield OrTemplate[F](left, right)
+  }
+
+  /**
+   * JSON encoder for a Not Proposition Template
+   */
+  implicit def notTemplateToJson[F[_]: Monad]: Encoder[NotTemplate[F]] = new Encoder[NotTemplate[F]] {
+
+    override def apply(a: NotTemplate[F]): Json = Json.obj(
+      "innerTemplate" -> a.innerTemplate.asJson
+    )
+  }
+
+  /**
+   * JSON decoder for a Not Proposition Template
+   */
+  implicit def notTemplateFromJson[F[_]: Monad]: Decoder[NotTemplate[F]] = new Decoder[NotTemplate[F]] {
+
+    override def apply(c: HCursor): Decoder.Result[NotTemplate[F]] =
+      for {
+        innerTemplate <- c.downField("innerTemplate").as[PropositionTemplate[F]]
+      } yield NotTemplate[F](innerTemplate)
+  }
+
+  /**
+   * JSON encoder for a Threshold Proposition Template
+   */
+  implicit def thresholdTemplateToJson[F[_]: Monad]: Encoder[ThresholdTemplate[F]] = new Encoder[ThresholdTemplate[F]] {
+
+    override def apply(a: ThresholdTemplate[F]): Json = Json.obj(
+      "threshold"      -> Json.fromInt(a.threshold),
+      "innerTemplates" -> a.innerTemplates.asJson
+    )
+  }
+
+  /**
+   * JSON decoder for a Threshold Proposition Template
+   */
+  implicit def thresholdTemplateFromJson[F[_]: Monad]: Decoder[ThresholdTemplate[F]] =
+    new Decoder[ThresholdTemplate[F]] {
+
+      override def apply(c: HCursor): Decoder.Result[ThresholdTemplate[F]] =
+        for {
+          threshold      <- c.downField("threshold").as[Int]
+          innerTemplates <- c.downField("innerTemplates").as[Seq[PropositionTemplate[F]]]
+        } yield ThresholdTemplate[F](innerTemplates, threshold)
+    }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -31,7 +31,6 @@ import quivr.models.{
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
-import quivr.models.VerificationKey._
 
 trait MockHelpers {
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
@@ -144,11 +143,7 @@ trait MockHelpers {
     IoTransaction.defaultInstance.withInputs(List(inputFull)).withOutputs(List(output)).withDatum(txDatum)
 
   val mockVks: List[VerificationKey] = List(
-    VerificationKey.defaultInstance.withExtendedEd25519(
-      ExtendedEd25519Vk(Ed25519Vk(ByteString.copyFrom("entity_1".getBytes)))
-    ),
-    VerificationKey.defaultInstance.withExtendedEd25519(
-      ExtendedEd25519Vk(Ed25519Vk(ByteString.copyFrom("entity_2".getBytes)))
-    )
+    MockChildKeyPair.vk,
+    (new ExtendedEd25519).deriveKeyPairFromSeed(Array.fill(96)(1: Byte)).vk
   )
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -44,6 +44,7 @@ import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyP
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
 import io.circe.Json
+import org.bouncycastle.util.Strings
 
 trait MockHelpers {
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
@@ -205,7 +206,7 @@ trait MockHelpers {
     val fields: List[(String, Json)] = List(
       "type"    -> Json.fromString(value.propositionType.label),
       "routine" -> Json.fromString(MockDigestRoutine),
-      "digest"  -> Json.fromString(MockDigest.value.toString)
+      "digest"  -> Json.fromString(Strings.fromByteArray(MockDigest.value.toByteArray))
     )
     val json: Json = Json.fromFields(fields)
   }
@@ -214,9 +215,9 @@ trait MockHelpers {
     def value(entityIdx: Int): SignatureTemplate[Id] = SignatureTemplate[Id](MockSigningRoutine, entityIdx)
 
     def fields(entityIdx: Int): List[(String, Json)] = List(
-      "type"    -> Json.fromString(value(entityIdx).propositionType.label),
-      "routine" -> Json.fromString(MockSigningRoutine),
-      "data"    -> Json.fromInt(entityIdx)
+      "type"      -> Json.fromString(value(entityIdx).propositionType.label),
+      "routine"   -> Json.fromString(MockSigningRoutine),
+      "entityIdx" -> Json.fromInt(entityIdx)
     )
     def json(entityIdx: Int): Json = Json.fromFields(fields(entityIdx))
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -16,11 +16,22 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.quivr.api.Proposer
 import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
-import quivr.models.{Digest, Int128, KeyPair, Preimage, Proof, Proposition, SignableBytes, SmallData, Witness}
+import quivr.models.{
+  Digest,
+  Int128,
+  KeyPair,
+  Preimage,
+  Proof,
+  Proposition,
+  SignableBytes,
+  SmallData,
+  VerificationKey,
+  Witness
+}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
-import co.topl.crypto.generation.mnemonic.Entropy
 import co.topl.crypto.signing.ExtendedEd25519
+import quivr.models.VerificationKey._
 
 trait MockHelpers {
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
@@ -131,4 +142,13 @@ trait MockHelpers {
 
   val txFull: IoTransaction =
     IoTransaction.defaultInstance.withInputs(List(inputFull)).withOutputs(List(output)).withDatum(txDatum)
+
+  val mockVks: List[VerificationKey] = List(
+    VerificationKey.defaultInstance.withExtendedEd25519(
+      ExtendedEd25519Vk(Ed25519Vk(ByteString.copyFrom("entity_1".getBytes)))
+    ),
+    VerificationKey.defaultInstance.withExtendedEd25519(
+      ExtendedEd25519Vk(Ed25519Vk(ByteString.copyFrom("entity_2".getBytes)))
+    )
+  )
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -1,6 +1,18 @@
 package co.topl.brambl
 
 import cats.Id
+import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
+import co.topl.brambl.builders.locks.PropositionTemplate.{
+  AndTemplate,
+  DigestTemplate,
+  HeightTemplate,
+  LockedTemplate,
+  NotTemplate,
+  OrTemplate,
+  SignatureTemplate,
+  ThresholdTemplate,
+  TickTemplate
+}
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
@@ -31,6 +43,7 @@ import quivr.models.{
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
+import io.circe.Json
 
 trait MockHelpers {
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
@@ -48,8 +61,10 @@ trait MockHelpers {
     )
   )
 
+  val MockSigningRoutine: String = "ExtendedEd25519"
+
   val MockSignatureProposition: Id[Proposition] =
-    Proposer.signatureProposer[Id].propose(("ExtendedEd25519", MockChildKeyPair.vk))
+    Proposer.signatureProposer[Id].propose((MockSigningRoutine, MockChildKeyPair.vk))
 
   val MockSignature: Witness = Witness(
     ByteString.copyFrom((new ExtendedEd25519).sign(MockChildKeyPair.signingKey, fakeMsgBind.value.toByteArray))
@@ -59,15 +74,20 @@ trait MockHelpers {
   val MockPreimage: Preimage = Preimage(ByteString.copyFrom("secret".getBytes), ByteString.copyFromUtf8("salt"))
 
   // Hardcoding Blake2b256
+  val MockDigestRoutine: String = "Blake2b256"
+
   val MockDigest: Digest =
     Digest(ByteString.copyFrom((new Blake2b256).hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray)))
-  val MockDigestProposition: Id[Proposition] = Proposer.digestProposer[Id].propose(("Blake2b256", MockDigest))
+  val MockDigestProposition: Id[Proposition] = Proposer.digestProposer[Id].propose((MockDigestRoutine, MockDigest))
   val MockDigestProof: Id[Proof] = Prover.digestProver[Id].prove(MockPreimage, fakeMsgBind)
 
-  val MockTickProposition: Id[Proposition] = Proposer.tickProposer[Id].propose((0, 100))
+  val MockMin: Long = 0L
+  val MockMax: Long = 100L
+  val MockChain: String = "header"
+  val MockTickProposition: Id[Proposition] = Proposer.tickProposer[Id].propose((MockMin, MockMax))
   val MockTickProof: Id[Proof] = Prover.tickProver[Id].prove((), fakeMsgBind)
 
-  val MockHeightProposition: Id[Proposition] = Proposer.heightProposer[Id].propose(("header", 0, 100))
+  val MockHeightProposition: Id[Proposition] = Proposer.heightProposer[Id].propose((MockChain, MockMin, MockMax))
   val MockHeightProof: Id[Proof] = Prover.heightProver[Id].prove((), fakeMsgBind)
 
   val MockLockedProposition: Id[Proposition] = Proposer.LockedProposer[Id].propose(None)
@@ -146,4 +166,151 @@ trait MockHelpers {
     MockChildKeyPair.vk,
     (new ExtendedEd25519).deriveKeyPairFromSeed(Array.fill(96)(1: Byte)).vk
   )
+
+  object ExpectedLockedProposition {
+    val value: LockedTemplate[Id] = LockedTemplate[Id](None)
+
+    val fields: List[(String, Json)] = List(
+      "type" -> Json.fromString(value.propositionType.label)
+    )
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedHeightProposition {
+    val value: HeightTemplate[Id] = HeightTemplate[Id](MockChain, MockMin, MockMax)
+
+    val fields: List[(String, Json)] = List(
+      "type"  -> Json.fromString(value.propositionType.label),
+      "chain" -> Json.fromString(MockChain),
+      "min"   -> Json.fromLong(MockMin),
+      "max"   -> Json.fromLong(MockMax)
+    )
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedTickProposition {
+    val value: TickTemplate[Id] = TickTemplate[Id](MockMin, MockMax)
+
+    val fields: List[(String, Json)] = List(
+      "type" -> Json.fromString(value.propositionType.label),
+      "min"  -> Json.fromLong(MockMin),
+      "max"  -> Json.fromLong(MockMax)
+    )
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedDigestProposition {
+    val value: DigestTemplate[Id] = DigestTemplate[Id](MockDigestRoutine, MockDigest)
+
+    val fields: List[(String, Json)] = List(
+      "type"    -> Json.fromString(value.propositionType.label),
+      "routine" -> Json.fromString(MockDigestRoutine),
+      "digest"  -> Json.fromString(MockDigest.value.toString)
+    )
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedSignatureProposition {
+    def value(entityIdx: Int): SignatureTemplate[Id] = SignatureTemplate[Id](MockSigningRoutine, entityIdx)
+
+    def fields(entityIdx: Int): List[(String, Json)] = List(
+      "type"    -> Json.fromString(value(entityIdx).propositionType.label),
+      "routine" -> Json.fromString(MockSigningRoutine),
+      "data"    -> Json.fromInt(entityIdx)
+    )
+    def json(entityIdx: Int): Json = Json.fromFields(fields(entityIdx))
+  }
+
+  object ExpectedAndProposition {
+
+    val value: AndTemplate[Id] = AndTemplate[Id](
+      ExpectedSignatureProposition.value(0),
+      ExpectedSignatureProposition.value(1)
+    )
+
+    val fields: List[(String, Json)] = List(
+      "type"  -> Json.fromString(value.propositionType.label),
+      "left"  -> ExpectedSignatureProposition.json(0),
+      "right" -> ExpectedSignatureProposition.json(1)
+    )
+
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedOrProposition {
+
+    val value: OrTemplate[Id] = OrTemplate[Id](
+      ExpectedLockedProposition.value,
+      ExpectedTickProposition.value
+    )
+
+    val fields: List[(String, Json)] = List(
+      "type"  -> Json.fromString(value.propositionType.label),
+      "left"  -> ExpectedLockedProposition.json,
+      "right" -> ExpectedTickProposition.json
+    )
+
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedNotProposition {
+    val value: NotTemplate[Id] = NotTemplate[Id](ExpectedHeightProposition.value)
+
+    val fields: List[(String, Json)] = List(
+      "type"          -> Json.fromString(value.propositionType.label),
+      "innerTemplate" -> ExpectedHeightProposition.json
+    )
+
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedThresholdProposition {
+
+    val value: ThresholdTemplate[Id] = ThresholdTemplate[Id](
+      List(
+        ExpectedAndProposition.value,
+        ExpectedOrProposition.value,
+        ExpectedNotProposition.value
+      ),
+      3
+    )
+
+    val fields: List[(String, Json)] = List(
+      "type"      -> Json.fromString(value.propositionType.label),
+      "threshold" -> Json.fromInt(value.threshold),
+      "innerTemplates" -> Json.fromValues(
+        List(
+          ExpectedAndProposition.json,
+          ExpectedOrProposition.json,
+          ExpectedNotProposition.json
+        )
+      )
+    )
+
+    val json: Json = Json.fromFields(fields)
+  }
+
+  object ExpectedPredicateLock {
+
+    val value: PredicateTemplate[Id] = PredicateTemplate[Id](
+      List(
+        ExpectedAndProposition.value,
+        ExpectedThresholdProposition.value
+      ),
+      2
+    )
+
+    val fields: List[(String, Json)] = List(
+      "type"      -> Json.fromString(value.lockType.label),
+      "threshold" -> Json.fromInt(value.threshold),
+      "innerTemplates" -> Json.fromValues(
+        List(
+          ExpectedAndProposition.json,
+          ExpectedThresholdProposition.json
+        )
+      )
+    )
+
+    val json: Json = Json.fromFields(fields)
+  }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
@@ -4,7 +4,7 @@ import cats.Id
 import quivr.models.Proposition.Value._
 import co.topl.brambl.MockHelpers
 import co.topl.brambl.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
-import co.topl.brambl.models.box.Lock.Predicate
+import co.topl.brambl.models.box.Lock.Value.Predicate
 
 class LockTemplateSpec extends munit.FunSuite with MockHelpers {
 
@@ -35,7 +35,7 @@ class LockTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(lockInstance.isRight)
     val lockPredicate = lockInstance.toOption.get
     assert(lockPredicate.value.isPredicate)
-    val andProposition = lockPredicate.value.asInstanceOf[Predicate].challenges.head.getRevealed
+    val andProposition = lockPredicate.value.asInstanceOf[Predicate].value.challenges.head.getRevealed
     assert(andProposition.value.isAnd)
     val andLeftProposition = andProposition.value.asInstanceOf[And].value.left
     val andRightProposition = andProposition.value.asInstanceOf[And].value.right
@@ -46,7 +46,7 @@ class LockTemplateSpec extends munit.FunSuite with MockHelpers {
     assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
     assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andRightEntityVk)
 
-    val thresholdProposition = lockPredicate.value.asInstanceOf[Predicate].challenges(1).getRevealed
+    val thresholdProposition = lockPredicate.value.asInstanceOf[Predicate].value.challenges(1).getRevealed
     assert(thresholdProposition.value.isThreshold)
     val notProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges.head
     assert(notProposition.value.isNot)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
@@ -9,21 +9,17 @@ import co.topl.brambl.models.box.Lock.Value.Predicate
 class LockTemplateSpec extends munit.FunSuite with MockHelpers {
 
   test("Build Predicate Lock via Template") {
-    val routine = "someRoutine"
     val andLeftEntityIdx = 0
     val andRightEntityIdx = 1
     val andLeftEntityVk = mockVks(andLeftEntityIdx)
     val andRightEntityVk = mockVks(andRightEntityIdx)
-    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andLeftEntityIdx)
-    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andRightEntityIdx)
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, andLeftEntityIdx)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, andRightEntityIdx)
     val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
-    val chain = "someChain"
-    val min = 0L
-    val max = 100L
-    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](MockChain, MockMin, MockMax)
     val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
     val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
-    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](MockMin, MockMax)
     val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
     val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](
       List(notTemplate, orTemplate),
@@ -41,9 +37,9 @@ class LockTemplateSpec extends munit.FunSuite with MockHelpers {
     val andRightProposition = andProposition.value.asInstanceOf[And].value.right
     assert(andLeftProposition.value.isDigitalSignature)
     assert(andRightProposition.value.isDigitalSignature)
-    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andLeftEntityVk)
-    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andRightEntityVk)
 
     val thresholdProposition = lockPredicate.value.asInstanceOf[Predicate].value.challenges(1).getRevealed
@@ -52,9 +48,9 @@ class LockTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(notProposition.value.isNot)
     val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
     assert(innerProposition.value.isHeightRange)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, MockChain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, MockMin)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, MockMax)
     val orProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(1)
     assert(orProposition.value.isOr)
     val orLeftProposition = orProposition.value.asInstanceOf[Or].value.left
@@ -62,22 +58,18 @@ class LockTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(orLeftProposition.value.isLocked)
     assertEquals(orLeftProposition.value.asInstanceOf[Locked].value.data, None)
     assert(orRightProposition.value.isTickRange)
-    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, min)
-    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, max)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, MockMin)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, MockMax)
   }
 
   test("Failure to build Predicate Lock via Template > Invalid Entity Index") {
-    val routine = "someRoutine"
-    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, 0)
-    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, 5)
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, 0)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, 5)
     val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
-    val chain = "someChain"
-    val min = 0L
-    val max = 100L
-    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](MockChain, MockMin, MockMax)
     val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
     val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
-    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](MockMin, MockMax)
     val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
     val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](List(notTemplate, orTemplate), 2)
     val lockTemplate = LockTemplate.PredicateTemplate[Id](List(andTemplate, thresholdTemplate), 2)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/LockTemplateSpec.scala
@@ -1,0 +1,89 @@
+package co.topl.brambl.builders.locks
+
+import cats.Id
+import quivr.models.Proposition.Value._
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
+import co.topl.brambl.models.box.Lock.Predicate
+
+class LockTemplateSpec extends munit.FunSuite with MockHelpers {
+
+  test("Build Predicate Lock via Template") {
+    val routine = "someRoutine"
+    val andLeftEntityIdx = 0
+    val andRightEntityIdx = 1
+    val andLeftEntityVk = mockVks(andLeftEntityIdx)
+    val andRightEntityVk = mockVks(andRightEntityIdx)
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andLeftEntityIdx)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andRightEntityIdx)
+    val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
+    val chain = "someChain"
+    val min = 0L
+    val max = 100L
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
+    val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
+    val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](
+      List(notTemplate, orTemplate),
+      2
+    )
+    val lockTemplate = LockTemplate.PredicateTemplate[Id](List(andTemplate, thresholdTemplate), 2)
+
+    val lockInstance = lockTemplate.build(mockVks)
+    assert(lockInstance.isRight)
+    val lockPredicate = lockInstance.toOption.get
+    assert(lockPredicate.value.isPredicate)
+    val andProposition = lockPredicate.value.asInstanceOf[Predicate].challenges.head.getRevealed
+    assert(andProposition.value.isAnd)
+    val andLeftProposition = andProposition.value.asInstanceOf[And].value.left
+    val andRightProposition = andProposition.value.asInstanceOf[And].value.right
+    assert(andLeftProposition.value.isDigitalSignature)
+    assert(andRightProposition.value.isDigitalSignature)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andLeftEntityVk)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andRightEntityVk)
+
+    val thresholdProposition = lockPredicate.value.asInstanceOf[Predicate].challenges(1).getRevealed
+    assert(thresholdProposition.value.isThreshold)
+    val notProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges.head
+    assert(notProposition.value.isNot)
+    val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
+    assert(innerProposition.value.isHeightRange)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+    val orProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(1)
+    assert(orProposition.value.isOr)
+    val orLeftProposition = orProposition.value.asInstanceOf[Or].value.left
+    val orRightProposition = orProposition.value.asInstanceOf[Or].value.right
+    assert(orLeftProposition.value.isLocked)
+    assertEquals(orLeftProposition.value.asInstanceOf[Locked].value.data, None)
+    assert(orRightProposition.value.isTickRange)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, min)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, max)
+  }
+
+  test("Failure to build Predicate Lock via Template > Invalid Entity Index") {
+    val routine = "someRoutine"
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, 0)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, 5)
+    val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
+    val chain = "someChain"
+    val min = 0L
+    val max = 100L
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
+    val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
+    val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](List(notTemplate, orTemplate), 2)
+    val lockTemplate = LockTemplate.PredicateTemplate[Id](List(andTemplate, thresholdTemplate), 2)
+
+    val lockInstance = lockTemplate.build(mockVks)
+    assert(lockInstance.isLeft)
+    assert(lockInstance.swap.toOption.get.isInstanceOf[UnableToBuildPropositionTemplate])
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
@@ -1,0 +1,197 @@
+package co.topl.brambl.builders.locks
+
+import cats.Id
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
+import com.google.protobuf.ByteString
+import quivr.models.Proposition.Value._
+import quivr.models.{Data, Digest => DigestValue}
+
+class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
+
+  test("Build Locked Proposition via Template") {
+    val data = Some(Data(ByteString.copyFrom("someData".getBytes)))
+    val lockedTemplate = PropositionTemplate.LockedTemplate[Id](data)
+    val lockedInstance = lockedTemplate.build(mockVks)
+    assert(lockedInstance.isRight)
+    val lockedProposition = lockedInstance.toOption.get
+    assert(lockedProposition.value.isLocked)
+    assertEquals(lockedProposition.value.asInstanceOf[Locked].value.data, data)
+  }
+
+  test("Build Height Proposition via Template") {
+    val chain = "someChain"
+    val min = 0L
+    val max = 100L
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightInstance = heightTemplate.build(mockVks)
+    assert(heightInstance.isRight)
+    val heightProposition = heightInstance.toOption.get
+    assert(heightProposition.value.isHeightRange)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.chain, chain)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.min, min)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.max, max)
+  }
+
+  test("Build Tick Proposition via Template") {
+    val min = 0L
+    val max = 100L
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val tickInstance = tickTemplate.build(mockVks)
+    assert(tickInstance.isRight)
+    val tickProposition = tickInstance.toOption.get
+    assert(tickProposition.value.isTickRange)
+    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.min, min)
+    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.max, max)
+  }
+
+  test("Build Digest Proposition via Template") {
+    val routine = "someRoutine"
+    val digest = DigestValue(ByteString.copyFrom("someDigest".getBytes))
+    val digestTemplate = PropositionTemplate.DigestTemplate[Id](routine, digest)
+    val digestInstance = digestTemplate.build(mockVks)
+    assert(digestInstance.isRight)
+    val digestProposition = digestInstance.toOption.get
+    assert(digestProposition.value.isDigest)
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, routine)
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, digest)
+  }
+
+  test("Build Signature Proposition via Template") {
+    val routine = "someRoutine"
+    val entityIdx = 0
+    val entityVk = mockVks(entityIdx)
+    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, entityIdx)
+    val signatureInstance = signatureTemplate.build(mockVks)
+    assert(signatureInstance.isRight)
+    val signatureProposition = signatureInstance.toOption.get
+    assert(signatureProposition.value.isDigitalSignature)
+    assertEquals(signatureProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(signatureProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, entityVk)
+  }
+
+  test("Failure to Build Signature Proposition via Template > Invalid Entity Index") {
+    val entityIdx = 2
+    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id]("someRoutine", entityIdx)
+    val signatureInstance = signatureTemplate.build(mockVks)
+    assert(signatureInstance.isLeft)
+    assert(signatureInstance.swap.toOption.get.isInstanceOf[UnableToBuildPropositionTemplate])
+  }
+
+  test("Build And Proposition via Template") {
+    val routine = "someRoutine"
+    val leftEntityIdx = 0
+    val rightEntityIdx = 1
+    val leftEntityVk = mockVks(leftEntityIdx)
+    val rightEntityVk = mockVks(rightEntityIdx)
+    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, leftEntityIdx)
+    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, rightEntityIdx)
+    val andTemplate = PropositionTemplate.AndTemplate[Id](leftSignatureTemplate, rightSignatureTemplate)
+    val andInstance = andTemplate.build(mockVks)
+    assert(andInstance.isRight)
+    val andProposition = andInstance.toOption.get
+    assert(andProposition.value.isAnd)
+    val leftProposition = andProposition.value.asInstanceOf[And].value.left
+    val rightProposition = andProposition.value.asInstanceOf[And].value.right
+    assert(leftProposition.value.isDigitalSignature)
+    assert(rightProposition.value.isDigitalSignature)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, leftEntityVk)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, rightEntityVk)
+  }
+
+  test("Build Or Proposition via Template") {
+    val routine = "someRoutine"
+    val leftEntityIdx = 0
+    val rightEntityIdx = 1
+    val leftEntityVk = mockVks(leftEntityIdx)
+    val rightEntityVk = mockVks(rightEntityIdx)
+    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, leftEntityIdx)
+    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, rightEntityIdx)
+    val orTemplate = PropositionTemplate.OrTemplate[Id](leftSignatureTemplate, rightSignatureTemplate)
+    val orInstance = orTemplate.build(mockVks)
+    assert(orInstance.isRight)
+    val orProposition = orInstance.toOption.get
+    assert(orProposition.value.isOr)
+    val leftProposition = orProposition.value.asInstanceOf[And].value.left
+    val rightProposition = orProposition.value.asInstanceOf[And].value.right
+    assert(leftProposition.value.isDigitalSignature)
+    assert(rightProposition.value.isDigitalSignature)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, leftEntityVk)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, rightEntityVk)
+  }
+
+  test("Build Not Proposition via Template") {
+    val chain = "someChain"
+    val min = 0L
+    val max = 100L
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
+    val notInstance = notTemplate.build(mockVks)
+    assert(notInstance.isRight)
+    val notProposition = notInstance.toOption.get
+    assert(notProposition.value.isNot)
+    val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
+    assert(innerProposition.value.isHeightRange)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+  }
+
+  test("Build Threshold Proposition via Template") {
+    val routine = "someRoutine"
+    val andLeftEntityIdx = 0
+    val andRightEntityIdx = 1
+    val andLeftEntityVk = mockVks(andLeftEntityIdx)
+    val andRightEntityVk = mockVks(andRightEntityIdx)
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andLeftEntityIdx)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andRightEntityIdx)
+    val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
+    val chain = "someChain"
+    val min = 0L
+    val max = 100L
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
+    val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
+    val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](
+      List(andTemplate, notTemplate, orTemplate),
+      3
+    )
+
+    val thresholdInstance = thresholdTemplate.build(mockVks)
+    assert(thresholdInstance.isRight)
+    val thresholdProposition = thresholdInstance.toOption.get
+    assert(thresholdProposition.value.isThreshold)
+    val andProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges.head
+    assert(andProposition.value.isAnd)
+    val andLeftProposition = andProposition.value.asInstanceOf[And].value.left
+    val andRightProposition = andProposition.value.asInstanceOf[And].value.right
+    assert(andLeftProposition.value.isDigitalSignature)
+    assert(andRightProposition.value.isDigitalSignature)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andLeftEntityVk)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andRightEntityVk)
+    val notProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(1)
+    assert(notProposition.value.isNot)
+    val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
+    assert(innerProposition.value.isHeightRange)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+    val orProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(2)
+    assert(orProposition.value.isOr)
+    val orLeftProposition = orProposition.value.asInstanceOf[Or].value.left
+    val orRightProposition = orProposition.value.asInstanceOf[Or].value.right
+    assert(orLeftProposition.value.isLocked)
+    assertEquals(orLeftProposition.value.asInstanceOf[Locked].value.data, None)
+    assert(orRightProposition.value.isTickRange)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, min)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, max)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
@@ -20,71 +20,63 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("Build Height Proposition via Template") {
-    val chain = "someChain"
-    val min = 0L
-    val max = 100L
-    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](MockChain, MockMin, MockMax)
     val heightInstance = heightTemplate.build(mockVks)
     assert(heightInstance.isRight)
     val heightProposition = heightInstance.toOption.get
     assert(heightProposition.value.isHeightRange)
-    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.chain, chain)
-    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.min, min)
-    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.max, max)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.chain, MockChain)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.min, MockMin)
+    assertEquals(heightProposition.value.asInstanceOf[HeightRange].value.max, MockMax)
   }
 
   test("Build Tick Proposition via Template") {
-    val min = 0L
-    val max = 100L
-    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](MockMin, MockMax)
     val tickInstance = tickTemplate.build(mockVks)
     assert(tickInstance.isRight)
     val tickProposition = tickInstance.toOption.get
     assert(tickProposition.value.isTickRange)
-    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.min, min)
-    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.max, max)
+    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.min, MockMin)
+    assertEquals(tickProposition.value.asInstanceOf[TickRange].value.max, MockMax)
   }
 
   test("Build Digest Proposition via Template") {
-    val routine = "someRoutine"
-    val digestTemplate = PropositionTemplate.DigestTemplate[Id](routine, MockDigest)
+    val digestTemplate = PropositionTemplate.DigestTemplate[Id](MockDigestRoutine, MockDigest)
     val digestInstance = digestTemplate.build(mockVks)
     assert(digestInstance.isRight)
     val digestProposition = digestInstance.toOption.get
     assert(digestProposition.value.isDigest)
-    assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, routine)
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, MockDigestRoutine)
     assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, MockDigest)
   }
 
   test("Build Signature Proposition via Template") {
-    val routine = "someRoutine"
     val entityIdx = 0
     val entityVk = mockVks(entityIdx)
-    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, entityIdx)
+    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, entityIdx)
     val signatureInstance = signatureTemplate.build(mockVks)
     assert(signatureInstance.isRight)
     val signatureProposition = signatureInstance.toOption.get
     assert(signatureProposition.value.isDigitalSignature)
-    assertEquals(signatureProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(signatureProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(signatureProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, entityVk)
   }
 
   test("Failure to Build Signature Proposition via Template > Invalid Entity Index") {
     val entityIdx = 2
-    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id]("someRoutine", entityIdx)
+    val signatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, entityIdx)
     val signatureInstance = signatureTemplate.build(mockVks)
     assert(signatureInstance.isLeft)
     assert(signatureInstance.swap.toOption.get.isInstanceOf[UnableToBuildPropositionTemplate])
   }
 
   test("Build And Proposition via Template") {
-    val routine = "someRoutine"
     val leftEntityIdx = 0
     val rightEntityIdx = 1
     val leftEntityVk = mockVks(leftEntityIdx)
     val rightEntityVk = mockVks(rightEntityIdx)
-    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, leftEntityIdx)
-    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, rightEntityIdx)
+    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, leftEntityIdx)
+    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, rightEntityIdx)
     val andTemplate = PropositionTemplate.AndTemplate[Id](leftSignatureTemplate, rightSignatureTemplate)
     val andInstance = andTemplate.build(mockVks)
     assert(andInstance.isRight)
@@ -94,20 +86,19 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     val rightProposition = andProposition.value.asInstanceOf[And].value.right
     assert(leftProposition.value.isDigitalSignature)
     assert(rightProposition.value.isDigitalSignature)
-    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, leftEntityVk)
-    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, rightEntityVk)
   }
 
   test("Build Or Proposition via Template") {
-    val routine = "someRoutine"
     val leftEntityIdx = 0
     val rightEntityIdx = 1
     val leftEntityVk = mockVks(leftEntityIdx)
     val rightEntityVk = mockVks(rightEntityIdx)
-    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, leftEntityIdx)
-    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, rightEntityIdx)
+    val leftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, leftEntityIdx)
+    val rightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, rightEntityIdx)
     val orTemplate = PropositionTemplate.OrTemplate[Id](leftSignatureTemplate, rightSignatureTemplate)
     val orInstance = orTemplate.build(mockVks)
     assert(orInstance.isRight)
@@ -117,17 +108,14 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     val rightProposition = orProposition.value.asInstanceOf[Or].value.right
     assert(leftProposition.value.isDigitalSignature)
     assert(rightProposition.value.isDigitalSignature)
-    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, leftEntityVk)
-    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(rightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, rightEntityVk)
   }
 
   test("Build Not Proposition via Template") {
-    val chain = "someChain"
-    val min = 0L
-    val max = 100L
-    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](MockChain, MockMin, MockMax)
     val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
     val notInstance = notTemplate.build(mockVks)
     assert(notInstance.isRight)
@@ -135,27 +123,23 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(notProposition.value.isNot)
     val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
     assert(innerProposition.value.isHeightRange)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, MockChain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, MockMin)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, MockMax)
   }
 
   test("Build Threshold Proposition via Template") {
-    val routine = "someRoutine"
     val andLeftEntityIdx = 0
     val andRightEntityIdx = 1
     val andLeftEntityVk = mockVks(andLeftEntityIdx)
     val andRightEntityVk = mockVks(andRightEntityIdx)
-    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andLeftEntityIdx)
-    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](routine, andRightEntityIdx)
+    val andLeftSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, andLeftEntityIdx)
+    val andRightSignatureTemplate = PropositionTemplate.SignatureTemplate[Id](MockSigningRoutine, andRightEntityIdx)
     val andTemplate = PropositionTemplate.AndTemplate[Id](andLeftSignatureTemplate, andRightSignatureTemplate)
-    val chain = "someChain"
-    val min = 0L
-    val max = 100L
-    val heightTemplate = PropositionTemplate.HeightTemplate[Id](chain, min, max)
+    val heightTemplate = PropositionTemplate.HeightTemplate[Id](MockChain, MockMin, MockMax)
     val notTemplate = PropositionTemplate.NotTemplate[Id](heightTemplate)
     val lockedTemplate = PropositionTemplate.LockedTemplate[Id](None)
-    val tickTemplate = PropositionTemplate.TickTemplate[Id](min, max)
+    val tickTemplate = PropositionTemplate.TickTemplate[Id](MockMin, MockMax)
     val orTemplate = PropositionTemplate.OrTemplate[Id](lockedTemplate, tickTemplate)
     val thresholdTemplate = PropositionTemplate.ThresholdTemplate[Id](
       List(andTemplate, notTemplate, orTemplate),
@@ -172,17 +156,17 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     val andRightProposition = andProposition.value.asInstanceOf[And].value.right
     assert(andLeftProposition.value.isDigitalSignature)
     assert(andRightProposition.value.isDigitalSignature)
-    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(andLeftProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andLeftEntityVk)
-    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)
+    assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.routine, MockSigningRoutine)
     assertEquals(andRightProposition.value.asInstanceOf[DigitalSignature].value.verificationKey, andRightEntityVk)
     val notProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(1)
     assert(notProposition.value.isNot)
     val innerProposition = notProposition.value.asInstanceOf[Not].value.proposition
     assert(innerProposition.value.isHeightRange)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, chain)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, min)
-    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, max)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.chain, MockChain)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.min, MockMin)
+    assertEquals(innerProposition.value.asInstanceOf[HeightRange].value.max, MockMax)
     val orProposition = thresholdProposition.value.asInstanceOf[Threshold].value.challenges(2)
     assert(orProposition.value.isOr)
     val orLeftProposition = orProposition.value.asInstanceOf[Or].value.left
@@ -190,7 +174,7 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(orLeftProposition.value.isLocked)
     assertEquals(orLeftProposition.value.asInstanceOf[Locked].value.data, None)
     assert(orRightProposition.value.isTickRange)
-    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, min)
-    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, max)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.min, MockMin)
+    assertEquals(orRightProposition.value.asInstanceOf[TickRange].value.max, MockMax)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
@@ -5,7 +5,7 @@ import co.topl.brambl.MockHelpers
 import co.topl.brambl.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
 import com.google.protobuf.ByteString
 import quivr.models.Proposition.Value._
-import quivr.models.{Data, Digest => DigestValue}
+import quivr.models.Data
 
 class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
 
@@ -47,14 +47,13 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
 
   test("Build Digest Proposition via Template") {
     val routine = "someRoutine"
-    val digest = DigestValue(ByteString.copyFrom("someDigest".getBytes))
-    val digestTemplate = PropositionTemplate.DigestTemplate[Id](routine, digest)
+    val digestTemplate = PropositionTemplate.DigestTemplate[Id](routine, MockDigest)
     val digestInstance = digestTemplate.build(mockVks)
     assert(digestInstance.isRight)
     val digestProposition = digestInstance.toOption.get
     assert(digestProposition.value.isDigest)
     assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, routine)
-    assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, digest)
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, MockDigest)
   }
 
   test("Build Signature Proposition via Template") {
@@ -114,8 +113,8 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(orInstance.isRight)
     val orProposition = orInstance.toOption.get
     assert(orProposition.value.isOr)
-    val leftProposition = orProposition.value.asInstanceOf[And].value.left
-    val rightProposition = orProposition.value.asInstanceOf[And].value.right
+    val leftProposition = orProposition.value.asInstanceOf[Or].value.left
+    val rightProposition = orProposition.value.asInstanceOf[Or].value.right
     assert(leftProposition.value.isDigitalSignature)
     assert(rightProposition.value.isDigitalSignature)
     assertEquals(leftProposition.value.asInstanceOf[DigitalSignature].value.routine, routine)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/codecs/LockTemplateCodecsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/codecs/LockTemplateCodecsSpec.scala
@@ -1,0 +1,41 @@
+package co.topl.brambl.codecs
+
+import cats.Id
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.locks.LockTemplate
+import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
+import co.topl.brambl.codecs.LockTemplateCodecs.{decodeLockTemplate, encodeLockTemplate}
+import io.circe.Json
+
+class LockTemplateCodecsSpec extends munit.FunSuite with MockHelpers {
+
+  def assertEncodeDecode[TemplateType <: LockTemplate[Id]](expectedValue: TemplateType, expectedJson: Json): Unit = {
+    // Decode test
+    val testPropositionRes = decodeLockTemplate[Id](expectedJson)
+    assert(testPropositionRes.isRight)
+    assert(testPropositionRes.toOption.get.isInstanceOf[TemplateType])
+    val templateInstance = testPropositionRes.toOption.get.asInstanceOf[TemplateType]
+    assertEquals(templateInstance, expectedValue)
+
+    // Encode test
+    val testJson = encodeLockTemplate(expectedValue)
+    assert(!testJson.isNull)
+    assertEquals(testJson, expectedJson)
+
+    // Decode then Encode test
+    val encodedFromDecoded = encodeLockTemplate(templateInstance)
+    assert(!encodedFromDecoded.isNull)
+    assertEquals(encodedFromDecoded, expectedJson)
+
+    // Encode then Decode test
+    val decodedFromEncoded = decodeLockTemplate[Id](testJson)
+    assert(decodedFromEncoded.isRight)
+    assert(decodedFromEncoded.toOption.get.isInstanceOf[TemplateType])
+    val templateInstanceFromEncoded = testPropositionRes.toOption.get.asInstanceOf[TemplateType]
+    assertEquals(templateInstanceFromEncoded, expectedValue)
+  }
+
+  test("Encode and Decode Predicate Lock Template") {
+    assertEncodeDecode[PredicateTemplate[Id]](ExpectedPredicateLock.value, ExpectedPredicateLock.json)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/codecs/PropositionTemplateCodecsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/codecs/PropositionTemplateCodecsSpec.scala
@@ -1,0 +1,90 @@
+package co.topl.brambl.codecs
+
+import cats.Id
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.locks.PropositionTemplate
+import co.topl.brambl.builders.locks.PropositionTemplate.{
+  AndTemplate,
+  DigestTemplate,
+  HeightTemplate,
+  LockedTemplate,
+  NotTemplate,
+  OrTemplate,
+  SignatureTemplate,
+  ThresholdTemplate,
+  TickTemplate
+}
+import co.topl.brambl.codecs.PropositionTemplateCodecs.{decodePropositionTemplate, encodePropositionTemplate}
+import io.circe.Json
+
+class PropositionTemplateCodecsSpec extends munit.FunSuite with MockHelpers {
+
+  def assertEncodeDecode[TemplateType <: PropositionTemplate[Id]](
+    expectedValue: TemplateType,
+    expectedJson:  Json
+  ): Unit = {
+    // Decode test
+    val testPropositionRes = decodePropositionTemplate[Id](expectedJson)
+    assert(testPropositionRes.isRight)
+    assert(testPropositionRes.toOption.get.isInstanceOf[TemplateType])
+    val templateInstance = testPropositionRes.toOption.get.asInstanceOf[TemplateType]
+    assertEquals(templateInstance, expectedValue)
+
+    // Encode test
+    val testJson = encodePropositionTemplate(expectedValue)
+    assert(!testJson.isNull)
+    assertEquals(testJson, expectedJson)
+
+    // Decode then Encode test
+    val encodedFromDecoded = encodePropositionTemplate(templateInstance)
+    assert(!encodedFromDecoded.isNull)
+    assertEquals(encodedFromDecoded, expectedJson)
+
+    // Encode then Decode test
+    val decodedFromEncoded = decodePropositionTemplate[Id](testJson)
+    assert(decodedFromEncoded.isRight)
+    assert(decodedFromEncoded.toOption.get.isInstanceOf[TemplateType])
+    val templateInstanceFromEncoded = testPropositionRes.toOption.get.asInstanceOf[TemplateType]
+    assertEquals(templateInstanceFromEncoded, expectedValue)
+  }
+
+  test("Encode and Decode Locked Proposition Template") {
+    assertEncodeDecode[LockedTemplate[Id]](ExpectedLockedProposition.value, ExpectedLockedProposition.json)
+  }
+
+  test("Encode and Decode Height Proposition Template") {
+    assertEncodeDecode[HeightTemplate[Id]](ExpectedHeightProposition.value, ExpectedHeightProposition.json)
+  }
+
+  test("Encode and Decode Tick Proposition Template") {
+    assertEncodeDecode[TickTemplate[Id]](ExpectedTickProposition.value, ExpectedTickProposition.json)
+  }
+
+  test("Encode and Decode Digest Proposition Template") {
+    assertEncodeDecode[DigestTemplate[Id]](ExpectedDigestProposition.value, ExpectedDigestProposition.json)
+  }
+
+  test("Encode and Decode Signature Proposition Template") {
+    assertEncodeDecode[SignatureTemplate[Id]](
+      ExpectedSignatureProposition.value(0),
+      ExpectedSignatureProposition.json(0)
+    )
+  }
+
+  test("Encode and Decode And Proposition Template") {
+    assertEncodeDecode[AndTemplate[Id]](ExpectedAndProposition.value, ExpectedAndProposition.json)
+  }
+
+  test("Encode and Decode Or Proposition Template") {
+    assertEncodeDecode[OrTemplate[Id]](ExpectedOrProposition.value, ExpectedOrProposition.json)
+  }
+
+  test("Encode and Decode Not Proposition Template") {
+    assertEncodeDecode[NotTemplate[Id]](ExpectedNotProposition.value, ExpectedNotProposition.json)
+  }
+
+  test("Encode and Decode Threshold Proposition Template") {
+    assertEncodeDecode[ThresholdTemplate[Id]](ExpectedThresholdProposition.value, ExpectedThresholdProposition.json)
+  }
+
+}


### PR DESCRIPTION
## Purpose

The y layer of the cartesian indexing scheme represents Contract/Lock Templates. These templates must be deterministic and portable to support the ability of sharing across participants. This PR adds the ability to define a new Lock (or proposition) template as well as the ability to instantiate a new instance by providing a list of VerificationKeys (which should map to the x layer of the cartesian indexing).

## Approach

- Added the ability to create Proposition Templates. Proposition Templates generally will not be used by the clients themselves; instead, they will create a Lock Template which contains Proposition templates within it. The following Proposition Templates are possible to be created:
    - Locked
    - Height
    - Tick
    - Digest
    - Signature
    - And
    - Or
    - Not
    - Threshold
- Added the ability to create a Lock Template. The only type of Lock we support are Predicate Locks where the Challenges are of type Revealed.
- Added the ability to instantiate a Lock or Proposition instance using it's respective template and a list of Verification Keys. As mentioned above, clients generally will not need to instantiate a Proposition from it's template, but instead instantiate a Lock (which contains proposition templates within).
-  Added JSON Serialization for Lock and Proposition Templates. The JSON representation should be portable and deterministically result in a Lock (or Proposition) template.
- Added tests for Building Templates/instantiating instances as well as serializing and deserializing the templates.

## Testing

- Added Tests for Building Lock Templates and instantiating Locks via a Template
- Added Tests for Building Proposition Templates and instantiating Propositions via a Template
- Added Tests for Serializing and Deserializing the JSON representation of Lock and Proposition Templates
- Ran `checkPR` and ensured all existing tests pass

## Tickets
* closes TSDK-479
