### PR TITLE
TSDK-480 Added WalletStateAlgebra from brambl-cli

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/DataApi.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.dataApi
 
 import co.topl.brambl.dataApi.DataApi._
-import co.topl.brambl.models.{Evidence, Indices, LockAddress, TransactionOutputAddress}
+import co.topl.brambl.models.{LockAddress, TransactionOutputAddress}
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.crypto.encryption.VaultStore
@@ -37,24 +37,6 @@ trait DataApi[F[_]] {
    * @return The Lock targeted by the given address, if it exists. Else a DataApiException
    */
   def getLockByLockAddress(address: LockAddress): F[Either[DataApiException, Lock]]
-
-  /**
-   * Return the preimage secret associated to a digest proposition.
-   *
-   * @param digestProposition The Digest Proposition for which to retrieve the preimage secret for
-   * @return The preimage secret associated to the Digest Proposition if it exists. Else a DataApiException
-   */
-  def getPreimage(digestProposition: Proposition.Digest): F[Either[DataApiException, Preimage]]
-
-  /**
-   * Return the indices (x/y/z) associated to a signature proposition. A Signature Proposition is created with a
-   * verification and must be signed with the corresponding signing key. The verification and signing key pair is
-   * derived from the indices.
-   *
-   * @param signatureProposition The Signature Proposition for which to retrieve the indices for
-   * @return The indices associated to the Signature Proposition if it exists. Else a DataApiException
-   */
-  def getIndices(signatureProposition: Proposition.DigitalSignature): F[Either[DataApiException, Indices]]
 
   /**
    * Persist a VaultStore for the Topl Main Secret Key.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
@@ -119,18 +119,18 @@ trait WalletStateAlgebra[F[_]] {
    *
    * @param party   A String label of the party to associate the new verification keys with
    * @param contract A String label of the contract to associate the new verification keys with
-   * @param entities The list of Verification Keys to add
+   * @param entities The list of Verification Keys in base58 format to add
    */
-  def addEntityVks(party: String, contract: String, entities: List[VerificationKey]): F[Unit]
+  def addEntityVks(party: String, contract: String, entities: List[String]): F[Unit]
 
   /**
-   * Get the list of entities associated to the given pair of party and contract
+   * Get the list of verification keys associated to the given pair of party and contract
    *
    * @param party   A String label of the party to get the verification keys for
-   * @return The list of entities associated to the given party and contract if possible. Else None.
-   *         It is possible that the list of entities is empty.
+   * @return The list of verification keys in base58 format associated to the given party and contract if possible.
+   *         Else None. It is possible that the list of entities is empty.
    */
-  def getEntityVks(party: String, contract: String): F[Option[List[VerificationKey]]]
+  def getEntityVks(party: String, contract: String): F[Option[List[String]]]
 
   /**
    * Add a new lock template entry to the wallet state's cartesian indexing. Lock templates are at the y (contract)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
@@ -1,0 +1,151 @@
+package co.topl.brambl.wallet
+
+import cats.data.ValidatedNel
+import co.topl.brambl.builders.locks.LockTemplate
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.box.Lock
+import quivr.models.{Preimage, Proposition, VerificationKey}
+
+abstract class WalletStateApiFailure extends RuntimeException
+
+trait WalletStateAlgebra[F[_]] {
+
+  /**
+   * Initialize the wallet state with the given verification key
+   *
+   * @param vk The verification key to initialize the wallet state with
+   */
+  def initWalletState(vk: VerificationKey): F[Unit]
+
+  /**
+   * Get the indices associated to a signature proposition
+   *
+   * @param signatureProposition The signature proposition to get the indices for
+   * @return The indices associated to the signature proposition if it exists. Else None
+   */
+  def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]]
+
+  /**
+   * Get the preimage secret associated to a digest proposition.
+   *
+   * @param digestProposition The Digest Proposition for which to retrieve the preimage secret for
+   * @return The preimage secret associated to the Digest Proposition if it exists. Else None
+   */
+  def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]]
+
+  /**
+   * Get the current address for the wallet state
+   *
+   * @return The current address of the wallet state as a string in base58 encoding
+   */
+  def getCurrentAddress: F[String]
+
+  /**
+   * Update the wallet state with a new set of Predicate Lock, Lock Address, and their associated Indices
+   *
+   * @param lockPredicate The lock predicate to add to the wallet state
+   * @param lockAddress    The lock address to add to the wallet state
+   * @param routine        The routine to add to the wallet state
+   * @param vk             The verification key to add to the wallet state
+   * @param indices        The indices to add to the wallet state
+   */
+  def updateWalletState(
+    lockPredicate: String,
+    lockAddress:   String,
+    routine:       Option[String],
+    vk:            Option[String],
+    indices:       Indices
+  ): F[Unit]
+
+  /**
+   * Get the current indices for the given party, contract and optional state
+   *
+   * @param party   A String label of the party to get the indices for
+   * @param contract A String label of the contract to get the indices for
+   * @param someState The optional state index of the indices. If not provided, the next state index for the given party
+   *                  and contract pair will be used
+   * @return The indices for the given party, contract and optional state if possible. Else None
+   */
+  def getCurrentIndicesForFunds(party: String, contract: String, someState: Option[Int]): F[Option[Indices]]
+
+  /**
+   * Validate that the supplied party, contract and optional state exist and are associated with each other in the
+   * current wallet state
+   *
+   * @param party   A String label of the party to validate with
+   * @param contract A String label of the contract to validate with
+   * @param someState The optional state index to validate with. If not provided, the next state for the given party
+   *                  and contract pair will be used
+   * @return The indices for the given party, contract and optional state if valid. If not, the relevant errors
+   */
+  def validateCurrentIndicesForFunds(
+    party:     String,
+    contract:  String,
+    someState: Option[Int]
+  ): F[ValidatedNel[String, Indices]]
+
+  /**
+   * Get the next available indices for the given party and contract
+   *
+   * @param party   A String label of the party to get the next indices for
+   * @param contract A String label of the contract to get the next indices for
+   * @return The next indices for the given party and contract if possible. Else None
+   */
+  def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]]
+
+  /**
+   * Get the lock predicate associated to the given indices
+   *
+   * @param indices The indices to get the lock predicate for
+   * @return The lock predicate for the given indices if possible. Else None
+   */
+  def getLockByIndex(indices: Indices): F[Option[Lock.Predicate]]
+
+  /**
+   * Get the lock address associated to the given party, contract and optional state
+   *
+   * @param party   A String label of the party to get the lock address for
+   * @param contract A String label of the contract to get the lock address for
+   * @param someState The optional state index to get the lock address for. If not provided, the next state for the
+   *                  given party and contract pair will be used
+   * @return The lock address for the given indices if possible. Else None
+   */
+  def getAddress(party: String, contract: String, someState: Option[Int]): F[Option[String]]
+
+  /**
+   * Add a new entry of entities to the wallet state's cartesian indexing. Entities are at the x (party) layer. This new
+   * entry will be associated to the label given by party. The index of the new entry (and thus associated with the
+   * party label) will be automatically derived by the next available x-index.
+   *
+   * @param party   A String label of the party to associate the new Entries entry with
+   * @param entities The list of Verification Keys of the entities to add to the new Entries entry
+   */
+  def addNewEntities(party: String, entities: List[VerificationKey]): F[Unit]
+
+  /**
+   * Get the list of entities associated to the given party
+   *
+   * @param party   A String label of the party to get the entities for
+   * @return The list of entities associated to the given party if possible. Else None. It is possible that the list of
+   *         entities is empty.
+   */
+  def getEntities(party: String): F[Option[List[VerificationKey]]]
+
+  /**
+   * Add a new lock template entry to the wallet state's cartesian indexing. Lock templates are at the y (contract)
+   * layer. This new entry will be associated to the label given by contract. The index of the new entry (and thus
+   * associated with the contract label) will be automatically derived by the next available y-index.
+   *
+   * @param contract   A String label of the contract to associate the new lockTemplate entry with
+   * @param lockTemplate The list of Lock Templates of the lock templates to add to the new Entries entry
+   */
+  def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[F]): F[Unit]
+
+  /**
+   * Get the lock template associated to the given contract
+   *
+   * @param contract A String label of the contract to get the lock template for
+   * @return The lock template associated to the given contract if possible. Else None.
+   */
+  def getLockTemplate(contract: String): F[Option[LockTemplate[F]]]
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletStateAlgebra.scala
@@ -113,23 +113,24 @@ trait WalletStateAlgebra[F[_]] {
   def getAddress(party: String, contract: String, someState: Option[Int]): F[Option[String]]
 
   /**
-   * Add a new entry of entities to the wallet state's cartesian indexing. Entities are at the x (party) layer. This new
-   * entry will be associated to the label given by party. The index of the new entry (and thus associated with the
-   * party label) will be automatically derived by the next available x-index.
+   * Add a new entry of entity verification keys to the wallet state's cartesian indexing. Entities are at a pair of
+   * x (party) and y (contract) layers and thus represent a Child verification key at a participants own x/y path.
+   * The respective x and y indices of the specified party and contract labels must already exist.
    *
-   * @param party   A String label of the party to associate the new Entries entry with
-   * @param entities The list of Verification Keys of the entities to add to the new Entries entry
+   * @param party   A String label of the party to associate the new verification keys with
+   * @param contract A String label of the contract to associate the new verification keys with
+   * @param entities The list of Verification Keys to add
    */
-  def addNewEntities(party: String, entities: List[VerificationKey]): F[Unit]
+  def addEntityVks(party: String, contract: String, entities: List[VerificationKey]): F[Unit]
 
   /**
-   * Get the list of entities associated to the given party
+   * Get the list of entities associated to the given pair of party and contract
    *
-   * @param party   A String label of the party to get the entities for
-   * @return The list of entities associated to the given party if possible. Else None. It is possible that the list of
-   *         entities is empty.
+   * @param party   A String label of the party to get the verification keys for
+   * @return The list of entities associated to the given party and contract if possible. Else None.
+   *         It is possible that the list of entities is empty.
    */
-  def getEntities(party: String): F[Option[List[VerificationKey]]]
+  def getEntityVks(party: String, contract: String): F[Option[List[VerificationKey]]]
 
   /**
    * Add a new lock template entry to the wallet state's cartesian indexing. Lock templates are at the y (contract)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockDataApi.scala
@@ -32,14 +32,6 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
 
   val lockAddrToLock: Map[LockAddress, Lock] = Map(inLockFullAddress -> inLockFull)
 
-  val propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
-    MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
-  )
-
-  val propEvidenceToIdx: Map[Evidence, Indices] = Map(
-    MockSignatureProposition.value.digitalSignature.get.sizedEvidence -> MockIndices
-  )
-
   override def getUtxoByTxoAddress(
     address: TransactionOutputAddress
   ): Either[DataApiException, UnspentTransactionOutput] =
@@ -47,12 +39,6 @@ object MockDataApi extends DataApi[Id] with MockHelpers {
 
   override def getLockByLockAddress(address: LockAddress): Either[DataApiException, Lock] =
     lockAddrToLock.get(address).toRight(LockNotFound)
-
-  override def getPreimage(digestProposition: Proposition.Digest): Either[DataApiException, Preimage] =
-    propEvidenceToPreimage.get(digestProposition.sizedEvidence).toRight(PreimageNotFound)
-
-  override def getIndices(signatureProposition: Proposition.DigitalSignature): Either[DataApiException, Indices] =
-    propEvidenceToIdx.get(signatureProposition.sizedEvidence).toRight(IndicesNotFound)
 
   override def saveMainKeyVaultStore(
     mainKeyVaultStore: VaultStore[Id],

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -57,9 +57,9 @@ object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
 
   override def getAddress(party: String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
 
-  override def addNewEntities(party: String, entities: List[VerificationKey]): Id[Unit] = ???
+  override def addEntityVks(party: String, contract: String, entities: List[VerificationKey]): Id[Unit] = ???
 
-  override def getEntities(party: String): Id[Option[List[VerificationKey]]] = ???
+  override def getEntityVks(party: String, contract: String): Id[Option[List[VerificationKey]]] = ???
 
   override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -57,9 +57,9 @@ object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
 
   override def getAddress(party: String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
 
-  override def addEntityVks(party: String, contract: String, entities: List[VerificationKey]): Id[Unit] = ???
+  override def addEntityVks(party: String, contract: String, entities: List[String]): Id[Unit] = ???
 
-  override def getEntityVks(party: String, contract: String): Id[Option[List[VerificationKey]]] = ???
+  override def getEntityVks(party: String, contract: String): Id[Option[List[String]]] = ???
 
   override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -1,0 +1,67 @@
+package co.topl.brambl
+
+import cats.Id
+import cats.data.ValidatedNel
+import co.topl.brambl.builders.locks.LockTemplate
+import co.topl.brambl.common.ContainsEvidence.Ops
+import co.topl.brambl.common.ContainsImmutable.instances._
+import co.topl.brambl.models._
+import co.topl.brambl.models.box.Lock
+import co.topl.brambl.wallet.WalletStateAlgebra
+import quivr.models._
+
+/**
+ * Mock Implementation of the WalletStateAlgebra for testing
+ */
+object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
+
+  val propEvidenceToIdx: Map[Evidence, Indices] = Map(
+    MockSignatureProposition.value.digitalSignature.get.sizedEvidence -> MockIndices
+  )
+
+  val propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
+    MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
+  )
+
+  override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): Option[Indices] =
+    propEvidenceToIdx.get(signatureProposition.sizedEvidence)
+
+  override def getPreimage(digestProposition: Proposition.Digest): Option[Preimage] =
+    propEvidenceToPreimage.get(digestProposition.sizedEvidence)
+
+  // The following are not implemented since they are not used in the tests
+  override def initWalletState(vk: VerificationKey): Id[Unit] = ???
+
+  override def getCurrentAddress: Id[String] = ???
+
+  override def updateWalletState(
+    lockPredicate: String,
+    lockAddress:   String,
+    routine:       Option[String],
+    vk:            Option[String],
+    indices:       Indices
+  ): Id[Unit] = ???
+
+  override def getCurrentIndicesForFunds(party: String, contract: String, someState: Option[Int]): Id[Option[Indices]] =
+    ???
+
+  override def validateCurrentIndicesForFunds(
+    party:     String,
+    contract:  String,
+    someState: Option[Int]
+  ): Id[ValidatedNel[String, Indices]] = ???
+
+  override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
+
+  override def getLockByIndex(indices: Indices): Id[Option[Lock.Predicate]] = ???
+
+  override def getAddress(party: String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
+
+  override def addNewEntities(party: String, entities: List[VerificationKey]): Id[Unit] = ???
+
+  override def getEntities(party: String): Id[Option[List[VerificationKey]]] = ???
+
+  override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
+
+  override def getLockTemplate(contract: String): Id[Option[LockTemplate[Id]]] = ???
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -545,8 +545,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
       override def getLockByIndex(indices:       Indices): Id[Option[Lock.Predicate]] = ???
       override def getAddress(party:   String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
-      override def addEntityVks(party: String, contract: String, entities:  List[VerificationKey]): Id[Unit] = ???
-      override def getEntityVks(party: String, contract: String): Id[Option[List[VerificationKey]]] = ???
+      override def addEntityVks(party: String, contract: String, entities:  List[String]): Id[Unit] = ???
+      override def getEntityVks(party: String, contract: String): Id[Option[List[String]]] = ???
       override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
       override def getLockTemplate(contract:    String): Id[Option[LockTemplate[Id]]] = ???
     }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -544,9 +544,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       ): Id[ValidatedNel[String, Indices]] = ???
       override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
       override def getLockByIndex(indices:       Indices): Id[Option[Lock.Predicate]] = ???
-      override def getAddress(party:     String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
-      override def addNewEntities(party: String, entities: List[VerificationKey]): Id[Unit] = ???
-      override def getEntities(party:    String): Id[Option[List[VerificationKey]]] = ???
+      override def getAddress(party:   String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
+      override def addEntityVks(party: String, contract: String, entities:  List[VerificationKey]): Id[Unit] = ???
+      override def getEntityVks(party: String, contract: String): Id[Option[List[VerificationKey]]] = ???
       override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
       override def getLockTemplate(contract:    String): Id[Option[LockTemplate[Id]]] = ???
     }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -1,11 +1,13 @@
 package co.topl.brambl.wallet
 
 import cats.Id
+import cats.data.ValidatedNel
 import cats.implicits._
+import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
-import co.topl.brambl.{Context, MockDataApi, MockHelpers}
+import co.topl.brambl.{Context, MockDataApi, MockHelpers, MockWalletStateApi}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
 import co.topl.brambl.dataApi.DataApi
@@ -21,16 +23,18 @@ import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
   LockedPropositionIsUnsatisfiable
 }
 import com.google.protobuf.ByteString
-import quivr.models.{Int128, KeyPair, Preimage, Proof, Proposition}
+import quivr.models.{Int128, KeyPair, Preimage, Proof, Proposition, VerificationKey}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.encryption.VaultStore
 
 import scala.util.Random
 
 class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
+  val walletApi: WalletApi[Id] = WalletApi.make[Id](MockDataApi)
 
   test("prove: Single Input Transaction with Attestation.Predicate > Provable propositions have non-empty proofs") {
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(txFull)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(txFull)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
     val nonEmpty = provenPredicate.responses.forall(proof => !proof.value.isEmpty)
@@ -55,7 +59,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(attestation = testAttestation)))
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(testTx)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
     val correctLen = provenPredicate.lock.challenges.length == 2
@@ -65,7 +70,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("validate: Single Input Transaction with Attestation.Predicate > Validation successful") {
-    val credentialler = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
     val provenTx: IoTransaction = credentialler.prove(txFull)
     val ctx = Context[Id](txFull, 50, _ => None) // Tick satisfies a proposition
     val errsNum = credentialler.validate(provenTx, ctx).length
@@ -78,7 +83,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val negativeValue: Value =
       Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
-    val credentialler = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
     val provenTx: IoTransaction = credentialler.prove(testTx)
     val ctx = Context[Id](testTx, 500, _ => None) // Tick does not satisfies proposition
     val errs = credentialler.validate(provenTx, ctx)
@@ -128,7 +133,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation successful") {
-    val credentialler = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
     val ctx = Context[Id](txFull, 50, _ => None) // Tick satisfies a proposition
     val res = credentialler.proveAndValidate(txFull, ctx)
 
@@ -138,7 +143,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation failed") {
     val negativeValue: Value =
       Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
-    val credentialler = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val ctx = Context[Id](testTx, 500, _ => None) // Tick does not satisfies proposition
     val res = credentialler.proveAndValidate(testTx, ctx)
@@ -150,7 +155,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     "proveAndValidate: Credentialler initialized with a main key different than used to create Single Input Transaction with Attestation.Predicate > Validation Failed"
   ) {
     val differentKeyPair = WalletApi.make[Id](MockDataApi).deriveChildKeys(MockMainKeyPair, Indices(0, 0, 1))
-    val credentialler = CredentiallerInterpreter.make[Id](MockDataApi, differentKeyPair)
+    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, differentKeyPair)
     // Tick satisfies its proposition. Height does not.
     val ctx = Context[Id](txFull, 50, _ => None)
     val res = credentialler.proveAndValidate(txFull, ctx)
@@ -183,7 +188,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(testTx)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val threshProof = provenPredicate.responses.head
@@ -206,7 +212,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(testTx)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val andProof = provenPredicate.responses.head
@@ -227,7 +234,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(testTx)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val orProof = provenPredicate.responses.head
@@ -247,7 +255,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val provenTx: IoTransaction = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).prove(testTx)
+    val provenTx: IoTransaction =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val notProof = provenPredicate.responses.head
@@ -270,7 +279,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -295,7 +305,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -318,7 +329,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 500, _ => None) // Tick and height should fail
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -342,7 +354,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -369,7 +382,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     // Both Tick and Height should pass
     val ctx = Context[Id](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -394,7 +408,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     // Both Tick and Height should pass
     val ctx = Context[Id](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -418,7 +433,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -442,7 +458,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 50, _ => None)
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -466,7 +483,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val ctx = Context[Id](testTx, 500, _ => None) // Tick should fail
-    val res = CredentiallerInterpreter.make[Id](MockDataApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+    val res =
+      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -495,39 +513,45 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     val bobSignatureProposition = Proposer.signatureProposer[Id].propose(("ExtendedEd25519", bobChildKey.vk))
     // To Mock someone else's DataApi
-    object NewDataApi extends DataApi[Id] {
-      case object Invalid extends DataApi.DataApiException("Invalid Call. Should not reach here.")
-
+    object NewWalletStateApi extends WalletStateAlgebra[Id] {
       // The only relevant call is getIndices
-      override def getIndices(
+      override def getIndicesBySignature(
         signatureProposition: Proposition.DigitalSignature
-      ): Id[Either[DataApi.DataApiException, Indices]] =
+      ): Id[Option[Indices]] =
         Map(
           bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
-        ).get(signatureProposition.sizedEvidence).toRight(Invalid)
+        ).get(signatureProposition.sizedEvidence)
 
-      override def getUtxoByTxoAddress(
-        address: TransactionOutputAddress
-      ): Id[Either[DataApi.DataApiException, UnspentTransactionOutput]] = Invalid.asLeft[UnspentTransactionOutput]
-      override def getLockByLockAddress(address: LockAddress): Id[Either[DataApi.DataApiException, Lock]] =
-        Invalid.asLeft[Lock]
-      override def getPreimage(digestProposition: Proposition.Digest): Id[Either[DataApi.DataApiException, Preimage]] =
-        Invalid.asLeft[Preimage]
-      override def saveMainKeyVaultStore(
-        mainKeyVaultStore: VaultStore[Id],
-        name:              String
-      ): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
-      override def getMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, VaultStore[Id]]] =
-        Invalid.asLeft[VaultStore[Id]]
-      override def updateMainKeyVaultStore(
-        mainKeyVaultStore: VaultStore[Id],
-        name:              String
-      ): Id[Either[DataApi.DataApiException, Unit]] = Invalid.asLeft[Unit]
-      override def deleteMainKeyVaultStore(name: String): Id[Either[DataApi.DataApiException, Unit]] =
-        Invalid.asLeft[Unit]
+      override def initWalletState(vk:            VerificationKey): Id[Unit] = ???
+      override def getPreimage(digestProposition: Proposition.Digest): Id[Option[Preimage]] = ???
+      override def getCurrentAddress: Id[String] = ???
+      override def updateWalletState(
+        lockPredicate: String,
+        lockAddress:   String,
+        routine:       Option[String],
+        vk:            Option[String],
+        indices:       Indices
+      ): Id[Unit] = ???
+      override def getCurrentIndicesForFunds(
+        party:     String,
+        contract:  String,
+        someState: Option[Int]
+      ): Id[Option[Indices]] = ???
+      override def validateCurrentIndicesForFunds(
+        party:     String,
+        contract:  String,
+        someState: Option[Int]
+      ): Id[ValidatedNel[String, Indices]] = ???
+      override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
+      override def getLockByIndex(indices:       Indices): Id[Option[Lock.Predicate]] = ???
+      override def getAddress(party:     String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
+      override def addNewEntities(party: String, entities: List[VerificationKey]): Id[Unit] = ???
+      override def getEntities(party:    String): Id[Option[List[VerificationKey]]] = ???
+      override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
+      override def getLockTemplate(contract:    String): Id[Option[LockTemplate[Id]]] = ???
     }
-    val aliceDataApi = MockDataApi
-    val bobDataApi = NewDataApi
+    val aliceDataApi = MockWalletStateApi
+    val bobDataApi = NewWalletStateApi
     val innerPropositions = List(
       Proposer.andProposer[Id].propose((MockTickProposition, aliceSignatureProposition)),
       Proposer.orProposer[Id].propose((MockDigestProposition, MockLockedProposition)),
@@ -555,14 +579,14 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     )
     val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
     // the following is used to mimic the initial proving of the transaction by alice.
-    val credentialler1 = CredentiallerInterpreter.make[Id](aliceDataApi, aliceMainKey)
+    val credentialler1 = CredentiallerInterpreter.make[Id](walletApi, aliceDataApi, aliceMainKey)
     val partiallyProven = credentialler1.prove(testTx) // should create a partially proven tx
     // Should not be validated since not sufficiently proven
     val res1 = credentialler1.validate(partiallyProven, ctx)
     assert(res1.length == 1)
     assertEquals(partiallyProven.signable.value, testTx.signable.value)
     // the following is used to mimic the second proving of the transaction by bob.
-    val credentialler2 = CredentiallerInterpreter.make[Id](bobDataApi, bobMainKey)
+    val credentialler2 = CredentiallerInterpreter.make[Id](walletApi, bobDataApi, bobMainKey)
     val completelyProven = credentialler2.prove(partiallyProven) // should create a completely proven tx
     // Should be validated since sufficiently proven
     val res2 = credentialler2.validate(completelyProven, ctx)


### PR DESCRIPTION
## Purpose

API definitions for the functions to track wallet state should be migrated to BramblSc from brambl-cli since they will be required by other components in BramblSc. For ex, Credentialler, TransactionBuilder (in TSDK-489), LockBuilder (in TSDK-482), etc.

## Approach

- Migrated the WalletStateAlgebra trait from brambl-cli to BramblSc. Added scaladoc
- Added 4 additional functions for tracking x and y entries; Add and get entities (verification keys) + add and get lock templates
- Moved getIndices and getPreimage to  WalletStateAlgebra  from DataApi
- Credentialler now takes in WalletStateAlgebra  and WalletApi instead of DataApi since it no longer requires the latter

## Testing

- Updated the Credentialler tests to align with the changes
- Ran `checkPR` and ensured was successful

## Tickets
* Part of TSDK-480
* Part of TSDK-481