### PR TITLE
TSDK-496 Prepare to Deploy to Maven

### DIFF
--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -24,4 +24,3 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          CI_SONATYPE_RELEASE: ${{ secrets.CI_SONATYPE_RELEASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val commonSettings = Seq(
     "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
     "Sonatype Staging" at "https://s01.oss.sonatype.org/content/repositories/staging",
     "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
+    "Sonatype Releases s01" at "https://s01.oss.sonatype.org/content/repositories/releases/",
     "Bintray" at "https://jcenter.bintray.com/",
     "jitpack" at "https://jitpack.io"
   ),
@@ -46,7 +47,7 @@ lazy val commonSettings = Seq(
 
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/Topl/BramblSc")),
-  sonatypeCredentialHost := "s01.oss.sonatype.org",
+  ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
   sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   Test / publishArtifact := false,
   pomIncludeRepository := { _ => false },

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "daa517d" // scala-steward:off
-    val protobufSpecsVersion = "e03a093" // scala-steward:off
+    val quivr4sVersion = "2.0.0-alpha1"
+    val protobufSpecsVersion = "2.0.0-alpha2"
     val mUnitTeVersion = "0.7.29"
   }
 
@@ -57,11 +57,11 @@ object Dependencies {
   )
 
   val protobufSpecs: Seq[ModuleID] = Seq(
-    "com.github.Topl.protobuf-specs" %% "protobuf-fs2" % protobufSpecsVersion
+    "co.topl" %% "protobuf-fs2" % protobufSpecsVersion
   )
 
   val quivr4s: Seq[ModuleID] = Seq(
-    "com.github.Topl" % "quivr4s" % quivr4sVersion
+    "co.topl" %% "quivr4s" % quivr4sVersion
   )
 
   object Crypto {


### PR DESCRIPTION
## Purpose

In preparation to deploy BramblSc to maven, some changes were made.

## Approach

 The tooling was already added in https://github.com/Topl/BramblSc/pull/50 , however this PR contains minor changes; prefixing `sonatypeCredentialHost` with `ThisBuild / ` and the `https://s01.oss.sonatype.org/content/repositories/releases/` resolver.

Additionally, the Topl dependencies (protobuf-specs and quivr4s) were also updated from jitpack to the released Maven artifacts. 

## Testing

- ensured released Topl dependencies from Maven are being used
![image](https://github.com/Topl/BramblSc/assets/17934976/bd921743-601c-4428-81c2-dcc61738116a)
- ran unit tests in both projects and ensured successful (sanity)
- ran `sbt checkPR` and ensured successful (sanity)
- ran `sbt publishLocal` and ensured successful (sanity)

The deployment will be tested after this PR is merged in and the 2.0.0-alpha1 tag is pushed

## Tickets
* TSDK-496