### PR TITLE
TSDK-530 Minor fixes to Locked and Digest Proposition Templates

### DIFF
--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -1,6 +1,7 @@
 package co.topl.brambl
 
 import cats.Id
+import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.{
   AndTemplate,
@@ -24,11 +25,13 @@ import co.topl.brambl.models.box.Challenge
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction._
+import co.topl.brambl.utils.Encoding.encodeToBase58
 import co.topl.crypto.hash.Blake2b256
 import co.topl.quivr.api.Proposer
 import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
 import quivr.models.{
+  Data,
   Digest,
   Int128,
   KeyPair,
@@ -177,10 +180,12 @@ trait MockHelpers {
   )
 
   object ExpectedLockedProposition {
-    val value: LockedTemplate[Id] = LockedTemplate[Id](None)
+    val data: Array[Byte] = "Hello world".getBytes
+    val value: LockedTemplate[Id] = LockedTemplate[Id](Data(ByteString.copyFrom(data)).some)
 
     val fields: List[(String, Json)] = List(
-      "type" -> Json.fromString(value.propositionType.label)
+      "type" -> Json.fromString(value.propositionType.label),
+      "data" -> Json.fromString(encodeToBase58(data))
     )
     val json: Json = Json.fromFields(fields)
   }
@@ -214,7 +219,7 @@ trait MockHelpers {
     val fields: List[(String, Json)] = List(
       "type"    -> Json.fromString(value.propositionType.label),
       "routine" -> Json.fromString(MockDigestRoutine),
-      "digest"  -> Json.fromString(Strings.fromByteArray(MockDigest.value.toByteArray))
+      "digest"  -> Json.fromString(encodeToBase58(MockDigest.value.toByteArray))
     )
     val json: Json = Json.fromFields(fields)
   }


### PR DESCRIPTION
## Purpose

There was a bug in Locked Proposition templates where instead of storing the value of the Locked data, we stored the string representation of the bytestring.
 In addition, the digest within the Digest Proposition Template was not human readable.

## Approach

- For encoding Locked to JSON, instead of using `a.data.get.value.toString`, we use `encodeToBase58(a.data.get.value.toByteArray)`
- For decoding Locked from JSON, we `decodeFromBase58` and then convert the decoded data into Locked Proposition. If decoding the data fails, we use a Custom Decoding (circe's DecodingFailure) reason
- For encoding Digest to JSON, instead of using `Strings.fromByteArray`, we use `encodeToBase58`
- For decoding Digest from JSON, we parse the digest value then `decodeFromBase58`. If successful we convert the decoded data into Digest Proposition. If it failed, we use a Custom Decoding (circe's DecodingFailure) reason

## Testing

- Updated MockData that is used in the unit tests. Previously we didnt test the optional data within the Locked proposition (which is why it was not caught). Ensured all tests pass
![image](https://github.com/Topl/BramblSc/assets/17934976/744c1683-a3e2-402d-8806-4f3c4ae6ae3a)
- Ran `checkPR`
- Printed the new JSONs manually to ensure it appears in base58: (locked and digest)
![image](https://github.com/Topl/BramblSc/assets/17934976/2bca87a2-f368-4446-8b22-aad3f5e58139)
![image](https://github.com/Topl/BramblSc/assets/17934976/6caf69d7-5f96-4cea-91c7-4d6e1bba59ef)


## Tickets
* Closes TSDK-530
