### PR TITLE
Updated README.md with updated consumption instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 Topl's Brambl SDK implemented in Scala
 
-Multiple artifacts will be built from this repo. Some will be just for Topl clients and some will be shared. Currently 
+Multiple artifacts will be built from this repo. Some will be just for Topl clients and some will be shared. 
 
-This repo should be consumed using jitpack. Here is how:
+## Consume with JitPack
+
+This repo can be consumed using jitpack. Here is how:
 
 First, be sure to add jitpack to the end of the resolvers list in build.sbt. It should look like this:
 ```sbt
@@ -16,12 +18,40 @@ First, be sure to add jitpack to the end of the resolvers list in build.sbt. It 
     "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
     "Bintray" at "https://jcenter.bintray.com/",
     "jitpack" at "https://jitpack.io"
+  )
 ```
 
 Then just add the dependency like this:
 ```sbt
-  val bramblScCrypto =
-    "com.github.Topl" % "BramblSc" % "v2.0.3"
+  val bramblSc =
+    "com.github.Topl" % "BramblSc" % "1bdc895"
+```
+Where `1bdc895` refers to a commit on this repo's main branch. This will add the artifacts for both `brambl-sdk` and `crypto`.
+Then just use the dependencies like you would any other.
+
+## Consume Maven Release
+
+First, be sure to add Sonatype s01 releases to the end of the resolvers list in build.sbt. It should look like this:
+```sbt
+  resolvers ++= Seq(
+    "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
+    "Sonatype Staging" at "https://s01.oss.sonatype.org/content/repositories/staging",
+    "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
+    "Bintray" at "https://jcenter.bintray.com/",
+    "jitpack" at "https://jitpack.io",
+    "Sonatype Releases" at "https://s01.oss.sonatype.org/content/repositories/releases/"
+  )
 ```
 
-Replace the release in the example with the latest release. Then just use the dependency like you would any other.
+Then just add the dependencies for `brambl-sdk` and `crypto` like this:
+```sbt
+  val brambl-sdk =
+    "co.topl" %% "brambl-sdk" % "2.0.0-alpha1"
+```
+
+```sbt
+  val crypto =
+    "co.topl" %% "crypto" % "2.0.0-alpha1"
+```
+
+Replace `2.0.0-alpha1` with the latest released version. Then just use the dependencies like you would any other.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/topl/bramblsc?label=release&sort=semver&style=plastic)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/topl/bramblsc?label=release&style=plastic)
 
 # BramblSc
 


### PR DESCRIPTION
## Purpose

- In addition to Jitpack, BramblSc can be consumed via maven releases. The README should be updated to reflect that
- This will serve as a test to https://github.com/Topl/BramblSc/pull/77

## Approach

- updated README.md

## Testing

n/a

## Tickets
* No ticket
* Tests TSDK-507