### PR TITLE
Update quivr4s to 2.0.0-alpha2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,6 @@ lazy val bramblSdk = project
       Dependencies.BramblSdk.sources ++
       Dependencies.BramblSdk.tests,
     scalamacrosParadiseSettings,
-    dependencyOverrides ++= Dependencies.protobufSpecs
   )
   .dependsOn(crypto)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val catsCoreVersion = "2.9.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.5"
-    val quivr4sVersion = "2.0.0-alpha1"
+    val quivr4sVersion = "2.0.0-alpha2"
     val protobufSpecsVersion = "2.0.0-alpha2"
     val mUnitTeVersion = "0.7.29"
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
   object BramblSdk {
 
     lazy val sources: Seq[ModuleID] =
-      quivr4s
+      quivr4s ++ Dependencies.protobufSpecs
 
     lazy val tests: Seq[ModuleID] =
       (


### PR DESCRIPTION
Update quivr4s to 2.0.0-alpha2

## Purpose

Update quivr4s dependency.

## Approach

Update quivr4s dependency.

## Testing

N/A

## Tickets
* Updated for release as part of ticket TSDK-470

