### PR TITLE
TSDK-531 Set up Scala Service Kit Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Topl's Brambl SDK implemented in Scala
 
 Multiple artifacts will be built from this repo. Some will be just for Topl clients and some will be shared. 
 
+The artifacts generated from this repo are:
+
+- brambl-sdk
+- crypto
+- service-kit
+
 ## Consume with JitPack
 
 This repo can be consumed using jitpack. Here is how:

--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,20 @@ lazy val bramblSdk = project
   )
   .dependsOn(crypto)
 
+lazy val serviceKit = project
+  .in(file("service-kit"))
+  .settings(
+    name := "service-kit",
+    commonSettings,
+    publishSettings,
+    Test / publishArtifact := true,
+    libraryDependencies ++=
+      Dependencies.ServiceKit.sources ++
+        Dependencies.ServiceKit.tests,
+    scalamacrosParadiseSettings,
+  )
+  .dependsOn(bramblSdk)
+
 lazy val brambl = project
   .in(file("."))
   .settings(
@@ -115,7 +129,8 @@ lazy val brambl = project
   .enablePlugins(ReproducibleBuildsPlugin)
   .aggregate(
     crypto,
-    bramblSdk
+    bramblSdk,
+    serviceKit
   )
 
 addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,4 +94,13 @@ object Dependencies {
           scalamock
       ).map(_ % Test)
   }
+
+  object ServiceKit {
+
+    lazy val sources: Seq[ModuleID] = Seq()
+
+    lazy val tests: Seq[ModuleID] = (
+        mUnitTest
+      ).map(_ % Test)
+  }
 }

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
@@ -1,0 +1,33 @@
+package co.topl.brambl.servicekit
+
+import cats.effect.kernel.{Resource, Sync}
+import co.topl.brambl.dataApi.WalletKeyApiAlgebra
+import co.topl.crypto.encryption.VaultStore
+
+import java.io.PrintWriter
+import scala.io.Source
+
+object WalletKeyApi {
+
+  def make[F[_]: Sync](): WalletKeyApiAlgebra[F] =
+    new WalletKeyApiAlgebra[F] {
+
+      override def updateMainKeyVaultStore(
+        mainKeyVaultStore: VaultStore[F],
+        name:              String
+      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+
+      override def deleteMainKeyVaultStore(
+        name: String
+      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+
+      override def saveMainKeyVaultStore(
+        mainKeyVaultStore: VaultStore[F],
+        name:              String
+      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+
+      override def getMainKeyVaultStore(
+        name: String
+      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, VaultStore[F]]] = ???
+    }
+}

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -1,0 +1,86 @@
+package co.topl.brambl.servicekit
+
+import cats.data.ValidatedNel
+import cats.effect.kernel.Sync
+import co.topl.brambl.builders.locks.LockTemplate
+import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.box.Lock
+import quivr.models.Preimage
+import quivr.models.Proposition
+import quivr.models.VerificationKey
+
+object WalletStateApi {
+
+  def make[F[_]: Sync](): WalletStateAlgebra[F] =
+    new WalletStateAlgebra[F] {
+
+      override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]] = ???
+
+      def getLockByIndex(indices: Indices): F[Option[Lock.Predicate]] = ???
+
+      override def updateWalletState(
+        lockPredicate: String,
+        lockAddress:   String,
+        routine:       Option[String],
+        vk:            Option[String],
+        indices:       Indices
+      ): F[Unit] = ???
+
+      override def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]] = ???
+
+      def validateCurrentIndicesForFunds(
+        party:     String,
+        contract:  String,
+        someState: Option[Int]
+      ): F[ValidatedNel[String, Indices]] = ???
+
+      override def getAddress(
+        party:     String,
+        contract:  String,
+        someState: Option[Int]
+      ): F[Option[String]] = ???
+
+      override def getCurrentIndicesForFunds(
+        party:     String,
+        contract:  String,
+        someState: Option[Int]
+      ): F[Option[Indices]] = ???
+
+      override def getCurrentAddress: F[String] = ???
+
+      override def initWalletState(
+        vk: VerificationKey
+      ): F[Unit] = ???
+
+      override def getPreimage(
+        digestProposition: Proposition.Digest
+      ): F[Option[Preimage]] = ???
+
+      override def addEntityVks(
+        party:    String,
+        contract: String,
+        entities: List[String]
+      ): F[Unit] = ???
+
+      override def getEntityVks(
+        party:    String,
+        contract: String
+      ): F[Option[List[String]]] = ???
+
+      override def addNewLockTemplate(
+        contract:     String,
+        lockTemplate: LockTemplate[F]
+      ): F[Unit] = ???
+
+      override def getLockTemplate(
+        contract: String
+      ): F[Option[LockTemplate[F]]] = ???
+
+      override def getLock(
+        party:     String,
+        contract:  String,
+        nextState: Int
+      ): F[Option[Lock]] = ???
+    }
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
@@ -1,0 +1,8 @@
+package co.topl.brambl.servicekit
+
+class WalletKeyApiSpec extends munit.FunSuite {
+
+  test("test placeholder") {
+    assert(true)
+  }
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -1,0 +1,8 @@
+package co.topl.brambl.servicekit
+
+class WalletStateApiSpec extends munit.FunSuite {
+
+  test("test placeholder") {
+    assert(true)
+  }
+}


### PR DESCRIPTION
## Purpose

To set up the Scala Service Kit Project. This PR does not contain any actual implementation; This will come with TSDK-532

## Approach

- Add project settings for service-kit. Mostly mirrors the settings for brambl-sdk project but with it's own dependencies and instead of depending on crypto, it depends on brambl-sdk. The dependencies are mostly empty for now
- Add service-kit to brambl project
- Added empty implementations for files that will be in the service kit. 

## Testing

- Ran `sbt checkPR` and `sbt test` to ensure that the placeholder tests run. The former is the tests ran for CI
- Verifying if the service-kit package is part of the maven release will come after this PR is merged (I will manually verify if it is added to the snapshot releases)

## Tickets
* Closes TSDK-531
