### PR TITLE
TSDK-532 Scala Service Kit Implementation

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/ContractStorageAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/ContractStorageAlgebra.scala
@@ -1,0 +1,36 @@
+package co.topl.brambl.dataApi
+
+/**
+ * @param yIdx The Y coordinate associated with the contract
+ * @param name The name of the contract
+ * @param lockTemplate The lock template associated with the contract
+ */
+case class WalletContract(yIdx: Int, name: String, lockTemplate: String)
+
+/**
+ * Defines a contract storage API.
+ */
+trait ContractStorageAlgebra[F[_]] {
+
+  /**
+   * Fetches all contracts.
+   * @return The fetched contracts.
+   */
+  def findContracts(): F[Seq[WalletContract]]
+
+  /**
+   * Add a new contract.
+   * @param walletContract The wallet contract to add.
+   */
+  def addContract(walletContract: WalletContract): F[Int]
+}
+
+object ContractStorageAlgebra {
+
+  /**
+   * @param yIdx         The Y coordinate associated with the contract
+   * @param name         The name of the contract
+   * @param lockTemplate The lock template associated with the contract
+   */
+  case class WalletContract(yIdx: Int, name: String, lockTemplate: String)
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/ContractStorageAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/ContractStorageAlgebra.scala
@@ -24,13 +24,3 @@ trait ContractStorageAlgebra[F[_]] {
    */
   def addContract(walletContract: WalletContract): F[Int]
 }
-
-object ContractStorageAlgebra {
-
-  /**
-   * @param yIdx         The Y coordinate associated with the contract
-   * @param name         The name of the contract
-   * @param lockTemplate The lock template associated with the contract
-   */
-  case class WalletContract(yIdx: Int, name: String, lockTemplate: String)
-}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/PartyStorageAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/PartyStorageAlgebra.scala
@@ -1,0 +1,25 @@
+package co.topl.brambl.dataApi
+
+/**
+ * @param xIdx The X coordinate associated with the entity
+ * @param name The name of the entity
+ */
+case class WalletEntity(xIdx: Int, name: String)
+
+/**
+ * Defines a party storage API.
+ */
+trait PartyStorageAlgebra[F[_]] {
+
+  /**
+   * Fetches all parties.
+   * @return The fetched parties.
+   */
+  def findParties(): F[Seq[WalletEntity]]
+
+  /**
+   * Add a new party.
+   * @param walletEntity The wallet entity to add.
+   */
+  def addParty(walletEntity: WalletEntity): F[Int]
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletKeyApiAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletKeyApiAlgebra.scala
@@ -20,6 +20,15 @@ trait WalletKeyApiAlgebra[F[_]] {
   def saveMainKeyVaultStore(mainKeyVaultStore: VaultStore[F], name: String): F[Either[WalletKeyException, Unit]]
 
   /**
+   * Persist a mnemonic used to recover a Topl Main Secret Key.
+   *
+   * @param mnemonic          The mnemonic to persist
+   * @param mnemonicName      The name identifier of the mnemonic.
+   * @return nothing if successful. If persisting fails due to an underlying cause, return a WalletKeyException
+   */
+  def saveMnemonic(mnemonic: IndexedSeq[String], mnemonicName: String): F[Either[WalletKeyException, Unit]]
+
+  /**
    * Return the VaultStore for the Topl Main Secret Key.
    *
    * @param name The name identifier  of the VaultStore. This is used to manage multiple wallet identities.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -236,28 +236,6 @@ trait WalletApi[F[_]] {
   ): F[Either[WalletApi.WalletApiFailure, VaultStore[F]]]
 
   /**
-   * Recover and persist wallet information from the VaultStore and optionally a snapshot.
-   *
-   * @note Without the snapshot, the wallet can only be partially recovered. The recoverable data includes only address
-   *       and fund information for simple 1-of-1 signature transactions. For more complex transactions, the snapshot is
-   *       required.
-   *
-   * @param mainKeyVaultStore The VaultStore containing the main key of the wallet to recover
-   * @param password The password to decrypt the VaultStore
-   * @param name A name used to identify a wallet in the DataApi. Defaults to "default". Most commonly, only one
-   *             wallet identity will be used. It is the responsibility of the dApp to keep track of the names of
-   *             the wallet identities if multiple will be used.
-   * @param snapshot The snapshot to recover the wallet from
-   * @return The wallet's VaultStore if import and save was successful. An error if unsuccessful.
-   */
-  def recoverWallet(
-    mainKeyVaultStore: VaultStore[F],
-    password:          Array[Byte],
-    name:              String = "default",
-    snapshot:          Option[Any] = None
-  ): F[Either[WalletApi.WalletApiFailure, Unit]]
-
-  /**
    * Import a wallet from a mnemonic and save it.
    *
    * @param mnemonic   The mnemonic to import
@@ -276,9 +254,8 @@ trait WalletApi[F[_]] {
   ): G[Either[WalletApi.WalletApiFailure, VaultStore[F]]] = {
     val toMonad = implicitly[ToMonad[G]]
     (for {
-      walletRes  <- EitherT(toMonad(importWallet(mnemonic, password, passphrase)))
-      saveRes    <- EitherT(toMonad(saveWallet(walletRes, name)))
-      recoverRes <- EitherT(toMonad(recoverWallet(walletRes, password, name)))
+      walletRes <- EitherT(toMonad(importWallet(mnemonic, password, passphrase)))
+      saveRes   <- EitherT(toMonad(saveWallet(walletRes, name)))
     } yield walletRes).value
   }
 
@@ -381,64 +358,6 @@ object WalletApi {
       mainKey    <- EitherT(Monad[F].pure(entropyToMainKey(entropy, passphrase).toByteArray.asRight[WalletApiFailure]))
       vaultStore <- EitherT(buildMainKeyVaultStore(mainKey, password).map(_.asRight[WalletApiFailure]))
     } yield vaultStore).value
-
-    override def recoverWallet(
-      mainKeyVaultStore: VaultStore[F],
-      password:          Array[Byte],
-      name:              String = "default",
-      snapshot:          Option[Any] = None
-    ): F[Either[WalletApiFailure, Unit]] = (for {
-      // recover 1-of-1 simple information (build lock addresses for each key pair in 0/0/z)
-      mainKey    <- EitherT(extractMainKey(mainKeyVaultStore, password))
-      recoverRes <- EitherT(recoverFromMainKey(mainKey, name))
-      // recover complex information from snapshot
-      snapshotRes <- EitherT(snapshot.map(recoverFromSnapshot(_, name)).getOrElse(().asRight[WalletApiFailure].pure[F]))
-    } yield snapshotRes.combine(recoverRes)).value
-
-    /**
-     * Recover wallet information from a provided snapshot
-     *
-     * TODO: To be implemented when the recovery from snapshot process has been fleshed out
-     *
-     * At a high level, the snapshot should be parsed and then the contained information should be stored in the DataApi
-     * associated with the wallet of name `name`.
-     *
-     * TODO: What should the type of snapshot be?
-     *
-     * @param snapshot The snapshot to recover the wallet from
-     * @param name The name of the wallet to recover
-     * @return A unit value if the recovery was successful, otherwise a WalletApiFailure
-     */
-    private def recoverFromSnapshot(snapshot: Any, name: String): F[Either[WalletApiFailure, Unit]] =
-      ().asRight[WalletApiFailure].pure[F]
-
-    /**
-     * Recover partial wallet information from the main key
-     *
-     * TODO: Revisit this when the recovery process has been fleshed out and AddressBuilder is implemented
-     *
-     * @note This function only recovers information about 1-of-1 Signature Locks derived from the main key.
-     *
-     * @param mainKey The main key to recover the wallet from
-     * @param name The name of the wallet to recover
-     * @return A unit value if the recovery was successful, otherwise a WalletApiFailure
-     */
-    private def recoverFromMainKey(mainKey: KeyPair, name: String): F[Either[WalletApiFailure, Unit]] = {
-      require(mainKey.vk.vk.isExtendedEd25519, "keyPair must be an extended Ed25519 key")
-      require(mainKey.sk.sk.isExtendedEd25519, "keyPair must be an extended Ed25519 key")
-
-      /**
-       * The process:
-       * 1. Iterate through children keys of the main key for related to 1-of-1 signature locks;
-       *    I.e, for all z in path 0/0/z
-       *    TODO: Do we need to iterate through all 2^32^? Can we assume if there is a big gap we can stop early?
-       * 2. For each child key, derive the 1-of-1 signature lock and it's address
-       *    TODO: This will be straightforward once AddressBuilder is implemented
-       * 3. For each address, query DataApi/Genus to see if for Txos to see if the address has been used
-       * 4. If the address has been used, store the address, the lock, with the indices to track the usage
-       */
-      ().asRight[WalletApiFailure].pure[F]
-    }
 
     override def saveWallet(vaultStore: VaultStore[F], name: String = "default"): F[Either[WalletApiFailure, Unit]] =
       dataApi.saveMainKeyVaultStore(vaultStore, name).map(res => res.leftMap(FailedToSaveWallet(_)))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
@@ -14,6 +14,7 @@ import io.circe.syntax.EncoderOps
 object MockWalletKeyApi extends WalletKeyApiAlgebra[Id] with MockHelpers {
 
   var mainKeyVaultStoreInstance: Map[String, Json] = Map()
+  var mnemonicInstance: Map[String, IndexedSeq[String]] = Map()
 
   override def saveMainKeyVaultStore(
     mainKeyVaultStore: VaultStore[Id],
@@ -62,4 +63,12 @@ object MockWalletKeyApi extends WalletKeyApiAlgebra[Id] with MockHelpers {
       extends WalletKeyException("Error decoding MainKeyVaultStore", cause)
   case object MainKeyVaultSaveFailure extends WalletKeyException("Error saving MainKeyVaultStore")
   case object MainKeyVaultDeleteFailure extends WalletKeyException("Error deleting MainKeyVaultStore")
+
+  override def saveMnemonic(
+    mnemonic:     IndexedSeq[String],
+    mnemonicName: String
+  ): Id[Either[WalletKeyException, Unit]] = {
+    mnemonicInstance += (mnemonicName -> mnemonic)
+    Right(())
+  }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -310,6 +310,4 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     assert(importedWallet.isLeft)
     assert(importedWallet.left.toOption.get == WalletApi.FailedToSaveWallet(MockWalletKeyApi.MainKeyVaultSaveFailure))
   }
-
-  test("recoverWallet: TBD when recovery is fleshed out".ignore) {}
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -310,4 +310,11 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     assert(importedWallet.isLeft)
     assert(importedWallet.left.toOption.get == WalletApi.FailedToSaveWallet(MockWalletKeyApi.MainKeyVaultSaveFailure))
   }
+
+  test("saveMnemonic: verify a simple save") {
+    val name = "test"
+    val res = walletApi.saveMnemonic(IndexedSeq("a", "b", "c"), name)
+    assert(res.isRight)
+    assert(MockWalletKeyApi.mnemonicInstance.contains(name))
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ lazy val serviceKit = project
     commonSettings,
     publishSettings,
     Test / publishArtifact := true,
+    Test / parallelExecution := false,
     libraryDependencies ++=
       Dependencies.ServiceKit.sources ++
         Dependencies.ServiceKit.tests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -104,7 +104,7 @@ object Dependencies {
     lazy val sources: Seq[ModuleID] = sqlite
 
     lazy val tests: Seq[ModuleID] = (
-        mUnitTest
+        mUnitTest ++ sqlite
       ).map(_ % Test)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,10 @@ object Dependencies {
     "co.topl" %% "quivr4s" % quivr4sVersion
   )
 
+  val sqlite: Seq[ModuleID] = Seq(
+    "org.xerial" % "sqlite-jdbc" % "3.41.2.1"
+  )
+
   object Crypto {
 
     lazy val sources: Seq[ModuleID] =
@@ -97,7 +101,7 @@ object Dependencies {
 
   object ServiceKit {
 
-    lazy val sources: Seq[ModuleID] = Seq()
+    lazy val sources: Seq[ModuleID] = sqlite
 
     lazy val tests: Seq[ModuleID] = (
         mUnitTest

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/ContractStorageApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/ContractStorageApi.scala
@@ -1,0 +1,53 @@
+package co.topl.brambl.servicekit
+
+import cats.effect.kernel.{Resource, Sync}
+import co.topl.brambl.dataApi.{ContractStorageAlgebra, WalletContract}
+
+object ContractStorageApi {
+
+  def make[F[_]: Sync](
+    connection: Resource[F, java.sql.Connection]
+  ): ContractStorageAlgebra[F] = new ContractStorageAlgebra[F] {
+
+    override def addContract(walletContract: WalletContract): F[Int] =
+      connection.use { conn =>
+        import cats.implicits._
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          inserted <- Sync[F].blocking(
+            stmnt.executeUpdate(
+              s"INSERT INTO contracts (contract, lock) VALUES ('${walletContract.name}', '${walletContract.lockTemplate}')"
+            )
+          )
+        } yield inserted
+      }
+
+    override def findContracts(): F[Seq[WalletContract]] =
+      connection.use { conn =>
+        import cats.implicits._
+        import io.circe.parser._
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs    <- Sync[F].blocking(stmnt.executeQuery("SELECT * FROM contracts"))
+        } yield LazyList
+          .unfold(rs) { rs =>
+            if (rs.next()) {
+              Some(
+                (
+                  WalletContract(
+                    rs.getInt("y_contract"),
+                    rs.getString("contract"),
+                    parse(rs.getString("lock")).toOption.get.noSpaces
+                  ),
+                  rs
+                )
+              )
+            } else {
+              None
+            }
+          }
+          .force
+          .toSeq
+      }
+  }
+}

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/PartyStorageApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/PartyStorageApi.scala
@@ -1,0 +1,51 @@
+package co.topl.brambl.servicekit
+
+import cats.effect.kernel.{Resource, Sync}
+import co.topl.brambl.dataApi.{PartyStorageAlgebra, WalletEntity}
+
+object PartyStorageApi {
+
+  def make[F[_]: Sync](
+    connection: Resource[F, java.sql.Connection]
+  ): PartyStorageAlgebra[F] = new PartyStorageAlgebra[F] {
+
+    override def addParty(walletEntity: WalletEntity): F[Int] =
+      connection.use { conn =>
+        import cats.implicits._
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          inserted <- Sync[F].blocking(
+            stmnt.executeUpdate(
+              s"INSERT INTO parties (party) VALUES ('${walletEntity.name}')"
+            )
+          )
+        } yield inserted
+      }
+
+    override def findParties(): F[Seq[WalletEntity]] =
+      connection.use { conn =>
+        import cats.implicits._
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs    <- Sync[F].blocking(stmnt.executeQuery("SELECT * FROM parties"))
+        } yield LazyList
+          .unfold(rs) { rs =>
+            if (rs.next()) {
+              Some(
+                (
+                  WalletEntity(
+                    rs.getInt("x_party"),
+                    rs.getString("party")
+                  ),
+                  rs
+                )
+              )
+            } else {
+              None
+            }
+          }
+          .force
+          .toSeq
+      }
+  }
+}

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
@@ -2,32 +2,95 @@ package co.topl.brambl.servicekit
 
 import cats.effect.kernel.{Resource, Sync}
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra
+import co.topl.brambl.dataApi.WalletKeyApiAlgebra.WalletKeyException
 import co.topl.crypto.encryption.VaultStore
+import co.topl.crypto.encryption.VaultStore.Codecs._
+import io.circe.syntax._
+import io.circe.parser.decode
+import cats.implicits._
 
 import java.io.PrintWriter
+import java.nio.file.{Files, Paths}
 import scala.io.Source
 
+/**
+ * An implementation of the WalletKeyApiAlgebra that stores the keyfile to disk.
+ */
 object WalletKeyApi {
 
   def make[F[_]: Sync](): WalletKeyApiAlgebra[F] =
     new WalletKeyApiAlgebra[F] {
 
+      case class DecodeVaultStoreException(msg: String, t: Throwable) extends WalletKeyException(msg, t)
+
+      case class VaultStoreDoesNotExistException(name: String)
+          extends WalletKeyException(s"VaultStore at $name does not exist")
+
+      /**
+       * Updates the main key vault store.
+       * @param mainKeyVaultStore The new VaultStore to update to.
+       * @param name              The filepath of the VaultStore to update.
+       * @return nothing if successful. An exception if the VaultStore does not exist.
+       */
       override def updateMainKeyVaultStore(
         mainKeyVaultStore: VaultStore[F],
         name:              String
-      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+      ): F[Either[WalletKeyException, Unit]] =
+        if (Paths.get(name).toFile.exists())
+          saveMainKeyVaultStore(mainKeyVaultStore, name) // overwrite keyfile
+        else
+          Either.left[WalletKeyException, Unit](VaultStoreDoesNotExistException(name)).pure[F]
 
+      /**
+       * Deletes the main key vault store.
+       * @param name The filepath of the VaultStore to delete.
+       * @return nothing if successful. An exception if the VaultStore does not exist.
+       */
       override def deleteMainKeyVaultStore(
         name: String
-      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+      ): F[Either[WalletKeyException, Unit]] =
+        if (Files.deleteIfExists(Paths.get(name)))
+          ().asRight[WalletKeyException].pure[F]
+        else
+          Either.left[WalletKeyException, Unit](VaultStoreDoesNotExistException(name)).pure[F]
 
+      /**
+       * Persists the main key vault store to disk.
+       * @param mainKeyVaultStore The VaultStore to persist
+       * @param name              The filepath to persist the VaultStore to.
+       *  @return nothing if successful. If persisting fails due to an underlying cause, return a WalletKeyException
+       */
       override def saveMainKeyVaultStore(
         mainKeyVaultStore: VaultStore[F],
         name:              String
-      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, Unit]] = ???
+      ): F[Either[WalletKeyException, Unit]] = Resource
+        .make(Sync[F].delay(new PrintWriter(name)))(file => Sync[F].delay(file.close()))
+        .use { file =>
+          for {
+            res <- Sync[F].blocking(file.write(mainKeyVaultStore.asJson.noSpaces))
+          } yield res.asRight[WalletKeyException]
+        }
 
+      /**
+       * Retrieves the main key vault store from disk.
+       * @param name The filepath of the VaultStore to retrieve.
+       *  @return The VaultStore for the Topl Main Secret Key if it exists.
+       *          If retrieving fails due to an underlying cause, return a WalletKeyException
+       */
       override def getMainKeyVaultStore(
         name: String
-      ): F[Either[WalletKeyApiAlgebra.WalletKeyException, VaultStore[F]]] = ???
+      ): F[Either[WalletKeyException, VaultStore[F]]] = Resource
+        .make(Sync[F].delay(Source.fromFile(name))) { file =>
+          Sync[F].delay(file.close())
+        }
+        .use { file =>
+          for {
+            inputString <- Sync[F].blocking(file.getLines().mkString("\n"))
+            res <- Sync[F].delay(
+              decode[VaultStore[F]](inputString)
+                .leftMap(e => DecodeVaultStoreException("Invalid JSON", e))
+            )
+          } yield res
+        }
     }
 }

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletKeyApi.scala
@@ -92,5 +92,21 @@ object WalletKeyApi {
             )
           } yield res
         }
+
+      /**
+       * @param mnemonic          The mnemonic to persist
+       * @param mnemonicName      The filepath to persist the mnemonic to.
+       *  @return nothing if successful. If persisting fails due to an underlying cause, return a WalletKeyException
+       */
+      override def saveMnemonic(
+        mnemonic:     IndexedSeq[String],
+        mnemonicName: String
+      ): F[Either[WalletKeyException, Unit]] = Resource
+        .make(Sync[F].delay(new PrintWriter(mnemonicName)))(file => Sync[F].delay(file.close()))
+        .use { file =>
+          for {
+            res <- Sync[F].blocking(file.write(mnemonic.mkString(",")))
+          } yield res.asRight[WalletKeyException]
+        }
     }
 }

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -1,23 +1,71 @@
 package co.topl.brambl.servicekit
 
-import cats.data.ValidatedNel
-import cats.effect.kernel.Sync
-import co.topl.brambl.builders.locks.LockTemplate
+import cats.data.{Validated, ValidatedNel}
+import cats.effect.kernel.{Resource, Sync}
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
 import co.topl.brambl.dataApi.WalletStateAlgebra
 import co.topl.brambl.models.Indices
 import co.topl.brambl.models.box.Lock
+import co.topl.brambl.wallet.WalletApi
 import quivr.models.Preimage
 import quivr.models.Proposition
 import quivr.models.VerificationKey
+import cats.implicits._
+import co.topl.brambl.codecs.LockTemplateCodecs.{decodeLockTemplate, encodeLockTemplate}
+import co.topl.brambl.utils.Encoding
+import io.circe.syntax.EncoderOps
+import io.circe.parser._
 
+/**
+ * An implementation of the WalletStateAlgebra that uses a database to store state information.
+ */
 object WalletStateApi {
 
-  def make[F[_]: Sync](): WalletStateAlgebra[F] =
+  def make[F[_]: Sync](
+    connection:            Resource[F, java.sql.Connection],
+    transactionBuilderApi: TransactionBuilderApi[F],
+    walletApi:             WalletApi[F]
+  ): WalletStateAlgebra[F] =
     new WalletStateAlgebra[F] {
 
-      override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]] = ???
+      override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]] =
+        connection.use { conn =>
+          for {
+            stmnt <- Sync[F].blocking(conn.createStatement())
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT x_party, y_contract, z_state, routine, vk FROM " +
+                s"cartesian WHERE routine = '${signatureProposition.routine}' AND " +
+                s"vk = '${Encoding.encodeToBase58(signatureProposition.verificationKey.toByteArray)}'"
+              )
+            )
+            hasNext <- Sync[F].delay(rs.next())
+            x       <- Sync[F].delay(rs.getInt("x_party"))
+            y       <- Sync[F].delay(rs.getInt("y_contract"))
+            z       <- Sync[F].delay(rs.getInt("z_state"))
+          } yield if (hasNext) Some(Indices(x, y, z)) else None
+        }
 
-      def getLockByIndex(indices: Indices): F[Option[Lock.Predicate]] = ???
+      def getLockByIndex(indices: Indices): F[Option[Lock.Predicate]] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party, y_contract, z_state, lock_predicate FROM " +
+              s"cartesian WHERE x_party = ${indices.x} AND " +
+              s"y_contract = ${indices.y} AND " +
+              s"z_state = ${indices.z}"
+            )
+          )
+          _              <- Sync[F].delay(rs.next())
+          lock_predicate <- Sync[F].delay(rs.getString("lock_predicate"))
+        } yield Some(
+          Lock.Predicate.parseFrom(
+            Encoding.decodeFromBase58Check(lock_predicate).toOption.get
+          )
+        )
+      }
 
       override def updateWalletState(
         lockPredicate: String,
@@ -25,62 +73,443 @@ object WalletStateApi {
         routine:       Option[String],
         vk:            Option[String],
         indices:       Indices
-      ): F[Unit] = ???
+      ): F[Unit] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          statement =
+            s"INSERT INTO cartesian (x_party, y_contract, z_state, lock_predicate, address, routine, vk) VALUES (${indices.x}, ${indices.y}, ${indices.z}, '${lockPredicate}', '" +
+              lockAddress + "', " + routine
+                .map(x => s"'$x'")
+                .getOrElse("NULL") + ", " + vk
+                .map(x => s"'$x'")
+                .getOrElse("NULL") + ")"
+          _ <- Sync[F].blocking(
+            stmnt.executeUpdate(statement)
+          )
+        } yield ()
+      }
 
-      override def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]] = ???
+      override def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]] = connection.use {
+        conn =>
+          for {
+            stmnt <- Sync[F].blocking(conn.createStatement())
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT x_party, party FROM parties WHERE party = '${party}'"
+              )
+            )
+            x <- Sync[F].delay(rs.getInt("x_party"))
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT y_contract, contract FROM contracts WHERE contract = '${contract}'"
+              )
+            )
+            y <- Sync[F].delay(rs.getInt("y_contract"))
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT x_party, y_contract, MAX(z_state) as z_index FROM cartesian WHERE x_party = ${x} AND y_contract = ${y}"
+              )
+            )
+            z <- Sync[F].delay(rs.getInt("z_index"))
+          } yield if (rs.next()) Some(Indices(x, y, z + 1)) else None
+      }
+
+      private def validateParty(
+        party: String
+      ): F[ValidatedNel[String, String]] =
+        connection.use { conn =>
+          for {
+            stmnt <- Sync[F].blocking(conn.createStatement())
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT x_party, party FROM parties WHERE party = '${party}'"
+              )
+            )
+          } yield
+            if (rs.next()) Validated.validNel(party)
+            else Validated.invalidNel("Party not found")
+        }
+
+      private def validateContract(
+        contract: String
+      ): F[ValidatedNel[String, String]] =
+        connection.use { conn =>
+          for {
+            stmnt <- Sync[F].blocking(conn.createStatement())
+            rs <- Sync[F].blocking(
+              stmnt.executeQuery(
+                s"SELECT y_contract, contract FROM contracts WHERE contract = '${contract}'"
+              )
+            )
+          } yield
+            if (rs.next()) Validated.validNel(contract)
+            else Validated.invalidNel("Contract not found")
+        }
 
       def validateCurrentIndicesForFunds(
         party:     String,
         contract:  String,
         someState: Option[Int]
-      ): F[ValidatedNel[String, Indices]] = ???
+      ): F[ValidatedNel[String, Indices]] = for {
+        validatedParty    <- validateParty(party)
+        validatedContract <- validateContract(contract)
+        indices           <- getCurrentIndicesForFunds(party, contract, someState)
+      } yield (
+        validatedParty,
+        validatedContract,
+        indices.toValidNel("Indices not found")
+      ).mapN((_, _, index) => index)
 
       override def getAddress(
         party:     String,
         contract:  String,
         someState: Option[Int]
-      ): F[Option[String]] = ???
+      ): F[Option[String]] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party, party FROM parties WHERE party = '${party}'"
+            )
+          )
+          x <- Sync[F].delay(rs.getInt("x_party"))
+          query =
+            s"SELECT y_contract, contract FROM contracts WHERE contract = '${contract}'"
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              query
+            )
+          )
+          y <- Sync[F].delay(rs.getInt("y_contract"))
+          query = s"SELECT address, x_party, y_contract, " + someState
+            .map(_ => "z_state as z_index")
+            .getOrElse(
+              "MAX(z_state) as z_index"
+            ) + s" FROM cartesian WHERE x_party = ${x} AND y_contract = ${y}" + someState
+            .map(x => s" AND z_state = ${x}")
+            .getOrElse("")
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              query
+            )
+          )
+          address <- Sync[F].delay(rs.getString("address"))
+        } yield if (rs.next()) Some(address) else None
+      }
 
       override def getCurrentIndicesForFunds(
         party:     String,
         contract:  String,
         someState: Option[Int]
-      ): F[Option[Indices]] = ???
+      ): F[Option[Indices]] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party, party FROM parties WHERE party = '${party}'"
+            )
+          )
+          x <- Sync[F].delay(rs.getInt("x_party"))
+          query =
+            s"SELECT y_contract, contract FROM contracts WHERE contract = '${contract}'"
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              query
+            )
+          )
+          y <- Sync[F].delay(rs.getInt("y_contract"))
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party, y_contract, " + someState
+                .map(_ => "z_state as z_index")
+                .getOrElse(
+                  "MAX(z_state) as z_index"
+                ) + s" FROM cartesian WHERE x_party = ${x} AND y_contract = ${y}" + someState
+                .map(x => s" AND z_state = ${x}")
+                .getOrElse("")
+            )
+          )
+          z <- someState
+            .map(x => Sync[F].point(x))
+            .getOrElse(Sync[F].delay(rs.getInt("z_index")))
+        } yield if (rs.next()) Some(Indices(x, y, z)) else None
+      }
 
-      override def getCurrentAddress: F[String] = ???
+      override def getCurrentAddress: F[String] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              "SELECT address, MAX(z_state) FROM cartesian WHERE x_party = 1 AND y_contract = 1  group by x_party, y_contract"
+            )
+          )
+          lockAddress <- Sync[F].delay(rs.getString("address"))
+        } yield lockAddress
+      }
 
       override def initWalletState(
         vk: VerificationKey
-      ): F[Unit] = ???
+      ): F[Unit] = {
+        import TransactionBuilderApi.implicits._
+        connection.use { conn =>
+          for {
+            stmnt <- Sync[F].delay(conn.createStatement())
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE TABLE IF NOT EXISTS cartesian (id INTEGER PRIMARY KEY," +
+                " x_party INTEGER NOT NULL, y_contract INTEGER NOT NULL, z_state INTEGER NOT NULL, " +
+                "lock_predicate TEXT NOT NULL, address TEXT NOT NULL, routine TEXT, vk TEXT)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE TABLE IF NOT EXISTS parties (party TEXT," +
+                " x_party INTEGER PRIMARY KEY ASC)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE TABLE IF NOT EXISTS contracts (contract TEXT NOT NULL," +
+                " y_contract INTEGER PRIMARY KEY ASC,  lock TEXT NOT NULL)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE TABLE IF NOT EXISTS verification_keys (x_party INTEGER NOT NULL," +
+                " y_contract INTEGER NOT NULL, vks TEXT NOT NULL, PRIMARY KEY (x_party, y_contract))"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS contract_names_idx ON contracts (contract)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE INDEX IF NOT EXISTS party_names_idx ON parties (party)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS cartesian_coordinates ON cartesian (x_party, y_contract, z_state)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.execute(
+                "CREATE INDEX IF NOT EXISTS signature_idx ON cartesian (routine, vk)"
+              )
+            )
+            defaultTemplate <- Sync[F].delay(
+              LockTemplate.PredicateTemplate[F](
+                List(
+                  PropositionTemplate.SignatureTemplate[F]("ExtendedEd25519", 0)
+                ),
+                1
+              )
+            )
+            genesisTemplate <- Sync[F].delay(
+              LockTemplate.PredicateTemplate[F](
+                List(
+                  PropositionTemplate
+                    .HeightTemplate[F]("header", 1, Long.MaxValue)
+                ),
+                1
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                "INSERT INTO parties (party, x_party) VALUES ('noparty', 0)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                "INSERT INTO parties (party, x_party) VALUES ('self', 1)"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                s"INSERT INTO contracts (contract, y_contract, lock) VALUES ('default', 1, '${encodeLockTemplate(defaultTemplate).toString}')"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                s"INSERT INTO contracts (contract, y_contract, lock) VALUES ('genesis', 2, '${encodeLockTemplate(genesisTemplate).toString}')"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                s"INSERT INTO verification_keys (x_party, y_contract, vks) VALUES (1, 1, '${List(Encoding.encodeToBase58(vk.toByteArray)).asJson.toString}')"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                s"INSERT INTO verification_keys (x_party, y_contract, vks) VALUES (0, 2, '${List[String]().asJson.toString}')"
+              )
+            )
+            defaultSignatureLock <- getLock("self", "default", 1).map(_.get)
+            signatureLockAddress <- transactionBuilderApi.lockAddress(
+              defaultSignatureLock
+            )
+            childVk           <- walletApi.deriveChildVerificationKey(vk, 1)
+            genesisHeightLock <- getLock("noparty", "genesis", 1).map(_.get)
+            heightLockAddress <- transactionBuilderApi.lockAddress(
+              genesisHeightLock
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                "INSERT INTO cartesian (x_party, y_contract, z_state, lock_predicate, address, routine, vk) VALUES (1, 1, 1, '" +
+                Encoding
+                  .encodeToBase58Check(
+                    defaultSignatureLock.getPredicate.toByteArray
+                  ) +
+                "', '" +
+                signatureLockAddress.toBase58 + "', " + "'ExtendedEd25519', " + "'" +
+                Encoding.encodeToBase58(childVk.toByteArray)
+                + "'" + ")"
+              )
+            )
+            _ <- Sync[F].delay(
+              stmnt.executeUpdate(
+                "INSERT INTO cartesian (x_party, y_contract, z_state, lock_predicate, address) VALUES (0, 2, 1, '" +
+                Encoding
+                  .encodeToBase58Check(
+                    genesisHeightLock.getPredicate.toByteArray
+                  ) +
+                "', '" +
+                heightLockAddress.toBase58 + "')"
+              )
+            )
+            _ <- Sync[F].delay(stmnt.close())
+          } yield ()
+        }
+      }
 
+      // TODO: We are not yet supporting Digest Propositions in brambl-cli.
       override def getPreimage(
         digestProposition: Proposition.Digest
-      ): F[Option[Preimage]] = ???
+      ): F[Option[Preimage]] = Sync[F].delay(
+        None
+      )
 
       override def addEntityVks(
         party:    String,
         contract: String,
         entities: List[String]
-      ): F[Unit] = ???
+      ): F[Unit] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party FROM parties WHERE party = '${party}'"
+            )
+          )
+          x <- Sync[F].delay(rs.getInt("x_party"))
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT y_contract FROM contracts WHERE contract = '${contract}'"
+            )
+          )
+          y <- Sync[F].delay(rs.getInt("y_contract"))
+          statement =
+            s"INSERT INTO verification_keys (x_party, y_contract, vks) VALUES (${x}, ${y}, " +
+              s"'${entities.asJson.toString}')"
+          _ <- Sync[F].blocking(
+            stmnt.executeUpdate(statement)
+          )
+        } yield ()
+      }
 
       override def getEntityVks(
         party:    String,
         contract: String
-      ): F[Option[List[String]]] = ???
+      ): F[Option[List[String]]] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT x_party FROM parties WHERE party = '${party}'"
+            )
+          )
+          x <- Sync[F].delay(rs.getInt("x_party"))
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT y_contract FROM contracts WHERE contract = '${contract}'"
+            )
+          )
+          y <- Sync[F].delay(rs.getInt("y_contract"))
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT vks FROM verification_keys WHERE x_party = ${x} AND y_contract = ${y}"
+            )
+          )
+          vks <- Sync[F].delay(rs.getString("vks"))
+        } yield
+          if (!rs.next()) None
+          else parse(vks).toOption.flatMap(_.as[List[String]].toOption)
+      }
 
+      // FIXME: use this method to get the lock template in the controller
       override def addNewLockTemplate(
         contract:     String,
         lockTemplate: LockTemplate[F]
-      ): F[Unit] = ???
+      ): F[Unit] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          // FIXME: do not use max, use autoincrement
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT MAX(y_contract) as y_index FROM contracts"
+            )
+          )
+          y <- Sync[F].delay(rs.getInt("y_index"))
+          statement =
+            s"INSERT INTO contracts (contract, y_contract, lock) VALUES ('${contract}', ${y + 1}, '${encodeLockTemplate(lockTemplate).toString}'"
+          _ <- Sync[F].blocking(
+            stmnt.executeUpdate(statement)
+          )
+        } yield ()
+      }
 
       override def getLockTemplate(
         contract: String
-      ): F[Option[LockTemplate[F]]] = ???
+      ): F[Option[LockTemplate[F]]] = connection.use { conn =>
+        for {
+          stmnt <- Sync[F].blocking(conn.createStatement())
+          rs <- Sync[F].blocking(
+            stmnt.executeQuery(
+              s"SELECT lock FROM contracts WHERE contract = '${contract}'"
+            )
+          )
+          lockStr <- Sync[F].delay(rs.getString("lock"))
+        } yield
+          if (!rs.next()) None
+          else
+            parse(lockStr).toOption.flatMap(decodeLockTemplate[F](_).toOption)
+      }
 
       override def getLock(
         party:     String,
         contract:  String,
         nextState: Int
-      ): F[Option[Lock]] = ???
+      ): F[Option[Lock]] = for {
+        changeTemplate <- getLockTemplate(contract)
+        entityVks <- getEntityVks(party, contract)
+          .map(
+            _.map(
+              _.map(vk =>
+                VerificationKey.parseFrom(
+                  Encoding.decodeFromBase58(vk).toOption.get
+                )
+              )
+            )
+          )
+        childVks <- entityVks
+          .map(vks => vks.map(walletApi.deriveChildVerificationKey(_, nextState)).sequence)
+          .sequence
+        changeLock <- changeTemplate
+          .flatMap(template => childVks.map(vks => template.build(vks).map(_.toOption)))
+          .sequence
+          .map(_.flatten)
+      } yield changeLock
     }
 }

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -448,7 +448,6 @@ object WalletStateApi {
           else parse(vks).toOption.flatMap(_.as[List[String]].toOption)
       }
 
-      // FIXME: use this method to get the lock template in the controller
       override def addNewLockTemplate(
         contract:     String,
         lockTemplate: LockTemplate[F]

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -463,7 +463,7 @@ object WalletStateApi {
           )
           y <- Sync[F].delay(rs.getInt("y_index"))
           statement =
-            s"INSERT INTO contracts (contract, y_contract, lock) VALUES ('${contract}', ${y + 1}, '${encodeLockTemplate(lockTemplate).toString}'"
+            s"INSERT INTO contracts (contract, y_contract, lock) VALUES ('${contract}', ${y + 1}, '${encodeLockTemplate(lockTemplate).toString}')"
           _ <- Sync[F].blocking(
             stmnt.executeUpdate(statement)
           )

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateResource.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateResource.scala
@@ -1,0 +1,21 @@
+package co.topl.brambl.servicekit
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+
+import java.sql.{Connection, DriverManager}
+
+/**
+ * A resource that provides a connection to a wallet state database.
+ */
+trait WalletStateResource {
+
+  def walletResource(name: String): Resource[IO, Connection] = Resource
+    .make(
+      IO.delay(
+        DriverManager.getConnection(
+          s"jdbc:sqlite:${name}"
+        )
+      )
+    )(conn => IO.delay(conn.close()))
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
@@ -1,0 +1,34 @@
+package co.topl.brambl.servicekit
+
+import munit.CatsEffectSuite
+
+import cats.effect.IO
+import co.topl.brambl.dataApi.WalletKeyApiAlgebra
+import co.topl.brambl.wallet.WalletApi
+import scala.concurrent.duration.Duration
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+trait BaseSpec extends CatsEffectSuite {
+  override val munitTimeout: Duration = Duration(180, "s")
+
+  val walletKeyApi: WalletKeyApiAlgebra[IO] = WalletKeyApi.make[IO]()
+  val walletApi: WalletApi[IO] = WalletApi.make[IO](walletKeyApi)
+
+  val TEST_DIR = "./tmp"
+  val testDir: File = Paths.get(TEST_DIR).toFile
+
+  private def removeDir() =
+    if (testDir.exists()) {
+      Paths.get(TEST_DIR).toFile.listFiles().map(_.delete()).mkString("\n")
+      Files.deleteIfExists(Paths.get(TEST_DIR))
+    }
+
+  val testDirectory: FunFixture[Path] = FunFixture[Path](
+    setup = { _ =>
+      removeDir()
+      Files.createDirectory(Paths.get(TEST_DIR))
+    },
+    teardown = { _ => removeDir() }
+  )
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
@@ -1,22 +1,43 @@
 package co.topl.brambl.servicekit
 
 import munit.CatsEffectSuite
-
 import cats.effect.IO
+import cats.effect.kernel.Resource
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra
 import co.topl.brambl.wallet.WalletApi
+
 import scala.concurrent.duration.Duration
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.constants.NetworkConstants._
+import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.wallet.WalletApi.cryptoToPbKeyPair
+import co.topl.crypto.generation.KeyInitializer.Instances.extendedEd25519Initializer
+import co.topl.crypto.signing.{ExtendedEd25519, KeyPair}
+import quivr.models
 
-trait BaseSpec extends CatsEffectSuite {
+import java.sql.Connection
+
+trait BaseSpec extends CatsEffectSuite with WalletStateResource {
   override val munitTimeout: Duration = Duration(180, "s")
-
-  val walletKeyApi: WalletKeyApiAlgebra[IO] = WalletKeyApi.make[IO]()
-  val walletApi: WalletApi[IO] = WalletApi.make[IO](walletKeyApi)
 
   val TEST_DIR = "./tmp"
   val testDir: File = Paths.get(TEST_DIR).toFile
+  val DB_FILE = s"$TEST_DIR/wallet.db"
+  val walletKeyApi: WalletKeyApiAlgebra[IO] = WalletKeyApi.make[IO]()
+  val walletApi: WalletApi[IO] = WalletApi.make[IO](walletKeyApi)
+
+  val transactionBuilderApi: TransactionBuilderApi[IO] =
+    TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+  val dbConnection: Resource[IO, Connection] = walletResource(DB_FILE)
+  val walletStateApi: WalletStateAlgebra[IO] = WalletStateApi.make[IO](dbConnection, transactionBuilderApi, walletApi)
+
+  def mockMainKeyPair: models.KeyPair = {
+    implicit val extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519
+    val sk = extendedEd25519Initializer.random()
+    cryptoToPbKeyPair(KeyPair(sk, extendedEd25519Instance.getVerificationKey(sk)))
+  }
 
   private def removeDir() =
     if (testDir.exists()) {

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/ContractStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/ContractStorageApiSpec.scala
@@ -1,0 +1,8 @@
+package co.topl.brambl.servicekit
+
+class ContractStorageApiSpec extends munit.FunSuite {
+
+  test("test placeholder") {
+    assert(true)
+  }
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
@@ -1,0 +1,8 @@
+package co.topl.brambl.servicekit
+
+class PartyStorageApiSpec extends munit.FunSuite {
+
+  test("test placeholder") {
+    assert(true)
+  }
+}

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
@@ -1,8 +1,22 @@
 package co.topl.brambl.servicekit
 
-class PartyStorageApiSpec extends munit.FunSuite {
+import cats.effect.IO
+import co.topl.brambl.dataApi.{PartyStorageAlgebra, WalletEntity}
+import munit.CatsEffectSuite
 
-  test("test placeholder") {
-    assert(true)
+class PartyStorageApiSpec extends CatsEffectSuite with BaseSpec {
+
+  val partyApi: PartyStorageAlgebra[IO] = PartyStorageApi.make[IO](dbConnection)
+
+  testDirectory.test("addParty then findParties") { _ =>
+    val party = WalletEntity(2, "testParty")
+    assertIO(
+      for {
+        init    <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        _       <- partyApi.addParty(party)
+        parties <- partyApi.findParties()
+      } yield parties.length == 3 && parties.last == party,
+      true
+    )
   }
 }

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
@@ -1,36 +1,10 @@
 package co.topl.brambl.servicekit
 
-import cats.effect.IO
-import co.topl.brambl.dataApi.WalletKeyApiAlgebra
-import co.topl.brambl.wallet.WalletApi
 import munit.CatsEffectSuite
 
-import java.io.File
-import java.nio.file.{Files, Path, Paths}
-import scala.concurrent.duration.Duration
+import java.nio.file.Paths
 
-class WalletKeyApiSpec extends CatsEffectSuite {
-
-  val walletKeyApi: WalletKeyApiAlgebra[IO] = WalletKeyApi.make[IO]()
-  val walletApi: WalletApi[IO] = WalletApi.make[IO](walletKeyApi)
-
-  override val munitTimeout: Duration = Duration(180, "s")
-  val TEST_DIR = "./tmp"
-  val testDir: File = Paths.get(TEST_DIR).toFile
-
-  private def removeDir() =
-    if (testDir.exists()) {
-      Paths.get(TEST_DIR).toFile.listFiles().map(_.delete()).mkString("\n")
-      Files.deleteIfExists(Paths.get(TEST_DIR))
-    }
-
-  val testDirectory: FunFixture[Path] = FunFixture[Path](
-    setup = { _ =>
-      removeDir()
-      Files.createDirectory(Paths.get(TEST_DIR))
-    },
-    teardown = { _ => removeDir() }
-  )
+class WalletKeyApiSpec extends CatsEffectSuite with BaseSpec {
 
   private def getFileName(name: String) = s"$TEST_DIR/$name"
 

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletKeyApiSpec.scala
@@ -1,8 +1,119 @@
 package co.topl.brambl.servicekit
 
-class WalletKeyApiSpec extends munit.FunSuite {
+import cats.effect.IO
+import co.topl.brambl.dataApi.WalletKeyApiAlgebra
+import co.topl.brambl.wallet.WalletApi
+import munit.CatsEffectSuite
 
-  test("test placeholder") {
-    assert(true)
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+import scala.concurrent.duration.Duration
+
+class WalletKeyApiSpec extends CatsEffectSuite {
+
+  val walletKeyApi: WalletKeyApiAlgebra[IO] = WalletKeyApi.make[IO]()
+  val walletApi: WalletApi[IO] = WalletApi.make[IO](walletKeyApi)
+
+  override val munitTimeout: Duration = Duration(180, "s")
+  val TEST_DIR = "./tmp"
+  val testDir: File = Paths.get(TEST_DIR).toFile
+
+  private def removeDir() =
+    if (testDir.exists()) {
+      Paths.get(TEST_DIR).toFile.listFiles().map(_.delete()).mkString("\n")
+      Files.deleteIfExists(Paths.get(TEST_DIR))
+    }
+
+  val testDirectory: FunFixture[Path] = FunFixture[Path](
+    setup = { _ =>
+      removeDir()
+      Files.createDirectory(Paths.get(TEST_DIR))
+    },
+    teardown = { _ => removeDir() }
+  )
+
+  private def getFileName(name: String) = s"$TEST_DIR/$name"
+
+  testDirectory.test("Save and get VaultStore") { _ =>
+    assertIO(
+      for {
+        vs     <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+        saved  <- walletKeyApi.saveMainKeyVaultStore(vs, getFileName("key.json"))
+        loaded <- walletKeyApi.getMainKeyVaultStore(getFileName("key.json"))
+      } yield loaded.toOption.get == vs,
+      true
+    )
+  }
+
+  testDirectory.test("Get VaultStore > Does not exist") { _ =>
+    assertIO(
+      for {
+        loaded <- walletKeyApi.getMainKeyVaultStore(getFileName("key.json"))
+      } yield loaded.isLeft && !Paths.get(getFileName("key.json")).toFile.exists(),
+      true
+    )
+  }
+
+  testDirectory.test("Save, delete and get VaultStore > Does not exist") { _ =>
+    assertIO(
+      for {
+        vs      <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+        saved   <- walletKeyApi.saveMainKeyVaultStore(vs, getFileName("key.json"))
+        deleted <- walletKeyApi.deleteMainKeyVaultStore(getFileName("key.json"))
+        loaded  <- walletKeyApi.getMainKeyVaultStore(getFileName("key.json"))
+      } yield loaded.isLeft && !Paths.get(getFileName("key.json")).toFile.exists(),
+      true
+    )
+  }
+
+  testDirectory.test("Delete VaultStore > VaultStore does not exists") { _ =>
+    assertIO(
+      for {
+        deleted <- walletKeyApi.deleteMainKeyVaultStore(getFileName("key.json"))
+      } yield deleted.isLeft && !Paths.get(getFileName("key.json")).toFile.exists(),
+      true
+    )
+  }
+
+  testDirectory.test("Save, update, and get VaultStore") { _ =>
+    assertIO(
+      for {
+        vs      <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+        saved   <- walletKeyApi.saveMainKeyVaultStore(vs, getFileName("key.json"))
+        newVs   <- walletApi.buildMainKeyVaultStore("a different dummyKeyPair".getBytes, "password".getBytes)
+        updated <- walletKeyApi.updateMainKeyVaultStore(newVs, getFileName("key.json"))
+        loaded  <- walletKeyApi.getMainKeyVaultStore(getFileName("key.json"))
+      } yield loaded.toOption.get == newVs,
+      true
+    )
+  }
+
+  testDirectory.test("Update VaultStore > VaultStore does not exists") { _ =>
+    assertIO(
+      for {
+        vs      <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+        updated <- walletKeyApi.updateMainKeyVaultStore(vs, getFileName("key.json"))
+      } yield updated.isLeft && !Paths.get(getFileName("key.json")).toFile.exists(),
+      true
+    )
+  }
+
+  testDirectory.test("Save Mnemonic") { _ =>
+    assertIO(
+      for {
+        saved <- walletKeyApi.saveMnemonic(IndexedSeq("a", "b", "c"), getFileName("mnemonic.txt"))
+      } yield saved.isRight && Paths.get(getFileName("mnemonic.txt")).toFile.exists(),
+      true
+    )
+  }
+
+  testDirectory.test("Save Mnemonic > Mnemonic already exists") { _ =>
+    assertIO(
+      for {
+        saved      <- walletKeyApi.saveMnemonic(IndexedSeq("a", "b", "c"), getFileName("mnemonic.txt"))
+        savedTwice <- walletKeyApi.saveMnemonic(IndexedSeq("a", "b", "c"), getFileName("mnemonic.txt"))
+      } yield savedTwice.isLeft && Paths.get(getFileName("mnemonic.txt")).toFile.exists(),
+      true
+    )
   }
 }

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -1,8 +1,71 @@
 package co.topl.brambl.servicekit
 
-class WalletStateApiSpec extends munit.FunSuite {
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.constants.NetworkConstants._
+import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.wallet.WalletApi.cryptoToPbKeyPair
+import co.topl.crypto.generation.KeyInitializer.Instances.extendedEd25519Initializer
+import co.topl.crypto.signing.{ExtendedEd25519, KeyPair}
+import munit.CatsEffectSuite
 
-  test("test placeholder") {
-    assert(true)
+import java.sql.Connection
+
+class WalletStateApiSpec extends CatsEffectSuite with WalletStateResource with BaseSpec {
+
+  val DB_FILE = s"$TEST_DIR/wallet.db"
+
+  val dbConnection: Resource[IO, Connection] = walletResource(DB_FILE)
+
+  val transactionBuilderApi: TransactionBuilderApi[IO] =
+    TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+  val walletStateApi: WalletStateAlgebra[IO] = WalletStateApi.make[IO](dbConnection, transactionBuilderApi, walletApi)
+
+  private def mockMainKeyPair = {
+    implicit val extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519
+    val sk = extendedEd25519Initializer.random()
+    cryptoToPbKeyPair(KeyPair(sk, extendedEd25519Instance.getVerificationKey(sk)))
+  }
+
+  testDirectory.test("initWalletState") { _ =>
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        partyCount <- dbConnection.use { conn =>
+          for {
+            stmt <- IO.delay(conn.createStatement())
+            rs <- IO.blocking(
+              stmt.executeQuery("SELECT COUNT(*) as res FROM parties WHERE party IN ('noparty', 'self')")
+            )
+            count <- IO.delay(rs.getInt("res"))
+          } yield count
+        }
+        contractCount <- dbConnection.use { conn =>
+          for {
+            stmt <- IO.delay(conn.createStatement())
+            rs <- IO.blocking(
+              stmt.executeQuery("SELECT COUNT(*) as res FROM contracts WHERE contract IN ('default', 'genesis')")
+            )
+            count <- IO.delay(rs.getInt("res"))
+          } yield count
+        }
+        vkCount <- dbConnection.use { conn =>
+          for {
+            stmt  <- IO.delay(conn.createStatement())
+            rs    <- IO.blocking(stmt.executeQuery("SELECT COUNT(*) as res FROM verification_keys"))
+            count <- IO.delay(rs.getInt("res"))
+          } yield count
+        }
+        cartesianCount <- dbConnection.use { conn =>
+          for {
+            stmt  <- IO.delay(conn.createStatement())
+            rs    <- IO.blocking(stmt.executeQuery("SELECT COUNT(*) as res FROM cartesian"))
+            count <- IO.delay(rs.getInt("res"))
+          } yield count
+        }
+      } yield partyCount == 2 && contractCount == 2 && vkCount == 2 && cartesianCount == 2,
+      true
+    )
   }
 }

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -1,14 +1,22 @@
 package co.topl.brambl.servicekit
 
+import cats.Id
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
 import co.topl.brambl.constants.NetworkConstants._
 import co.topl.brambl.dataApi.WalletStateAlgebra
+import co.topl.brambl.models.Indices
+import co.topl.brambl.models.box.Lock
+import co.topl.brambl.utils.Encoding
 import co.topl.brambl.wallet.WalletApi.cryptoToPbKeyPair
 import co.topl.crypto.generation.KeyInitializer.Instances.extendedEd25519Initializer
 import co.topl.crypto.signing.{ExtendedEd25519, KeyPair}
+import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
+import quivr.models.Digest
+import quivr.models.{Proposition, VerificationKey}
 
 import java.sql.Connection
 
@@ -68,4 +76,203 @@ class WalletStateApiSpec extends CatsEffectSuite with WalletStateResource with B
       true
     )
   }
+
+  testDirectory.test("updateWalletState") { _ =>
+    val testValue = "testValue"
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        update <- walletStateApi.updateWalletState(
+          testValue,
+          testValue,
+          Some(testValue),
+          Some(testValue),
+          Indices(9, 9, 9)
+        )
+        count <- dbConnection.use { conn =>
+          for {
+            stmt <- IO.delay(conn.createStatement())
+            rs <- IO.blocking(
+              stmt.executeQuery("SELECT COUNT(*) as res FROM cartesian")
+            )
+            count <- IO.delay(rs.getInt("res"))
+          } yield count
+        }
+        rowValid <- dbConnection.use { conn =>
+          for {
+            stmt <- IO.delay(conn.createStatement())
+            rs <- IO.blocking(
+              stmt.executeQuery("SELECT * FROM cartesian WHERE x_party = 9 AND y_contract = 9 AND z_state = 9")
+            )
+            predicate <- IO.delay(rs.getString("lock_predicate"))
+            address   <- IO.delay(rs.getString("address"))
+            routine   <- IO.delay(rs.getString("routine"))
+            vk        <- IO.delay(rs.getString("vk"))
+          } yield predicate.equals(testValue) && address.equals(testValue) && routine.equals(testValue) && vk.equals(
+            testValue
+          )
+        }
+      } yield count == 3 && rowValid,
+      true
+    )
+  }
+
+  testDirectory.test("getIndicesBySignature") { _ =>
+    val testValue = "testValue"
+    val idx = Indices(9, 9, 9)
+    val proposition = Proposition.DigitalSignature(testValue, mockMainKeyPair.vk)
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        update <- walletStateApi.updateWalletState(
+          testValue,
+          testValue,
+          Some(testValue),
+          Some(Encoding.encodeToBase58(proposition.verificationKey.toByteArray)),
+          idx
+        )
+        indices <- walletStateApi.getIndicesBySignature(proposition)
+      } yield indices.isDefined && indices.get == idx,
+      true
+    )
+  }
+
+  testDirectory.test("getLockByIndex") { _ =>
+    val testValue = "testValue"
+    val idx = Indices(9, 9, 9)
+    val predicate = Lock.Predicate(Seq(), 1)
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        update <- walletStateApi.updateWalletState(
+          Encoding.encodeToBase58Check(predicate.toByteArray),
+          testValue,
+          None,
+          None,
+          idx
+        )
+        lock <- walletStateApi.getLockByIndex(idx)
+      } yield lock.isDefined && lock.get == predicate,
+      true
+    )
+  }
+
+  testDirectory.test("getNextIndicesForFunds") { _ =>
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        idx  <- walletStateApi.getNextIndicesForFunds("self", "default")
+      } yield idx.isDefined && idx.get == Indices(1, 1, 2),
+      true
+    )
+  }
+
+  testDirectory.test("validateCurrentIndicesForFunds") { _ =>
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        idx  <- walletStateApi.validateCurrentIndicesForFunds("self", "default", None)
+      } yield idx.isValid && idx.toOption.get == Indices(1, 1, 1),
+      true
+    )
+  }
+
+  testDirectory.test("getAddress") { _ =>
+    val testValue = "testValue"
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        update <- walletStateApi.updateWalletState(
+          testValue,
+          testValue,
+          Some(testValue),
+          Some(testValue),
+          Indices(1, 1, 2)
+        )
+        addr <- walletStateApi.getAddress("self", "default", None)
+      } yield addr.isDefined && addr.get.equals(testValue),
+      true
+    )
+  }
+
+  testDirectory.test("getCurrentIndicesForFunds") { _ =>
+    val testValue = "testValue"
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        idx  <- walletStateApi.getCurrentIndicesForFunds("self", "default", None)
+      } yield idx.isDefined && idx.get == Indices(1, 1, 1),
+      true
+    )
+  }
+
+  testDirectory.test("getCurrentAddress") { _ =>
+    val testValue = "testValue"
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        update <- walletStateApi.updateWalletState(
+          testValue,
+          testValue,
+          Some(testValue),
+          Some(testValue),
+          Indices(1, 1, 2)
+        )
+        addr <- walletStateApi.getCurrentAddress
+      } yield addr.equals(testValue),
+      true
+    )
+  }
+
+  testDirectory.test("getPreimage") { _ =>
+    val proposition = Proposition.Digest("testValue", Digest(ByteString.copyFrom(Array.fill(32)(0: Byte))))
+    assertIO(
+      for {
+        preimage <- walletStateApi.getPreimage(proposition)
+      } yield preimage.isEmpty,
+      true
+    )
+  }
+
+  testDirectory.test("addEntityVks then getEntityVks") { _ =>
+    val testValues = List("testValue1", "testValue2")
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        _    <- walletStateApi.addEntityVks("test", "default", testValues)
+        vks  <- walletStateApi.getEntityVks("test", "default")
+      } yield vks.isDefined && vks.get == testValues,
+      true
+    )
+  }
+
+  testDirectory.test("addNewLockTemplate then getLockTemplate") { _ =>
+    val lockTemplate: LockTemplate[IO] =
+      LockTemplate.PredicateTemplate[IO](List(PropositionTemplate.HeightTemplate[IO]("chain", 0, 100)), 1)
+    assertIO(
+      for {
+        init     <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        _        <- walletStateApi.addNewLockTemplate("height", lockTemplate)
+        template <- walletStateApi.getLockTemplate("height")
+      } yield template.isDefined && template.get == lockTemplate,
+      true
+    )
+  }
+
+  testDirectory.test("getLock") { _ =>
+    val lockTemplate: LockTemplate[IO] =
+      LockTemplate.PredicateTemplate[IO](List(PropositionTemplate.SignatureTemplate[IO]("routine", 0)), 1)
+    val entityVks = List(mockMainKeyPair.vk)
+    assertIO(
+      for {
+        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        _    <- walletStateApi.addNewLockTemplate("test", lockTemplate)
+        _ <- walletStateApi.addEntityVks("self", "test", entityVks.map(vk => Encoding.encodeToBase58(vk.toByteArray)))
+        lock <- walletStateApi.getLock("self", "test", 2)
+      } yield lock.isDefined && lock.get.getPredicate.challenges.head.getRevealed.value
+        .isInstanceOf[Proposition.Value.DigitalSignature],
+      true
+    )
+  }
+
 }

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -1,40 +1,17 @@
 package co.topl.brambl.servicekit
 
-import cats.Id
 import cats.effect.IO
-import cats.effect.kernel.Resource
-import co.topl.brambl.builders.TransactionBuilderApi
 import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
-import co.topl.brambl.constants.NetworkConstants._
-import co.topl.brambl.dataApi.WalletStateAlgebra
 import co.topl.brambl.models.Indices
 import co.topl.brambl.models.box.Lock
 import co.topl.brambl.utils.Encoding
-import co.topl.brambl.wallet.WalletApi.cryptoToPbKeyPair
-import co.topl.crypto.generation.KeyInitializer.Instances.extendedEd25519Initializer
-import co.topl.crypto.signing.{ExtendedEd25519, KeyPair}
+
 import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
 import quivr.models.Digest
 import quivr.models.{Proposition, VerificationKey}
 
-import java.sql.Connection
-
-class WalletStateApiSpec extends CatsEffectSuite with WalletStateResource with BaseSpec {
-
-  val DB_FILE = s"$TEST_DIR/wallet.db"
-
-  val dbConnection: Resource[IO, Connection] = walletResource(DB_FILE)
-
-  val transactionBuilderApi: TransactionBuilderApi[IO] =
-    TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
-  val walletStateApi: WalletStateAlgebra[IO] = WalletStateApi.make[IO](dbConnection, transactionBuilderApi, walletApi)
-
-  private def mockMainKeyPair = {
-    implicit val extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519
-    val sk = extendedEd25519Initializer.random()
-    cryptoToPbKeyPair(KeyPair(sk, extendedEd25519Instance.getVerificationKey(sk)))
-  }
+class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
 
   testDirectory.test("initWalletState") { _ =>
     assertIO(


### PR DESCRIPTION
## Purpose

Add the service kit implementation. This kit provides a base implementation of the WalletKeyApi (persisting to disk), PartyStorageApi, ContractStorageApi, and WalletStateApi (latter 3 using sqlite).

## Approach

- Migrate the bulk of the implementation from brambl-cli; traits in brambl-sdk and interpreters in the service kit
- Made additions to WalletKeyApi (previously update and delete were not implemented)
- Updated WalletApi in brambl-sdk: Added save mnemonic functionality, and removed older stubs for wallet recovery that will not exist in brambl-sdk
- Wrote tests

## Testing

- Wrote tests for each of the APIs
- Ensured all existing tests pass
- Consumed this package in brambl-cli

## Tickets
* Closes TSDK-532