### PR TITLE
TSDK-532 Remove reference to network id where not necessary

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
@@ -14,9 +14,11 @@ trait WalletStateAlgebra[F[_]] {
   /**
    * Initialize the wallet state with the given verification key
    *
+   * @param networkId The network id to initialize the wallet state with
+   * @param ledgerId The ledger id to initialize the wallet state with
    * @param vk The verification key to initialize the wallet state with
    */
-  def initWalletState(vk: VerificationKey): F[Unit]
+  def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit]
 
   /**
    * Get the indices associated to a signature proposition

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -30,7 +30,7 @@ object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
     propEvidenceToPreimage.get(digestProposition.sizedEvidence)
 
   // The following are not implemented since they are not used in the tests
-  override def initWalletState(vk: VerificationKey): Id[Unit] = ???
+  override def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): Id[Unit] = ???
 
   override def getCurrentAddress: Id[String] = ???
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -522,7 +522,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
           bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
         ).get(signatureProposition.sizedEvidence)
 
-      override def initWalletState(vk:            VerificationKey): Id[Unit] = ???
+      override def initWalletState(networkId:     Int, ledgerId: Int, vk: VerificationKey): Id[Unit] = ???
       override def getPreimage(digestProposition: Proposition.Digest): Id[Option[Preimage]] = ???
       override def getCurrentAddress: Id[String] = ???
       override def updateWalletState(

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val commonScalacOptions = Seq(
 )
 
 lazy val commonSettings = Seq(
+  fork := true,
   scalacOptions ++= commonScalacOptions,
   semanticdbEnabled := true, // enable SemanticDB for Scalafix
   Compile / unmanagedSourceDirectories += {

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/BaseSpec.scala
@@ -31,7 +31,7 @@ trait BaseSpec extends CatsEffectSuite with WalletStateResource {
   val transactionBuilderApi: TransactionBuilderApi[IO] =
     TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
   val dbConnection: Resource[IO, Connection] = walletResource(DB_FILE)
-  val walletStateApi: WalletStateAlgebra[IO] = WalletStateApi.make[IO](dbConnection, transactionBuilderApi, walletApi)
+  val walletStateApi: WalletStateAlgebra[IO] = WalletStateApi.make[IO](dbConnection, walletApi)
 
   def mockMainKeyPair: models.KeyPair = {
     implicit val extendedEd25519Instance: ExtendedEd25519 = new ExtendedEd25519

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/ContractStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/ContractStorageApiSpec.scala
@@ -5,6 +5,7 @@ import co.topl.brambl.builders.locks.{LockTemplate, PropositionTemplate}
 import co.topl.brambl.codecs.LockTemplateCodecs.encodeLockTemplate
 import co.topl.brambl.dataApi.{ContractStorageAlgebra, WalletContract}
 import munit.CatsEffectSuite
+import co.topl.brambl.constants.NetworkConstants
 
 class ContractStorageApiSpec extends CatsEffectSuite with BaseSpec {
 
@@ -17,7 +18,8 @@ class ContractStorageApiSpec extends CatsEffectSuite with BaseSpec {
     val contract = WalletContract(3, "testContract", lockTemplateStr)
     assertIO(
       for {
-        init      <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         _         <- contractApi.addContract(contract)
         contracts <- contractApi.findContracts()
       } yield contracts.length == 3 && contracts.last == contract,

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/PartyStorageApiSpec.scala
@@ -3,6 +3,7 @@ package co.topl.brambl.servicekit
 import cats.effect.IO
 import co.topl.brambl.dataApi.{PartyStorageAlgebra, WalletEntity}
 import munit.CatsEffectSuite
+import co.topl.brambl.constants.NetworkConstants
 
 class PartyStorageApiSpec extends CatsEffectSuite with BaseSpec {
 
@@ -12,7 +13,8 @@ class PartyStorageApiSpec extends CatsEffectSuite with BaseSpec {
     val party = WalletEntity(2, "testParty")
     assertIO(
       for {
-        init    <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         _       <- partyApi.addParty(party)
         parties <- partyApi.findParties()
       } yield parties.length == 3 && parties.last == party,

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -10,13 +10,18 @@ import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
 import quivr.models.Digest
 import quivr.models.{Proposition, VerificationKey}
+import co.topl.brambl.constants.NetworkConstants
 
 class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
 
   testDirectory.test("initWalletState") { _ =>
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi.initWalletState(
+          NetworkConstants.PRIVATE_NETWORK_ID,
+          NetworkConstants.MAIN_NETWORK_ID,
+          mockMainKeyPair.vk
+        )
         partyCount <- dbConnection.use { conn =>
           for {
             stmt <- IO.delay(conn.createStatement())
@@ -58,7 +63,11 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val testValue = "testValue"
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi.initWalletState(
+          NetworkConstants.PRIVATE_NETWORK_ID,
+          NetworkConstants.MAIN_NETWORK_ID,
+          mockMainKeyPair.vk
+        )
         update <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -100,7 +109,8 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val proposition = Proposition.DigitalSignature(testValue, mockMainKeyPair.vk)
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         update <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -120,7 +130,8 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val predicate = Lock.Predicate(Seq(), 1)
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         update <- walletStateApi.updateWalletState(
           Encoding.encodeToBase58Check(predicate.toByteArray),
           testValue,
@@ -137,8 +148,9 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
   testDirectory.test("getNextIndicesForFunds") { _ =>
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
-        idx  <- walletStateApi.getNextIndicesForFunds("self", "default")
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+        idx <- walletStateApi.getNextIndicesForFunds("self", "default")
       } yield idx.isDefined && idx.get == Indices(1, 1, 2),
       true
     )
@@ -147,8 +159,9 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
   testDirectory.test("validateCurrentIndicesForFunds") { _ =>
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
-        idx  <- walletStateApi.validateCurrentIndicesForFunds("self", "default", None)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+        idx <- walletStateApi.validateCurrentIndicesForFunds("self", "default", None)
       } yield idx.isValid && idx.toOption.get == Indices(1, 1, 1),
       true
     )
@@ -158,7 +171,8 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val testValue = "testValue"
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         update <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -176,8 +190,9 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val testValue = "testValue"
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
-        idx  <- walletStateApi.getCurrentIndicesForFunds("self", "default", None)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+        idx <- walletStateApi.getCurrentIndicesForFunds("self", "default", None)
       } yield idx.isDefined && idx.get == Indices(1, 1, 1),
       true
     )
@@ -187,7 +202,8 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val testValue = "testValue"
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         update <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -215,9 +231,10 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val testValues = List("testValue1", "testValue2")
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
-        _    <- walletStateApi.addEntityVks("test", "default", testValues)
-        vks  <- walletStateApi.getEntityVks("test", "default")
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+        _   <- walletStateApi.addEntityVks("test", "default", testValues)
+        vks <- walletStateApi.getEntityVks("test", "default")
       } yield vks.isDefined && vks.get == testValues,
       true
     )
@@ -228,7 +245,8 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
       LockTemplate.PredicateTemplate[IO](List(PropositionTemplate.HeightTemplate[IO]("chain", 0, 100)), 1)
     assertIO(
       for {
-        init     <- walletStateApi.initWalletState(mockMainKeyPair.vk)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
         _        <- walletStateApi.addNewLockTemplate("height", lockTemplate)
         template <- walletStateApi.getLockTemplate("height")
       } yield template.isDefined && template.get == lockTemplate,
@@ -242,8 +260,9 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     val entityVks = List(mockMainKeyPair.vk)
     assertIO(
       for {
-        init <- walletStateApi.initWalletState(mockMainKeyPair.vk)
-        _    <- walletStateApi.addNewLockTemplate("test", lockTemplate)
+        init <- walletStateApi
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+        _ <- walletStateApi.addNewLockTemplate("test", lockTemplate)
         _ <- walletStateApi.addEntityVks("self", "test", entityVks.map(vk => Encoding.encodeToBase58(vk.toByteArray)))
         lock <- walletStateApi.getLock("self", "test", 2)
       } yield lock.isDefined && lock.get.getPredicate.challenges.head.getRevealed.value


### PR DESCRIPTION
## Purpose

The goal of this PR is to remove the network id where not necessary.

## Approach

We require new parameters for some methods of the WalletStateAlgebra so that we do not need the transactionApi as a dependency.

## Testing

The tests were fixed.

## Tickets

* TSDK-532