### PR TITLE
TSDK-572 Address WalletApi flaky test with CatsUnsafeResource

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/utils/CatsUnsafeResource.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/utils/CatsUnsafeResource.scala
@@ -1,17 +1,12 @@
 package co.topl.brambl.utils
 
-
-import cats.Id
 import cats.data.OptionT
 import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.effect.std.Queue
 import cats.implicits._
-import cats.{Applicative, Monad}
 import cats.implicits.{toFlatMapOps, toFunctorOps}
-import cats.implicits.catsSyntaxApplicativeId
-
 
 /**
  * Manages thread-unsafe resources in a thread-safe manner by utilizing a cats-effect queue. Inactive resources

--- a/brambl-sdk/src/main/scala/co/topl/brambl/utils/CatsUnsafeResource.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/utils/CatsUnsafeResource.scala
@@ -1,0 +1,36 @@
+package co.topl.brambl.utils
+
+
+import cats.Id
+import cats.data.OptionT
+import cats.effect.Async
+import cats.effect.Resource
+import cats.effect.Sync
+import cats.effect.std.Queue
+import cats.implicits._
+import cats.{Applicative, Monad}
+import cats.implicits.{toFlatMapOps, toFunctorOps}
+import cats.implicits.catsSyntaxApplicativeId
+
+
+/**
+ * Manages thread-unsafe resources in a thread-safe manner by utilizing a cats-effect queue. Inactive resources
+ * sit in a queue.  As requests arrive, a resource is dequeued, used, and then requeued.
+ */
+object CatsUnsafeResource {
+
+  def make[F[_]: Async, T](init: => T, maxParallelism: Int): F[Resource[F, T]] =
+    for {
+      _     <- Async[F].raiseWhen(maxParallelism < 1)(new IllegalArgumentException("Invalid maxParallelism"))
+      queue <- Queue.unbounded[F, Option[T]]
+      // Launch with several uninitialized resources
+      _ <- 0.iterateUntilM(i => queue.offer(None).as(i + 1))(_ >= maxParallelism)
+      res = Resource.make(
+        Sync[F].defer(
+          OptionT(queue.take)
+            // If an uninitialized resource was pulled, initialize it
+            .getOrElseF(Async[F].delay(init))
+        )
+      )(t => Sync[F].defer(queue.offer(t.some)))
+    } yield res
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -291,7 +291,7 @@ object WalletApi {
    * @param walletKeyApi The Api to use to handle wallet key persistence
    * @return A new WalletAPI instance
    */
-  def make[F[_]: Monad: Async](walletKeyApi: WalletKeyApiAlgebra[F]): WalletApi[F] = new WalletApi[F] {
+  def make[F[_]: Async](walletKeyApi: WalletKeyApiAlgebra[F]): WalletApi[F] = new WalletApi[F] {
     final val Purpose = 1852
     final val CoinType = 7091
     val kdf: Kdf[F] = SCrypt.make[F](SCrypt.SCryptParams(SCrypt.generateSalt))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -1,19 +1,10 @@
 package co.topl.brambl
 
 import cats.Id
+import cats.effect.IO
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
-import co.topl.brambl.builders.locks.PropositionTemplate.{
-  AndTemplate,
-  DigestTemplate,
-  HeightTemplate,
-  LockedTemplate,
-  NotTemplate,
-  OrTemplate,
-  SignatureTemplate,
-  ThresholdTemplate,
-  TickTemplate
-}
+import co.topl.brambl.builders.locks.PropositionTemplate.{AndTemplate, DigestTemplate, HeightTemplate, LockedTemplate, NotTemplate, OrTemplate, SignatureTemplate, ThresholdTemplate, TickTemplate}
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
@@ -30,19 +21,7 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.quivr.api.Proposer
 import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
-import quivr.models.{
-  Data,
-  Digest,
-  Int128,
-  KeyPair,
-  Preimage,
-  Proof,
-  Proposition,
-  SignableBytes,
-  SmallData,
-  VerificationKey,
-  Witness
-}
+import quivr.models.{Data, Digest, Int128, KeyPair, Preimage, Proof, Proposition, SignableBytes, SmallData, VerificationKey, Witness}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
@@ -52,6 +31,8 @@ import io.circe.Json
 import org.bouncycastle.util.Strings
 
 trait MockHelpers {
+  type F[A] = IO[A]
+
   val fakeMsgBind: SignableBytes = "transaction binding".getBytes.immutable.signable
 
   val MockIndices: Indices = Indices(0, 0, 0)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -4,7 +4,17 @@ import cats.Id
 import cats.effect.IO
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
-import co.topl.brambl.builders.locks.PropositionTemplate.{AndTemplate, DigestTemplate, HeightTemplate, LockedTemplate, NotTemplate, OrTemplate, SignatureTemplate, ThresholdTemplate, TickTemplate}
+import co.topl.brambl.builders.locks.PropositionTemplate.{
+  AndTemplate,
+  DigestTemplate,
+  HeightTemplate,
+  LockedTemplate,
+  NotTemplate,
+  OrTemplate,
+  SignatureTemplate,
+  ThresholdTemplate,
+  TickTemplate
+}
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
@@ -21,7 +31,19 @@ import co.topl.crypto.hash.Blake2b256
 import co.topl.quivr.api.Proposer
 import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
-import quivr.models.{Data, Digest, Int128, KeyPair, Preimage, Proof, Proposition, SignableBytes, SmallData, VerificationKey, Witness}
+import quivr.models.{
+  Data,
+  Digest,
+  Int128,
+  KeyPair,
+  Preimage,
+  Proof,
+  Proposition,
+  SignableBytes,
+  SmallData,
+  VerificationKey,
+  Witness
+}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
@@ -1,6 +1,7 @@
 package co.topl.brambl
 
 import cats.Id
+import cats.effect.IO
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra.WalletKeyException
 import co.topl.crypto.encryption.VaultStore
@@ -11,51 +12,51 @@ import io.circe.syntax.EncoderOps
 /**
  * Mock Implementation of the DataApi
  */
-object MockWalletKeyApi extends WalletKeyApiAlgebra[Id] with MockHelpers {
+object MockWalletKeyApi extends WalletKeyApiAlgebra[IO] with MockHelpers {
 
   var mainKeyVaultStoreInstance: Map[String, Json] = Map()
   var mnemonicInstance: Map[String, IndexedSeq[String]] = Map()
 
   override def saveMainKeyVaultStore(
-    mainKeyVaultStore: VaultStore[Id],
+    mainKeyVaultStore: VaultStore[IO],
     name:              String = "default"
-  ): Id[Either[WalletKeyException, Unit]] =
-    if ("error".equals(name)) Left(MainKeyVaultSaveFailure) // Mocking a save failure
+  ): IO[Either[WalletKeyException, Unit]] =
+    if ("error".equals(name)) IO.pure(Left(MainKeyVaultSaveFailure)) // Mocking a save failure
     else {
       mainKeyVaultStoreInstance += (name -> mainKeyVaultStore.asJson)
-      Right(())
+      IO.pure(Right(()))
     }
 
   override def getMainKeyVaultStore(
     name: String = "default"
-  ): Id[Either[WalletKeyException, VaultStore[Id]]] =
+  ): IO[Either[WalletKeyException, VaultStore[Id]]] =
     if (mainKeyVaultStoreInstance.getOrElse(name, Json.Null).isNull)
-      Left(MainKeyVaultStoreNotInitialized)
+      IO.pure(Left(MainKeyVaultStoreNotInitialized))
     else
-      mainKeyVaultStoreInstance(name)
+      IO.pure(mainKeyVaultStoreInstance(name)
         .as[VaultStore[Id]]
         .left
-        .map(MainKeyVaultInvalid(_))
+        .map(MainKeyVaultInvalid(_)))
 
   override def updateMainKeyVaultStore(
-    mainKeyVaultStore: VaultStore[Id],
+    mainKeyVaultStore: VaultStore[IO],
     name:              String = "default"
-  ): Id[Either[WalletKeyException, Unit]] =
+  ): IO[Either[WalletKeyException, Unit]] =
     if (
       mainKeyVaultStoreInstance.getOrElse(name, Json.Null).isNull
     ) // not using getMainKeyVaultStore since it's okay if the existing VaultStore is invalid
-      Left(MainKeyVaultStoreNotInitialized) // if the existing VaultStore does not exist, return an error
+      IO.pure(Left(MainKeyVaultStoreNotInitialized)) // if the existing VaultStore does not exist, return an error
     else saveMainKeyVaultStore(mainKeyVaultStore, name)
 
-  override def deleteMainKeyVaultStore(name: String = "default"): Id[Either[WalletKeyException, Unit]] =
+  override def deleteMainKeyVaultStore(name: String = "default"): IO[Either[WalletKeyException, Unit]] =
     if (
       mainKeyVaultStoreInstance.getOrElse(name, Json.Null).isNull
     ) // not using getMainKeyVaultStore since it's okay if the existing VaultStore is invalid
       // if the existing VaultStore does not exist, return an error
-      Left(MainKeyVaultDeleteFailure)
+      IO.pure(Left(MainKeyVaultDeleteFailure))
     else {
       mainKeyVaultStoreInstance -= name
-      Right(())
+      IO.pure(Right(()))
     }
   case object MainKeyVaultStoreNotInitialized extends WalletKeyException("MainKeyVaultStore not initialized")
 
@@ -67,8 +68,8 @@ object MockWalletKeyApi extends WalletKeyApiAlgebra[Id] with MockHelpers {
   override def saveMnemonic(
     mnemonic:     IndexedSeq[String],
     mnemonicName: String
-  ): Id[Either[WalletKeyException, Unit]] = {
+  ): IO[Either[WalletKeyException, Unit]] = {
     mnemonicInstance += (mnemonicName -> mnemonic)
-    Right(())
+    IO.pure(Right(()))
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
@@ -29,14 +29,16 @@ object MockWalletKeyApi extends WalletKeyApiAlgebra[IO] with MockHelpers {
 
   override def getMainKeyVaultStore(
     name: String = "default"
-  ): IO[Either[WalletKeyException, VaultStore[Id]]] =
+  ): IO[Either[WalletKeyException, VaultStore[IO]]] =
     if (mainKeyVaultStoreInstance.getOrElse(name, Json.Null).isNull)
       IO.pure(Left(MainKeyVaultStoreNotInitialized))
     else
-      IO.pure(mainKeyVaultStoreInstance(name)
-        .as[VaultStore[Id]]
-        .left
-        .map(MainKeyVaultInvalid(_)))
+      IO.pure(
+        mainKeyVaultStoreInstance(name)
+          .as[VaultStore[IO]]
+          .left
+          .map(MainKeyVaultInvalid(_))
+      )
 
   override def updateMainKeyVaultStore(
     mainKeyVaultStore: VaultStore[IO],

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -2,6 +2,7 @@ package co.topl.brambl
 
 import cats.Id
 import cats.data.ValidatedNel
+import cats.effect.IO
 import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances._
@@ -13,7 +14,7 @@ import quivr.models._
 /**
  * Mock Implementation of the WalletStateAlgebra for testing
  */
-object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
+object MockWalletStateApi extends WalletStateAlgebra[IO] with MockHelpers {
 
   val propEvidenceToIdx: Map[Evidence, Indices] = Map(
     MockSignatureProposition.value.digitalSignature.get.sizedEvidence -> MockIndices
@@ -23,16 +24,16 @@ object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
     MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
   )
 
-  override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): Option[Indices] =
-    propEvidenceToIdx.get(signatureProposition.sizedEvidence)
+  override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]] =
+    IO.pure(propEvidenceToIdx.get(signatureProposition.sizedEvidence))
 
-  override def getPreimage(digestProposition: Proposition.Digest): Option[Preimage] =
-    propEvidenceToPreimage.get(digestProposition.sizedEvidence)
+  override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] =
+    IO.pure(propEvidenceToPreimage.get(digestProposition.sizedEvidence))
 
   // The following are not implemented since they are not used in the tests
-  override def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): Id[Unit] = ???
+  override def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???
 
-  override def getCurrentAddress: Id[String] = ???
+  override def getCurrentAddress: F[String] = ???
 
   override def updateWalletState(
     lockPredicate: String,
@@ -40,30 +41,30 @@ object MockWalletStateApi extends WalletStateAlgebra[Id] with MockHelpers {
     routine:       Option[String],
     vk:            Option[String],
     indices:       Indices
-  ): Id[Unit] = ???
+  ): F[Unit] = ???
 
-  override def getCurrentIndicesForFunds(party: String, contract: String, someState: Option[Int]): Id[Option[Indices]] =
+  override def getCurrentIndicesForFunds(party: String, contract: String, someState: Option[Int]): F[Option[Indices]] =
     ???
 
   override def validateCurrentIndicesForFunds(
     party:     String,
     contract:  String,
     someState: Option[Int]
-  ): Id[ValidatedNel[String, Indices]] = ???
+  ): F[ValidatedNel[String, Indices]] = ???
 
-  override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
+  override def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]] = ???
 
-  override def getLockByIndex(indices: Indices): Id[Option[Lock.Predicate]] = ???
+  override def getLockByIndex(indices: Indices): F[Option[Lock.Predicate]] = ???
 
-  override def getAddress(party: String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
+  override def getAddress(party: String, contract: String, someState: Option[Int]): F[Option[String]] = ???
 
-  override def addEntityVks(party: String, contract: String, entities: List[String]): Id[Unit] = ???
+  override def addEntityVks(party: String, contract: String, entities: List[String]): F[Unit] = ???
 
-  override def getEntityVks(party: String, contract: String): Id[Option[List[String]]] = ???
+  override def getEntityVks(party: String, contract: String): F[Option[List[String]]] = ???
 
-  override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
+  override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[F]): F[Unit] = ???
 
-  override def getLockTemplate(contract: String): Id[Option[LockTemplate[Id]]] = ???
+  override def getLockTemplate(contract: String): F[Option[LockTemplate[F]]] = ???
 
-  override def getLock(party: String, contract: String, nextState: Int): Id[Option[Lock]] = ???
+  override def getLock(party: String, contract: String, nextState: Int): F[Option[Lock]] = ???
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/utils/CatsUnsafeResourceSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/utils/CatsUnsafeResourceSpec.scala
@@ -1,0 +1,38 @@
+package co.topl.brambl.utils
+
+import cats.effect.IO
+import cats.effect.Sync
+import cats.implicits._
+import munit.CatsEffectSuite
+
+class CatsUnsafeResourceSpec extends CatsEffectSuite {
+
+  type F[A] = IO[A]
+
+  test("give thread safety to mutable data") {
+    val a1 = Array.fill(16)(0: Byte)
+    val a2 = Array.fill(16)(1: Byte)
+    for {
+      underTest <- CatsUnsafeResource.make[F, MutableResource](new MutableResource(16), 1)
+      (r1, r2) <- (
+        underTest.use(d => Sync[F].delay { d.setBytesSlowly(a1); d.getArrayCopy }),
+        underTest.use(d => Sync[F].delay { d.setBytesSlowly(a2); d.getArrayCopy })
+      ).parTupled
+      _ = assert(r1 sameElements a1)
+      _ = assert(r2 sameElements a2)
+    } yield ()
+  }
+
+}
+
+private class MutableResource(length: Int) {
+  private val array = new Array[Byte](length)
+  def set(index: Int, byte: Byte): Unit = array(index) = byte
+
+  def setBytesSlowly(newBytes: Array[Byte]): Unit =
+    newBytes.zipWithIndex.foreach { case (byte, idx) =>
+      set(idx, byte)
+      Thread.sleep(100)
+    }
+  def getArrayCopy: Array[Byte] = array.clone()
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -80,13 +80,17 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
   }
 
   test("validate: Single Input Transaction with Attestation.Predicate > Validation successful") {
-    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
-    val provenTx: IoTransaction = credentialler.prove(txFull)
     val ctx = Context[F](txFull, 50, _ => None) // Tick satisfies a proposition
-    val errsNum = credentialler.validate(provenTx, ctx).length
-    // Although not all but propositions pass, threshold is met so authorization is successful
-    // Transaction syntax is also valid
-    assertEquals(errsNum, 0)
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
+    assertIO(
+      for {
+        provenTx <- credentialler.prove(txFull)
+        errs <- credentialler.validate(provenTx, ctx)
+        // Although not all but propositions pass, threshold is met so authorization is successful
+        // Transaction syntax is also valid
+      } yield errs.length.isEmpty,
+      true
+    )
   }
 
   test("validate: Single Input Transaction with Attestation.Predicate > Validation failed") {
@@ -94,60 +98,81 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
       Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
-    val provenTx: IoTransaction = credentialler.prove(testTx)
     val ctx = Context[F](testTx, 500, _ => None) // Tick does not satisfies proposition
-    val errs = credentialler.validate(provenTx, ctx)
-    // Threshold is not met so authorization failed
-    // Transaction syntax is also invalid
-    assertEquals(errs.length, 2)
-    assert(
-      errs.contains(TransactionSyntaxError.NonPositiveOutputValue(negativeValue)),
+    val provenTxWrapped = credentialler.prove(testTx)
+    val errsWrapped = provenTxWrapped.flatMap(credentialler.validate(_, ctx))
+    assertIO(
+      errsWrapped.map(_.length == 2),
+      true,
+      "Threshold is not met so authorization failed and Transaction syntax is also invalid"
+    )
+    assertIO(
+      errsWrapped.map(_.contains(TransactionSyntaxError.NonPositiveOutputValue(negativeValue))),
+      true,
       "NonPositiveOutputValue Syntax Error is expected"
     )
-    val provenAttestation = provenTx.inputs.head.attestation.getPredicate
-    assert(errs.tail.head.isInstanceOf[AuthorizationFailed], "AuthorizationFailed error is expected")
-    assert(
-      errs.tail.head.asInstanceOf[AuthorizationFailed].errors.length == 3,
+    assertIO(
+      errsWrapped.map(_.tail.head.isInstanceOf[AuthorizationFailed]),
+      true,
+      "AuthorizationFailed error is expected"
+    )
+    assertIO(
+      errsWrapped.map(_.tail.head.asInstanceOf[AuthorizationFailed].errors.length == 3),
+      true,
       "AuthorizationFailed error expects exactly 3 errors"
     )
-    assert(
-      errs.tail.head.asInstanceOf[AuthorizationFailed].errors.contains(LockedPropositionIsUnsatisfiable),
-      s"AuthorizationFailed error expects errors Locked error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+    assertIO(
+      errsWrapped.map(_.tail.head.asInstanceOf[AuthorizationFailed].errors.contains(LockedPropositionIsUnsatisfiable)),
+      true,
+      s"AuthorizationFailed error expects errors Locked error. Received: ${errsWrapped.map(_.tail.head.asInstanceOf[AuthorizationFailed].errors)}"
     )
-    assert(
-      errs.tail.head
-        .asInstanceOf[AuthorizationFailed]
-        .errors
-        // TODO: fix .getRevealed
-        .contains(
-          EvaluationAuthorizationFailed(
-            provenAttestation.lock.challenges(3).getRevealed,
-            provenAttestation.responses(3)
+    assertIO(
+      for {
+        provenAttestation <- provenTxWrapped.map(_.inputs.head.attestation.getPredicate)
+        errs <- errsWrapped
+      } yield {
+        errs.tail.head
+          .asInstanceOf[AuthorizationFailed]
+          .errors
+          // TODO: fix .getRevealed once implemented on the node
+          .contains(
+            EvaluationAuthorizationFailed(
+              provenAttestation.lock.challenges(3).getRevealed,
+              provenAttestation.responses(3)
+            )
           )
-        ),
-      s"AuthorizationFailed error expects Height error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+      },
+      true,
+      s"AuthorizationFailed error expects errors Height error. Received: ${errsWrapped.map(_.tail.head.asInstanceOf[AuthorizationFailed].errors)}"
     )
-    assert(
-      errs.tail.head
-        .asInstanceOf[AuthorizationFailed]
-        .errors
-        // TODO: fix .getRevealed
-        .contains(
-          EvaluationAuthorizationFailed(
-            provenAttestation.lock.challenges(4).getRevealed,
-            provenAttestation.responses(4)
+    assertIO(
+      for {
+        provenAttestation <- provenTxWrapped.map(_.inputs.head.attestation.getPredicate)
+        errs <- errsWrapped
+      } yield {
+        errs.tail.head
+          .asInstanceOf[AuthorizationFailed]
+          .errors
+          // TODO: fix .getRevealed once implemented on the node
+          .contains(
+            EvaluationAuthorizationFailed(
+              provenAttestation.lock.challenges(4).getRevealed,
+              provenAttestation.responses(4)
+            )
           )
-        ),
-      s"AuthorizationFailed error expects Tick error. Received: ${errs.tail.head.asInstanceOf[AuthorizationFailed].errors}"
+      },
+      true,
+      s"AuthorizationFailed error expects errors Tick error. Received: ${errsWrapped.map(_.tail.head.asInstanceOf[AuthorizationFailed].errors)}"
     )
   }
 
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation successful") {
     val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
     val ctx = Context[F](txFull, 50, _ => None) // Tick satisfies a proposition
-    val res = credentialler.proveAndValidate(txFull, ctx)
-
-    assertEquals(res.isRight, true)
+    assertIO(
+      credentialler.proveAndValidate(txFull, ctx).map(_.isRight),
+      true
+    )
   }
 
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation failed") {
@@ -156,354 +181,383 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
     val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
     val ctx = Context[F](testTx, 500, _ => None) // Tick does not satisfies proposition
-    val res = credentialler.proveAndValidate(testTx, ctx)
-    assertEquals(res.isLeft, true)
-    assertEquals(res.swap.getOrElse(List.empty).length, 2)
+    assertIO(
+      for {
+        res <- credentialler.proveAndValidate(testTx, ctx)
+      } yield res.isLeft && (res.swap.getOrElse(List.empty).length == 2),
+      true
+    )
   }
 
   test(
     "proveAndValidate: Credentialler initialized with a main key different than used to create Single Input Transaction with Attestation.Predicate > Validation Failed"
   ) {
-    val differentKeyPair = WalletApi.make[F](MockWalletKeyApi).deriveChildKeys(MockMainKeyPair, Indices(0, 0, 1))
-    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, differentKeyPair)
     // Tick satisfies its proposition. Height does not.
     val ctx = Context[F](txFull, 50, _ => None)
-    val res = credentialler.proveAndValidate(txFull, ctx)
-
-    assert(res.isLeft, s"Result expecting to be left. Received ${res}")
+    val differentKeyPair = WalletApi.make[F](MockWalletKeyApi).deriveChildKeys(MockMainKeyPair, Indices(0, 0, 1))
+    val credentialler = differentKeyPair.map(CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, _))
+    val res = credentialler.flatMap(_.proveAndValidate(txFull, ctx))
     // The DigitalSignature proof fails. Including Locked and Height failure, 3 errors are expected
-    val errs = res.left.getOrElse(List.empty).head.asInstanceOf[AuthorizationFailed].errors
-    assert(
-      errs.length == 3,
-      s"AuthorizationFailed errors expects exactly 3 errors. Received: ${errs.length}"
+    val errs = res.map(_.left.getOrElse(List.empty).head.asInstanceOf[AuthorizationFailed].errors)
+    assertIO(
+      res.map(_.isLeft),
+      true,
+      s"Result expecting to be left. Received ${res}"
     )
-    assert(
-      errs.exists {
+    assertIO(
+      errs.map(_.length == 3),
+      true,
+      s"AuthorizationFailed errors expects exactly 3 errors. Received: ${errs.map(_.length)}"
+    )
+    assertIO(
+      errs.map(_.exists {
         case EvaluationAuthorizationFailed(Proposition(Proposition.Value.DigitalSignature(_), _), _) => true
         case _                                                                                       => false
-      },
+      }),
+      true,
       s"AuthorizationFailed errors expects a DigitalSignature error. Received: ${errs}"
     )
   }
 
   test("prove: Transaction with Threshold Proposition > Threshold Proof is correctly generated") {
-    val testProposition =
-      Challenge().withRevealed(
-        Proposer.thresholdProposer[F].propose((Set(MockTickProposition, MockHeightProposition), 2))
-      )
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.thresholdProposer[F].propose((Set(MockTickProposition, MockHeightProposition), 2))
+        .map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val threshProof = provenPredicate.responses.head
+        val validThreshold = (!threshProof.value.isEmpty) && (threshProof.value.isThreshold)
+        val innerProofs = threshProof.value.threshold.get.responses
+        val validProofs = (innerProofs.length == 2) && (innerProofs.head.value.isTickRange) && (innerProofs(1).value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validThreshold && validProofs && validSignable
+      },
+      true
     )
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val threshProof = provenPredicate.responses.head
-    assert(!threshProof.value.isEmpty)
-    assert(threshProof.value.isThreshold)
-    val innerProofs = threshProof.value.threshold.get.responses
-    assert(innerProofs.length == 2)
-    assert(innerProofs.head.value.isTickRange)
-    assert(innerProofs(1).value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("prove: Transaction with And Proposition > And Proof is correctly generated") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val andProof = provenPredicate.responses.head
+        val validAnd = (!andProof.value.isEmpty) && (andProof.value.isAnd) && (andProof.value.and.get.left.value.isTickRange) && (andProof.value.and.get.right.value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validAnd && validSignable
+      },
+      true
     )
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val andProof = provenPredicate.responses.head
-    assert(!andProof.value.isEmpty)
-    assert(andProof.value.isAnd)
-    assert(andProof.value.and.get.left.value.isTickRange)
-    assert(andProof.value.and.get.right.value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
+
   }
 
   test("prove: Transaction with Or Proposition > Or Proof is correctly generated") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val orProof = provenPredicate.responses.head
+        val validAnd = (!orProof.value.isEmpty) && (orProof.value.isOr) && (orProof.value.or.get.left.value.isTickRange) && (orProof.value.or.get.right.value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validAnd && validSignable
+      },
+      true
     )
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val orProof = provenPredicate.responses.head
-    assert(!orProof.value.isEmpty)
-    assert(orProof.value.isOr)
-    assert(orProof.value.or.get.left.value.isTickRange)
-    assert(orProof.value.or.get.right.value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("prove: Transaction with Not Proposition > Not Proof is correctly generated") {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.notProposer[F].propose(MockTickProposition).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val notProof = provenPredicate.responses.head
+        val validAnd = (!notProof.value.isEmpty) && (notProof.value.isNot) && (notProof.value.not.get.proof.value.isTickRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validAnd && validSignable
+      },
+      true
     )
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val notProof = provenPredicate.responses.head
-    assert(!notProof.value.isEmpty)
-    assert(notProof.value.isNot)
-    assert(notProof.value.not.get.proof.value.isTickRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("proveAndValidate: Transaction with Threshold Proposition > Unmet Threshold fails validation") {
-    val testProposition =
-      Challenge().withRevealed(
-        Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2)
-      )
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val validationErrs = provenTx.swap.getOrElse(List.empty)
+        val validLength = validationErrs.length == 1
+
+        val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
+        val validQuivrErrs = (quivrErrs.length == 1) && (quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
+        val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
+        val validThreshold = (err.proposition == testProposition.getRevealed) && (err.proof.value.isThreshold) && (err.proof.value.threshold.get.responses.head.value.isTickRange) && (err.proof.value.threshold.get.responses(1).value.isHeightRange)
+        validLength && validQuivrErrs && validThreshold
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isLeft)
-    val validationErrs = res.swap.getOrElse(List.empty)
-    assert(validationErrs.length == 1)
-    val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
-    assert(quivrErrs.length == 1)
-    assert(quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
-    val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
-    assert(err.proposition == testProposition.getRevealed)
-    assert(err.proof.value.isThreshold)
-    assert(err.proof.value.threshold.get.responses.head.value.isTickRange)
-    assert(err.proof.value.threshold.get.responses(1).value.isHeightRange)
   }
 
   test("proveAndValidate: Transaction with And Proposition > If one inner proof fails, the And proof fails") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val validationErrs = provenTx.swap.getOrElse(List.empty)
+        val validLength = validationErrs.length == 1
+        val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
+        val validQuivrErrs = (quivrErrs.length == 1) && (quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
+        val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
+        // If an AND proposition fails, the error of the failed inner proof is returned. In this case it is the Height
+        val validAnd = (err.proposition == MockHeightProposition) && (err.proof.value.isHeightRange)
+        validLength && validQuivrErrs && validAnd
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isLeft)
-    val validationErrs = res.swap.getOrElse(List.empty)
-    assert(validationErrs.length == 1)
-    val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
-    assert(quivrErrs.length == 1)
-    assert(quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
-    // If an AND proposition fails, the error of the failed inner proof is returned. In this case it is the Height
-    assert(quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed].proposition == MockHeightProposition)
-    assert(quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed].proof.value.isHeightRange)
   }
 
   test("proveAndValidate: Transaction with Or Proposition > If both inner proofs fail, the Or proof fails") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 500, _ => None) // Tick and height should fail
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val validationErrs = provenTx.swap.getOrElse(List.empty)
+        val validLength = validationErrs.length == 1
+        val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
+        val validQuivrErrs = (quivrErrs.length == 1) && (quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
+        val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
+        val validOr = (err.proposition == testProposition.getRevealed) && (err.proof.value.isOr) && (err.proof.value.or.get.left.value.isTickRange) && (err.proof.value.or.get.right.value.isHeightRange)
+        validLength && validQuivrErrs && validOr
+      },
+      true
     )
-    val ctx = Context[F](testTx, 500, _ => None) // Tick and height should fail
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isLeft)
-    val validationErrs = res.swap.getOrElse(List.empty)
-    assert(validationErrs.length == 1)
-    val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
-    assert(quivrErrs.length == 1)
-    assert(quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
-    val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
-    assert(err.proposition == testProposition.getRevealed)
-    assert(err.proof.value.isOr)
-    assert(err.proof.value.or.get.left.value.isTickRange)
-    assert(err.proof.value.or.get.right.value.isHeightRange)
   }
 
   test("proveAndValidate: Transaction with Not Proposition > If inner proof succeeds, the Not proof fails") {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.notProposer[F].propose(MockTickProposition).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 50, _ => None) // Tick should pass
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val validationErrs = provenTx.swap.getOrElse(List.empty)
+        val validLength = validationErrs.length == 1
+        val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
+        val validQuivrErrs = (quivrErrs.length == 1) && (quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
+        val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
+        val validOr = (err.proposition == testProposition.getRevealed) && (err.proof.value.isNot) && (err.proof.value.not.get.proof.value.isTickRange)
+        validLength && validQuivrErrs && validOr
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isLeft)
-    val validationErrs = res.swap.getOrElse(List.empty)
-    assert(validationErrs.length == 1)
-    val quivrErrs = validationErrs.head.asInstanceOf[AuthorizationFailed].errors
-    assert(quivrErrs.length == 1)
-    assert(quivrErrs.head.isInstanceOf[EvaluationAuthorizationFailed])
-    val err = quivrErrs.head.asInstanceOf[EvaluationAuthorizationFailed]
-    assert(err.proposition == testProposition.getRevealed)
-    assert(err.proof.value.isNot)
-    assert(err.proof.value.not.get.proof.value.isTickRange)
   }
 
   test("proveAndValidate: Transaction with Threshold Proposition > Threshold met passes validation") {
-    val testProposition =
-      Challenge().withRevealed(
-        Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2)
-      )
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        // Both Tick and Height should pass
+        ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
+        res <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val provenTx: IoTransaction = res.toOption.get
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val threshProof = provenPredicate.responses.head
+        val validThreshold = (!threshProof.value.isEmpty) && (threshProof.value.isThreshold) && (threshProof.value.threshold.get.responses.head.value.isTickRange) && (threshProof.value.threshold.get.responses(1).value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validThreshold && validSignable
+      },
+      true
     )
-    // Both Tick and Height should pass
-    val ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isRight)
-    val provenTx: IoTransaction = res.toOption.get
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val threshProof = provenPredicate.responses.head
-    assert(!threshProof.value.isEmpty)
-    assert(threshProof.value.isThreshold)
-    assert(threshProof.value.threshold.get.responses.head.value.isTickRange)
-    assert(threshProof.value.threshold.get.responses(1).value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("proveAndValidate: Transaction with And Proposition > If both inner proofs pass, the And proof passes") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        // Both Tick and Height should pass
+        ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
+        res <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val provenTx: IoTransaction = res.toOption.get
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val andProof = provenPredicate.responses.head
+        val validAnd = (!andProof.value.isEmpty) && (andProof.value.isAnd) && (andProof.value.and.get.left.value.isTickRange) && (andProof.value.and.get.left.value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validAnd && validSignable
+      },
+      true
     )
-    // Both Tick and Height should pass
-    val ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isRight)
-    val provenTx: IoTransaction = res.toOption.get
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val andProof = provenPredicate.responses.head
-    assert(!andProof.value.isEmpty)
-    assert(andProof.value.isAnd)
-    assert(andProof.value.and.get.left.value.isTickRange)
-    assert(andProof.value.and.get.right.value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("proveAndValidate: Transaction with Or Proposition > If only one inner proof passes, the Or proof passes") {
-    val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
+        res <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val provenTx: IoTransaction = res.toOption.get
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val orProof = provenPredicate.responses.head
+        val validOr = (!orProof.value.isEmpty) && (orProof.value.isOr) && (orProof.value.and.get.left.value.isTickRange) && (orProof.value.and.get.left.value.isHeightRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validOr && validSignable
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isRight)
-    val provenTx: IoTransaction = res.toOption.get
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val orProof = provenPredicate.responses.head
-    assert(!orProof.value.isEmpty)
-    assert(orProof.value.isOr)
-    assert(orProof.value.or.get.left.value.isTickRange)
-    assert(orProof.value.or.get.right.value.isHeightRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("proveAndValidate: Transaction with Not Proposition > If inner proof fails with error, the Not proof succeeds") {
-    // Locked should cause quivr runtime error
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockLockedProposition))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        // Locked should cause quivr runtime error
+        testProposition <- Proposer.notProposer[F].propose(MockLockedProposition).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 50, _ => None)
+        res <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val provenTx: IoTransaction = res.toOption.get
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val notProof = provenPredicate.responses.head
+        val validNot = (!notProof.value.isEmpty) && (notProof.value.isNot) && (notProof.value.not.get.proof.value.isLocked)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validNot && validSignable
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None)
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isRight)
-    val provenTx: IoTransaction = res.toOption.get
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val notProof = provenPredicate.responses.head
-    assert(!notProof.value.isEmpty)
-    assert(notProof.value.isNot)
-    assert(notProof.value.not.get.proof.value.isLocked)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test(
     "proveAndValidate: Transaction with Not Proposition > If inner proof fails with `false`, the Not proof succeeds"
   ) {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+    assertIO(
+      for {
+        testProposition <- Proposer.notProposer[F].propose(MockTickProposition).map(Challenge().withRevealed(_))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(Attestation.Predicate(Lock.Predicate(List(testProposition), 1), List(Proof())))
+            )
+          )
         )
-      )
+        ctx = Context[F](testTx, 500, _ => None) // Tick should fail
+        res <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      } yield {
+        val provenTx: IoTransaction = res.toOption.get
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val validLength = provenPredicate.responses.length == 1
+        val notProof = provenPredicate.responses.head
+        val validNot = (!notProof.value.isEmpty) && (notProof.value.isNot) && (notProof.value.not.get.proof.value.isTickRange)
+        val validSignable = provenTx.signable.value == testTx.signable.value
+        validLength && validNot && validSignable
+      },
+      true
     )
-    val ctx = Context[F](testTx, 500, _ => None) // Tick should fail
-    val res =
-      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
-    assert(res.isRight)
-    val provenTx: IoTransaction = res.toOption.get
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    assert(provenPredicate.responses.length == 1)
-    val notProof = provenPredicate.responses.head
-    assert(!notProof.value.isEmpty)
-    assert(notProof.value.isNot)
-    assert(notProof.value.not.get.proof.value.isTickRange)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test(
@@ -528,9 +582,9 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
       override def getIndicesBySignature(
         signatureProposition: Proposition.DigitalSignature
       ): F[Option[Indices]] =
-        Map(
-          bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
-        ).get(signatureProposition.sizedEvidence)
+        bobSignatureProposition.map(p =>
+          Map(p.value.digitalSignature.get.sizedEvidence -> bobIndices).get(signatureProposition.sizedEvidence)
+        )
 
       override def initWalletState(networkId:     Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???
       override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] = ???
@@ -563,45 +617,49 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
     }
     val aliceDataApi = MockWalletStateApi
     val bobDataApi = NewWalletStateApi
-    val innerPropositions = List(
-      Proposer.andProposer[F].propose((MockTickProposition, aliceSignatureProposition)),
-      Proposer.orProposer[F].propose((MockDigestProposition, MockLockedProposition)),
-      Proposer.notProposer[F].propose(MockHeightProposition)
-    )
-    val testTx = txFull.copy(inputs =
-      List(
-        inputFull.copy(attestation =
-          Attestation().withPredicate(
-            Attestation.Predicate(
-              Lock.Predicate(
-                List(
-                  Proposer.thresholdProposer[F].propose((innerPropositions.toSet, innerPropositions.length)),
-                  Proposer
-                    .thresholdProposer[F]
-                    .propose(((innerPropositions :+ bobSignatureProposition).toSet, innerPropositions.length + 1))
-                ).map(Challenge().withRevealed),
-                2
-              ),
-              List.fill(2)(Proof())
+    // the following is used to mimic the initial proving of the transaction by alice.
+    val credentialler1 = CredentiallerInterpreter.make[F](walletApi, aliceDataApi, aliceMainKey)
+    // the following is used to mimic the second proving of the transaction by bob.
+    val credentialler2 = CredentiallerInterpreter.make[F](walletApi, bobDataApi, bobMainKey)
+    assertIO(
+      for {
+        andProp <- Proposer.andProposer[F].propose((MockTickProposition, aliceSignatureProposition))
+        orProp <- Proposer.orProposer[F].propose((MockDigestProposition, MockLockedProposition))
+        notProp <- Proposer.notProposer[F].propose(MockHeightProposition)
+        innerPropositions = List(andProp, orProp, notProp)
+        bobProp <- bobSignatureProposition
+        thresh1 <- Proposer.thresholdProposer[F].propose((innerPropositions.toSet, innerPropositions.length))
+        thresh2 <- Proposer
+          .thresholdProposer[F]
+          .propose(((innerPropositions :+ bobProp).toSet, innerPropositions.length + 1))
+        testTx = txFull.copy(inputs =
+          List(
+            inputFull.copy(attestation =
+              Attestation().withPredicate(
+                Attestation.Predicate(
+                  Lock.Predicate(
+                    List(thresh1, thresh2).map(Challenge().withRevealed),
+                    2
+                  ),
+                  List.fill(2)(Proof())
+                )
+              )
             )
           )
         )
-      )
+        ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
+        partiallyProven <- credentialler1.prove(testTx) // should create a partially proven tx
+        // Should not be validated since not sufficiently proven
+        res1 <- credentialler1.validate(partiallyProven, ctx)
+        completelyProven <- credentialler2.prove(partiallyProven) // should create a completely proven tx
+        // Should be validated since sufficiently proven
+        res2 <- credentialler2.validate(completelyProven, ctx)
+      } yield {
+        val validRes1 = (res1.length == 1) && (partiallyProven.signable.value == testTx.signable.value)
+        val validRes2 = (res2.isEmpty) && (completelyProven.signable.value == testTx.signable.value)
+        validRes1 && validRes2
+      },
+      true
     )
-    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
-    // the following is used to mimic the initial proving of the transaction by alice.
-    val credentialler1 = CredentiallerInterpreter.make[F](walletApi, aliceDataApi, aliceMainKey)
-    val partiallyProven = credentialler1.prove(testTx) // should create a partially proven tx
-    // Should not be validated since not sufficiently proven
-    val res1 = credentialler1.validate(partiallyProven, ctx)
-    assert(res1.length == 1)
-    assertEquals(partiallyProven.signable.value, testTx.signable.value)
-    // the following is used to mimic the second proving of the transaction by bob.
-    val credentialler2 = CredentiallerInterpreter.make[F](walletApi, bobDataApi, bobMainKey)
-    val completelyProven = credentialler2.prove(partiallyProven) // should create a completely proven tx
-    // Should be validated since sufficiently proven
-    val res2 = credentialler2.validate(completelyProven, ctx)
-    assert(res2.isEmpty)
-    assertEquals(completelyProven.signable.value, testTx.signable.value)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -1,12 +1,13 @@
 package co.topl.brambl.wallet
 
-import cats.Id
 import cats.data.ValidatedNel
+import cats.effect.IO
 import cats.implicits._
 import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
+import co.topl.brambl.{Context, MockHelpers, MockWalletKeyApi, MockWalletStateApi}
 import co.topl.brambl.{Context, MockHelpers, MockWalletKeyApi, MockWalletStateApi}
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
@@ -18,61 +19,70 @@ import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
 import co.topl.quivr.api.Proposer
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
-  EvaluationAuthorizationFailed,
-  LockedPropositionIsUnsatisfiable
-}
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
 import com.google.protobuf.ByteString
 import quivr.models.{Int128, KeyPair, Preimage, Proof, Proposition, VerificationKey}
 import co.topl.brambl.wallet.WalletApi.{cryptoToPbKeyPair, pbKeyPairToCryotoKeyPair}
 import co.topl.crypto.encryption.VaultStore
+import munit.CatsEffectAssertions.assertIO
+import munit.CatsEffectSuite
 
 import scala.util.Random
 
-class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
-  val walletApi: WalletApi[Id] = WalletApi.make[Id](MockWalletKeyApi)
+class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
+  val walletApi: WalletApi[F] = WalletApi.make[F](MockWalletKeyApi)
 
   test("prove: Single Input Transaction with Attestation.Predicate > Provable propositions have non-empty proofs") {
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(txFull)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
-    val nonEmpty = provenPredicate.responses.forall(proof => !proof.value.isEmpty)
-    assert(sameLen && nonEmpty)
-    assertEquals(provenTx.signable.value, txFull.signable.value)
+    assertIO(
+      for {
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(txFull)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
+        val nonEmpty = provenPredicate.responses.forall(proof => !proof.value.isEmpty)
+        sameLen && nonEmpty && (provenTx.signable.value == txFull.signable.value)
+      },
+      true
+    )
   }
 
   test("prove: Single Input Transaction with Attestation.Predicate > Unprovable propositions have empty proofs") {
-    // Secrets are not available for the updated Signature and Digest propositions
-    val testSignatureProposition = Proposer.signatureProposer[Id].propose(("invalid-routine", MockChildKeyPair.vk))
-    val testDigestProposition = Proposer.digestProposer[Id].propose(("invalid-routine", MockDigest))
-    val testAttestation = Attestation().withPredicate(
-      Attestation.Predicate(
-        Lock.Predicate(
-          List(
-            Challenge().withRevealed(testSignatureProposition),
-            Challenge().withRevealed(testDigestProposition)
-          ),
-          2
-        ),
-        List(Proof(), Proof())
-      )
+    assertIO(
+      for {
+        // Secrets are not available for the updated Signature and Digest propositions
+        testSignatureProposition <- Proposer.signatureProposer[F].propose(("invalid-routine", MockChildKeyPair.vk))
+        testDigestProposition <- Proposer.digestProposer[F].propose(("invalid-routine", MockDigest))
+        testTx <- {
+          val testAttestation = Attestation().withPredicate(
+            Attestation.Predicate(
+              Lock.Predicate(
+                List(
+                  Challenge().withRevealed(testSignatureProposition),
+                  Challenge().withRevealed(testDigestProposition)
+                ),
+                2
+              ),
+              List(Proof(), Proof())
+            )
+          )
+          IO.pure(txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(attestation = testAttestation))))
+        }
+        provenTx <- CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      } yield {
+        val provenPredicate = provenTx.inputs.head.attestation.getPredicate
+        val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
+        val correctLen = provenPredicate.lock.challenges.length == 2
+        val allEmpty = provenPredicate.responses.forall(_.value.isEmpty) // Digest and Signature proofs are empty
+        sameLen && correctLen && allEmpty && (provenTx.signable.value == testTx.signable.value)
+      },
+      true
     )
-    val testTx = txFull.copy(inputs = txFull.inputs.map(stxo => stxo.copy(attestation = testAttestation)))
-    val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
-    val provenPredicate = provenTx.inputs.head.attestation.getPredicate
-    val sameLen = provenPredicate.lock.challenges.length == provenPredicate.responses.length
-    val correctLen = provenPredicate.lock.challenges.length == 2
-    val allEmpty = provenPredicate.responses.forall(_.value.isEmpty) // Digest and Signature proofs are empty
-    assert(sameLen && correctLen && allEmpty)
-    assertEquals(provenTx.signable.value, testTx.signable.value)
   }
 
   test("validate: Single Input Transaction with Attestation.Predicate > Validation successful") {
-    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
     val provenTx: IoTransaction = credentialler.prove(txFull)
-    val ctx = Context[Id](txFull, 50, _ => None) // Tick satisfies a proposition
+    val ctx = Context[F](txFull, 50, _ => None) // Tick satisfies a proposition
     val errsNum = credentialler.validate(provenTx, ctx).length
     // Although not all but propositions pass, threshold is met so authorization is successful
     // Transaction syntax is also valid
@@ -83,9 +93,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
     val negativeValue: Value =
       Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
-    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
     val provenTx: IoTransaction = credentialler.prove(testTx)
-    val ctx = Context[Id](testTx, 500, _ => None) // Tick does not satisfies proposition
+    val ctx = Context[F](testTx, 500, _ => None) // Tick does not satisfies proposition
     val errs = credentialler.validate(provenTx, ctx)
     // Threshold is not met so authorization failed
     // Transaction syntax is also invalid
@@ -133,8 +143,8 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation successful") {
-    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
-    val ctx = Context[Id](txFull, 50, _ => None) // Tick satisfies a proposition
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
+    val ctx = Context[F](txFull, 50, _ => None) // Tick satisfies a proposition
     val res = credentialler.proveAndValidate(txFull, ctx)
 
     assertEquals(res.isRight, true)
@@ -143,9 +153,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test("proveAndValidate: Single Input Transaction with Attestation.Predicate > Validation failed") {
     val negativeValue: Value =
       Value.defaultInstance.withLvl(Value.LVL(Int128(ByteString.copyFrom(BigInt(-1).toByteArray))))
-    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair)
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair)
     val testTx = txFull.copy(outputs = Seq(output.copy(value = negativeValue)))
-    val ctx = Context[Id](testTx, 500, _ => None) // Tick does not satisfies proposition
+    val ctx = Context[F](testTx, 500, _ => None) // Tick does not satisfies proposition
     val res = credentialler.proveAndValidate(testTx, ctx)
     assertEquals(res.isLeft, true)
     assertEquals(res.swap.getOrElse(List.empty).length, 2)
@@ -154,10 +164,10 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test(
     "proveAndValidate: Credentialler initialized with a main key different than used to create Single Input Transaction with Attestation.Predicate > Validation Failed"
   ) {
-    val differentKeyPair = WalletApi.make[Id](MockWalletKeyApi).deriveChildKeys(MockMainKeyPair, Indices(0, 0, 1))
-    val credentialler = CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, differentKeyPair)
+    val differentKeyPair = WalletApi.make[F](MockWalletKeyApi).deriveChildKeys(MockMainKeyPair, Indices(0, 0, 1))
+    val credentialler = CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, differentKeyPair)
     // Tick satisfies its proposition. Height does not.
-    val ctx = Context[Id](txFull, 50, _ => None)
+    val ctx = Context[F](txFull, 50, _ => None)
     val res = credentialler.proveAndValidate(txFull, ctx)
 
     assert(res.isLeft, s"Result expecting to be left. Received ${res}")
@@ -179,7 +189,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test("prove: Transaction with Threshold Proposition > Threshold Proof is correctly generated") {
     val testProposition =
       Challenge().withRevealed(
-        Proposer.thresholdProposer[Id].propose((Set(MockTickProposition, MockHeightProposition), 2))
+        Proposer.thresholdProposer[F].propose((Set(MockTickProposition, MockHeightProposition), 2))
       )
     val testTx = txFull.copy(inputs =
       List(
@@ -189,7 +199,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val threshProof = provenPredicate.responses.head
@@ -204,7 +214,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("prove: Transaction with And Proposition > And Proof is correctly generated") {
     val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -213,7 +223,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val andProof = provenPredicate.responses.head
@@ -226,7 +236,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("prove: Transaction with Or Proposition > Or Proof is correctly generated") {
     val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -235,7 +245,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val orProof = provenPredicate.responses.head
@@ -247,7 +257,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("prove: Transaction with Not Proposition > Not Proof is correctly generated") {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[Id].propose(MockTickProposition))
+    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -256,7 +266,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     val provenTx: IoTransaction =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).prove(testTx)
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
     assert(provenPredicate.responses.length == 1)
     val notProof = provenPredicate.responses.head
@@ -269,7 +279,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test("proveAndValidate: Transaction with Threshold Proposition > Unmet Threshold fails validation") {
     val testProposition =
       Challenge().withRevealed(
-        Proposer.thresholdProposer[Id].propose(Set(MockTickProposition, MockHeightProposition), 2)
+        Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2)
       )
     val testTx = txFull.copy(inputs =
       List(
@@ -278,9 +288,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
+    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -296,7 +306,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("proveAndValidate: Transaction with And Proposition > If one inner proof fails, the And proof fails") {
     val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -304,9 +314,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
+    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -320,7 +330,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("proveAndValidate: Transaction with Or Proposition > If both inner proofs fail, the Or proof fails") {
     val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -328,9 +338,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 500, _ => None) // Tick and height should fail
+    val ctx = Context[F](testTx, 500, _ => None) // Tick and height should fail
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -345,7 +355,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("proveAndValidate: Transaction with Not Proposition > If inner proof succeeds, the Not proof fails") {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[Id].propose(MockTickProposition))
+    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -353,9 +363,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass
+    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isLeft)
     val validationErrs = res.swap.getOrElse(List.empty)
     assert(validationErrs.length == 1)
@@ -371,7 +381,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test("proveAndValidate: Transaction with Threshold Proposition > Threshold met passes validation") {
     val testProposition =
       Challenge().withRevealed(
-        Proposer.thresholdProposer[Id].propose(Set(MockTickProposition, MockHeightProposition), 2)
+        Proposer.thresholdProposer[F].propose(Set(MockTickProposition, MockHeightProposition), 2)
       )
     val testTx = txFull.copy(inputs =
       List(
@@ -381,9 +391,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     // Both Tick and Height should pass
-    val ctx = Context[Id](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
+    val ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -398,7 +408,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("proveAndValidate: Transaction with And Proposition > If both inner proofs pass, the And proof passes") {
     val testProposition =
-      Challenge().withRevealed(Proposer.andProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.andProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -407,9 +417,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
       )
     )
     // Both Tick and Height should pass
-    val ctx = Context[Id](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
+    val ctx = Context[F](testTx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -424,7 +434,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("proveAndValidate: Transaction with Or Proposition > If only one inner proof passes, the Or proof passes") {
     val testProposition =
-      Challenge().withRevealed(Proposer.orProposer[Id].propose((MockTickProposition, MockHeightProposition)))
+      Challenge().withRevealed(Proposer.orProposer[F].propose((MockTickProposition, MockHeightProposition)))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -432,9 +442,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
+    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -449,7 +459,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
 
   test("proveAndValidate: Transaction with Not Proposition > If inner proof fails with error, the Not proof succeeds") {
     // Locked should cause quivr runtime error
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[Id].propose(MockLockedProposition))
+    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockLockedProposition))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -457,9 +467,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None)
+    val ctx = Context[F](testTx, 50, _ => None)
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -474,7 +484,7 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
   test(
     "proveAndValidate: Transaction with Not Proposition > If inner proof fails with `false`, the Not proof succeeds"
   ) {
-    val testProposition = Challenge().withRevealed(Proposer.notProposer[Id].propose(MockTickProposition))
+    val testProposition = Challenge().withRevealed(Proposer.notProposer[F].propose(MockTickProposition))
     val testTx = txFull.copy(inputs =
       List(
         inputFull.copy(attestation =
@@ -482,9 +492,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 500, _ => None) // Tick should fail
+    val ctx = Context[F](testTx, 500, _ => None) // Tick should fail
     val res =
-      CredentiallerInterpreter.make[Id](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
+      CredentiallerInterpreter.make[F](walletApi, MockWalletStateApi, MockMainKeyPair).proveAndValidate(testTx, ctx)
     assert(res.isRight)
     val provenTx: IoTransaction = res.toOption.get
     val provenPredicate = provenTx.inputs.head.attestation.getPredicate
@@ -511,52 +521,52 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         Bip32Indexes.SoftIndex(bobIndices.z)
       )
     )
-    val bobSignatureProposition = Proposer.signatureProposer[Id].propose(("ExtendedEd25519", bobChildKey.vk))
+    val bobSignatureProposition = Proposer.signatureProposer[F].propose(("ExtendedEd25519", bobChildKey.vk))
     // To Mock someone else's DataApi
-    object NewWalletStateApi extends WalletStateAlgebra[Id] {
+    object NewWalletStateApi extends WalletStateAlgebra[F] {
       // The only relevant call is getIndices
       override def getIndicesBySignature(
         signatureProposition: Proposition.DigitalSignature
-      ): Id[Option[Indices]] =
+      ): F[Option[Indices]] =
         Map(
           bobSignatureProposition.value.digitalSignature.get.sizedEvidence -> bobIndices
         ).get(signatureProposition.sizedEvidence)
 
-      override def initWalletState(networkId:     Int, ledgerId: Int, vk: VerificationKey): Id[Unit] = ???
-      override def getPreimage(digestProposition: Proposition.Digest): Id[Option[Preimage]] = ???
-      override def getCurrentAddress: Id[String] = ???
+      override def initWalletState(networkId:     Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???
+      override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] = ???
+      override def getCurrentAddress: F[String] = ???
       override def updateWalletState(
         lockPredicate: String,
         lockAddress:   String,
         routine:       Option[String],
         vk:            Option[String],
         indices:       Indices
-      ): Id[Unit] = ???
+      ): F[Unit] = ???
       override def getCurrentIndicesForFunds(
         party:     String,
         contract:  String,
         someState: Option[Int]
-      ): Id[Option[Indices]] = ???
+      ): F[Option[Indices]] = ???
       override def validateCurrentIndicesForFunds(
         party:     String,
         contract:  String,
         someState: Option[Int]
-      ): Id[ValidatedNel[String, Indices]] = ???
-      override def getNextIndicesForFunds(party: String, contract: String): Id[Option[Indices]] = ???
-      override def getLockByIndex(indices:       Indices): Id[Option[Lock.Predicate]] = ???
-      override def getAddress(party:   String, contract: String, someState: Option[Int]): Id[Option[String]] = ???
-      override def addEntityVks(party: String, contract: String, entities:  List[String]): Id[Unit] = ???
-      override def getEntityVks(party: String, contract: String): Id[Option[List[String]]] = ???
-      override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[Id]): Id[Unit] = ???
-      override def getLockTemplate(contract:    String): Id[Option[LockTemplate[Id]]] = ???
-      override def getLock(party:               String, contract:     String, nextState: Int): Id[Option[Lock]] = ???
+      ): F[ValidatedNel[String, Indices]] = ???
+      override def getNextIndicesForFunds(party: String, contract: String): F[Option[Indices]] = ???
+      override def getLockByIndex(indices:       Indices): F[Option[Lock.Predicate]] = ???
+      override def getAddress(party:   String, contract: String, someState: Option[Int]): F[Option[String]] = ???
+      override def addEntityVks(party: String, contract: String, entities:  List[String]): F[Unit] = ???
+      override def getEntityVks(party: String, contract: String): F[Option[List[String]]] = ???
+      override def addNewLockTemplate(contract: String, lockTemplate: LockTemplate[F]): F[Unit] = ???
+      override def getLockTemplate(contract:    String): F[Option[LockTemplate[F]]] = ???
+      override def getLock(party:               String, contract:     String, nextState: Int): F[Option[Lock]] = ???
     }
     val aliceDataApi = MockWalletStateApi
     val bobDataApi = NewWalletStateApi
     val innerPropositions = List(
-      Proposer.andProposer[Id].propose((MockTickProposition, aliceSignatureProposition)),
-      Proposer.orProposer[Id].propose((MockDigestProposition, MockLockedProposition)),
-      Proposer.notProposer[Id].propose(MockHeightProposition)
+      Proposer.andProposer[F].propose((MockTickProposition, aliceSignatureProposition)),
+      Proposer.orProposer[F].propose((MockDigestProposition, MockLockedProposition)),
+      Proposer.notProposer[F].propose(MockHeightProposition)
     )
     val testTx = txFull.copy(inputs =
       List(
@@ -565,9 +575,9 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
             Attestation.Predicate(
               Lock.Predicate(
                 List(
-                  Proposer.thresholdProposer[Id].propose((innerPropositions.toSet, innerPropositions.length)),
+                  Proposer.thresholdProposer[F].propose((innerPropositions.toSet, innerPropositions.length)),
                   Proposer
-                    .thresholdProposer[Id]
+                    .thresholdProposer[F]
                     .propose(((innerPropositions :+ bobSignatureProposition).toSet, innerPropositions.length + 1))
                 ).map(Challenge().withRevealed),
                 2
@@ -578,16 +588,16 @@ class CredentiallerInterpreterSpec extends munit.FunSuite with MockHelpers {
         )
       )
     )
-    val ctx = Context[Id](testTx, 50, _ => None) // Tick should pass, height should fail
+    val ctx = Context[F](testTx, 50, _ => None) // Tick should pass, height should fail
     // the following is used to mimic the initial proving of the transaction by alice.
-    val credentialler1 = CredentiallerInterpreter.make[Id](walletApi, aliceDataApi, aliceMainKey)
+    val credentialler1 = CredentiallerInterpreter.make[F](walletApi, aliceDataApi, aliceMainKey)
     val partiallyProven = credentialler1.prove(testTx) // should create a partially proven tx
     // Should not be validated since not sufficiently proven
     val res1 = credentialler1.validate(partiallyProven, ctx)
     assert(res1.length == 1)
     assertEquals(partiallyProven.signable.value, testTx.signable.value)
     // the following is used to mimic the second proving of the transaction by bob.
-    val credentialler2 = CredentiallerInterpreter.make[Id](walletApi, bobDataApi, bobMainKey)
+    val credentialler2 = CredentiallerInterpreter.make[F](walletApi, bobDataApi, bobMainKey)
     val completelyProven = credentialler2.prove(partiallyProven) // should create a completely proven tx
     // Should be validated since sufficiently proven
     val res2 = credentialler2.validate(completelyProven, ctx)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -12,10 +12,11 @@ import io.circe.syntax.EncoderOps
 import co.topl.crypto.encryption.VaultStore.Codecs._
 import co.topl.crypto.generation.mnemonic.EntropyFailures.PhraseToEntropyFailure
 import co.topl.crypto.generation.mnemonic.PhraseFailures.InvalidWordLength
+import munit.CatsEffectAssertions.assertIO
 
 class WalletApiSpec extends munit.FunSuite with MockHelpers {
-  implicit val idToId: FunctionK[Id, Id] = FunctionK.id[Id]
-  val walletApi: WalletApi[Id] = WalletApi.make[Id](MockWalletKeyApi)
+  implicit val idToId: FunctionK[F, F] = FunctionK.id[F]
+  val walletApi: WalletApi[F] = WalletApi.make[F](MockWalletKeyApi)
   val testMsg: Array[Byte] = "test message".getBytes
 
   // Runs after each individual test.
@@ -26,61 +27,81 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
     "createAndSaveNewWallet: Creating a new wallet creates VaultStore that contains a Topl Main Key and a Mnemonic (default length 12)"
   ) {
     val password = "password".getBytes
-    val res = walletApi.createAndSaveNewWallet[Id](password)
-    assert(res.isRight)
-    assert(res.toOption.get.mnemonic.length == 12)
-    val vs = res.toOption.get.mainKeyVaultStore
-    val vsStored = MockWalletKeyApi.getMainKeyVaultStore().toOption
-    assert(vsStored.isDefined)
-    assert(vsStored.get == vs)
-    val mainKey = VaultStore.decodeCipher[Id](vs, password).toOption.map(KeyPair.parseFrom)
-    assert(mainKey.isDefined)
-    assert(mainKey.get.vk.vk.extendedEd25519.isDefined)
-    assert(mainKey.get.sk.sk.extendedEd25519.isDefined)
+    assertIO(
+      for {
+        res      <- walletApi.createAndSaveNewWallet[F](password)
+        vsStored <- MockWalletKeyApi.getMainKeyVaultStore().map(_.toOption)
+        vs = res.toOption.get.mainKeyVaultStore
+        mainKey <- VaultStore.decodeCipher[F](vs, password).map(_.toOption.map(KeyPair.parseFrom))
+      } yield {
+        val validMnemonic = res.toOption.get.mnemonic.length == 12
+        val validVsStored = (vsStored.isDefined) && (vsStored.get == vs)
+        val validMainKey =
+          (mainKey.isDefined) && (mainKey.get.vk.vk.extendedEd25519.isDefined) && (mainKey.get.sk.sk.extendedEd25519.isDefined)
+        validMnemonic && validVsStored && validMainKey
+      },
+      true
+    )
   }
 
   test("createNewWallet: Specifying a valid mnemonic length returns a mnemonic of correct length") {
-    val res = walletApi.createNewWallet("password".getBytes, mLen = MnemonicSizes.words24)
-    assert(res.isRight)
-    assert(res.toOption.get.mnemonic.length == 24)
+    assertIO(
+      walletApi
+        .createNewWallet("password".getBytes, mLen = MnemonicSizes.words24)
+        .map(_.toOption.get.mnemonic.length == 24),
+      true
+    )
   }
 
   test("saveWallet and loadWallet: specifying a name other than 'default' saves the wallet under that name") {
-    val w1 = walletApi.createNewWallet("password1".getBytes).toOption.get.mainKeyVaultStore
-    val w2 = walletApi.createNewWallet("password2".getBytes).toOption.get.mainKeyVaultStore
-    assert(w1 != w2)
-    val res1 = walletApi.saveWallet(w1, "w1")
-    val res2 = walletApi.saveWallet(w2, "w2")
-    assert(res1.isRight)
-    assert(res2.isRight)
-    val stored1 = walletApi.loadWallet("w1").toOption
-    assert(stored1.isDefined)
-    assert(stored1.get == w1)
-    val stored2 = walletApi.loadWallet("w2").toOption
-    assert(stored2.isDefined)
-    assert(stored2.get == w2)
+    assertIO(
+      for {
+        w1      <- walletApi.createNewWallet("password1".getBytes).map(_.toOption.get.mainKeyVaultStore)
+        w2      <- walletApi.createNewWallet("password2".getBytes).map(_.toOption.get.mainKeyVaultStore)
+        res1    <- walletApi.saveWallet(w1, "w1")
+        res2    <- walletApi.saveWallet(w2, "w2")
+        stored1 <- walletApi.loadWallet("w1").map(_.toOption)
+        stored2 <- walletApi.loadWallet("w2").map(_.toOption)
+      } yield {
+        val validWalletUnique = w1 != w2
+        val validInitialStored = res1.isRight && res2.isRight
+        val validLoad1 = (stored1.isDefined) && (stored1.get == w1)
+        val validLoad2 = (stored2.isDefined) && (stored2.get == w2)
+        validWalletUnique && validInitialStored && validLoad1 && validLoad2
+      },
+      true
+    )
   }
 
   test(
     "loadWallet: if the wallet with the name does not exist, the correct error is returned"
   ) {
-    val loadRes = walletApi.loadWallet("w1")
-    assert(loadRes.isLeft)
-    assert(loadRes.left.toOption.get == WalletApi.FailedToLoadWallet(MockWalletKeyApi.MainKeyVaultStoreNotInitialized))
+    assertIO(
+      walletApi
+        .loadWallet("w1")
+        .map(_.left.toOption.get == WalletApi.FailedToLoadWallet(MockWalletKeyApi.MainKeyVaultStoreNotInitialized)),
+      true
+    )
   }
 
   test("extractMainKey: ExtendedEd25519 Topl Main Key is returned") {
     val password = "password".getBytes
-    val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
-    val mainKeyOpt = walletApi.extractMainKey(vaultStore, password)
-    assert(mainKeyOpt.isRight)
-    val mainKey = mainKeyOpt.toOption.get
-    assert(mainKey.vk.vk.extendedEd25519.isDefined)
-    assert(mainKey.sk.sk.extendedEd25519.isDefined)
-    val testMsg = "test message".getBytes
-    val signingInstance = new ExtendedEd25519
-    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(mainKey).signingKey, testMsg)
-    assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(mainKey).verificationKey))
+    assertIO(
+      for {
+        vaultStore <- walletApi.createNewWallet(password).map(_.toOption.get.mainKeyVaultStore)
+        mainKeyOpt <- walletApi.extractMainKey(vaultStore, password)
+      } yield {
+        val mainKey = mainKeyOpt.toOption.get
+        val validKey = (mainKey.vk.vk.extendedEd25519.isDefined) && (mainKey.sk.sk.extendedEd25519.isDefined)
+        val testMsg = "test message".getBytes
+        val signingInstance = new ExtendedEd25519
+        val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(mainKey).signingKey, testMsg)
+        val validSignature =
+          signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(mainKey).verificationKey)
+        validKey && validSignature
+      },
+      true
+    )
   }
 
   test(
@@ -88,70 +109,101 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
   ) {
     val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
-    val res1 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase1"), name = "w1")
-    val res2 = walletApi.createAndSaveNewWallet[Id](password, passphrase = Some("passphrase2"), name = "w2")
-    assert(res1.isRight)
-    assert(res2.isRight)
-    val kp1Either = walletApi.loadAndExtractMainKey[Id](password, "w1")
-    val kp2Either = walletApi.loadAndExtractMainKey[Id](password, "w2")
-    assert(kp1Either.isRight)
-    assert(kp2Either.isRight)
-    val kp1 = kp1Either.toOption.get
-    val kp2 = kp2Either.toOption.get
-    assert(kp1.vk.vk.extendedEd25519.isDefined)
-    assert(kp1.sk.sk.extendedEd25519.isDefined)
-    assert(kp2.vk.vk.extendedEd25519.isDefined)
-    assert(kp2.sk.sk.extendedEd25519.isDefined)
-    val signature1 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp1).signingKey, testMsg)
-    val signature2 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp2).signingKey, testMsg)
-    assert(signingInstance.verify(signature1, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey))
-    assert(signingInstance.verify(signature2, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey))
-    assert(!signingInstance.verify(signature1, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey))
-    assert(!signingInstance.verify(signature2, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey))
+    assertIO(
+      for {
+        _         <- walletApi.createAndSaveNewWallet[F](password, passphrase = Some("passphrase1"), name = "w1")
+        _         <- walletApi.createAndSaveNewWallet[F](password, passphrase = Some("passphrase2"), name = "w2")
+        kp1Either <- walletApi.loadAndExtractMainKey[F](password, "w1")
+        kp2Either <- walletApi.loadAndExtractMainKey[F](password, "w2")
+      } yield {
+        val kp1 = kp1Either.toOption.get
+        val kp2 = kp2Either.toOption.get
+        val validKeyPairs =
+          (kp1.vk.vk.extendedEd25519.isDefined && kp1.sk.sk.extendedEd25519.isDefined) && (kp2.vk.vk.extendedEd25519.isDefined && kp2.sk.sk.extendedEd25519.isDefined)
+        val signature1 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp1).signingKey, testMsg)
+        val signature2 = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(kp2).signingKey, testMsg)
+        val validSignatures = (signingInstance.verify(
+          signature1,
+          testMsg,
+          WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey
+        )) && (signingInstance.verify(
+          signature2,
+          testMsg,
+          WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey
+        )) && (!signingInstance.verify(
+          signature1,
+          testMsg,
+          WalletApi.pbKeyPairToCryotoKeyPair(kp2).verificationKey
+        )) && (!signingInstance.verify(signature2, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(kp1).verificationKey))
+        validKeyPairs && validSignatures
+      },
+      true
+    )
   }
 
   test(
     "createAndSaveNewWallet: If the wallet is successfully created but not saved, the correct error is returned"
   ) {
     // DataApi mocked "error" to return an error when saving the wallet
-    val res = walletApi.createAndSaveNewWallet[Id]("password".getBytes, name = "error")
-    assert(res.isLeft)
-    assert(res.left.toOption.get == WalletApi.FailedToSaveWallet(MockWalletKeyApi.MainKeyVaultSaveFailure))
+    assertIO(
+      walletApi
+        .createAndSaveNewWallet[F]("password".getBytes, name = "error")
+        .map(_.left.toOption.get == WalletApi.FailedToSaveWallet(MockWalletKeyApi.MainKeyVaultSaveFailure)),
+      true
+    )
   }
 
   test("deriveChildKeys: Verify deriving path 4'/4/4 produces a valid child key pair") {
     val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
-    val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
-    val mainKey = walletApi.extractMainKey(vaultStore, password).toOption.get
     val idx = Indices(4, 4, 4)
-    val childKey = walletApi.deriveChildKeys(mainKey, idx)
-    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKey).signingKey, testMsg)
-    assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(childKey).verificationKey))
+    assertIO(
+      for {
+        vaultStore <- walletApi.createNewWallet(password).map(_.toOption.get.mainKeyVaultStore)
+        mainKey    <- walletApi.extractMainKey(vaultStore, password).map(_.toOption.get)
+        childKey   <- walletApi.deriveChildKeys(mainKey, idx)
+      } yield {
+        val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKey).signingKey, testMsg)
+        signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(childKey).verificationKey)
+      },
+      true
+    )
   }
 
   test("deriveChildKeysPartial: Verify deriving path 4'/4 produces a valid child key pair") {
     val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
-    val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
-    val mainKey = walletApi.extractMainKey(vaultStore, password).toOption.get
-    val childKey = walletApi.deriveChildKeysPartial(mainKey, 4, 4)
-    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKey).signingKey, testMsg)
-    assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(childKey).verificationKey))
+    assertIO(
+      for {
+        vaultStore <- walletApi.createNewWallet(password).map(_.toOption.get.mainKeyVaultStore)
+        mainKey    <- walletApi.extractMainKey(vaultStore, password).map(_.toOption.get)
+        childKey   <- walletApi.deriveChildKeysPartial(mainKey, 4, 4)
+      } yield {
+        val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKey).signingKey, testMsg)
+        signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(childKey).verificationKey)
+      },
+      true
+    )
   }
 
   test("deriveChildVerificationKey: Verify deriving path '4' produces a valid child verification key") {
     val signingInstance: ExtendedEd25519 = new ExtendedEd25519
     val password = "password".getBytes
-    val vaultStore = walletApi.createNewWallet(password).toOption.map(_.mainKeyVaultStore).get
-    val mainKey = walletApi.extractMainKey(vaultStore, password).toOption.get
-    val childKeyExpected = walletApi.deriveChildKeys(mainKey, Indices(4, 4, 4))
-    val childKeyPartial = walletApi.deriveChildKeysPartial(mainKey, 4, 4)
-    val childVerificationKeyTest = walletApi.deriveChildVerificationKey(childKeyPartial.vk, 4)
-    assert(childVerificationKeyTest == childKeyExpected.vk)
-    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKeyExpected).signingKey, testMsg)
-    assert(
-      signingInstance.verify(signature, testMsg, WalletApi.pbVkToCryptoVk(childVerificationKeyTest.getExtendedEd25519))
+
+    assertIO(
+      for {
+        vaultStore               <- walletApi.createNewWallet(password).map(_.toOption.get.mainKeyVaultStore)
+        mainKey                  <- walletApi.extractMainKey(vaultStore, password).map(_.toOption.get)
+        childKeyExpected         <- walletApi.deriveChildKeys(mainKey, Indices(4, 4, 4))
+        childKeyPartial          <- walletApi.deriveChildKeysPartial(mainKey, 4, 4)
+        childVerificationKeyTest <- walletApi.deriveChildVerificationKey(childKeyPartial.vk, 4)
+      } yield {
+        val validVk = childVerificationKeyTest == childKeyExpected.vk
+        val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(childKeyExpected).signingKey, testMsg)
+        validVk && signingInstance
+          .verify(signature, testMsg, WalletApi.pbVkToCryptoVk(childVerificationKeyTest.getExtendedEd25519))
+      },
+      true
     )
   }
 
@@ -160,69 +212,88 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
   ) {
     val mainKey = "dummyKeyPair".getBytes
     val password = "password".getBytes
-    // Using the same password should return the same VaultStore
-    val v1 = walletApi.buildMainKeyVaultStore(mainKey, password)
-    val v2 = walletApi.buildMainKeyVaultStore(mainKey, password)
-    assert(v1 == v2)
-    assert(
-      VaultStore.decodeCipher(v1, password).toOption.get sameElements VaultStore.decodeCipher(v2, password).toOption.get
-    )
-    // Using a different password should decode the VaultStore to the same key
-    val v3 = walletApi.buildMainKeyVaultStore(mainKey, "password2".getBytes)
-    assert(v1 != v3)
-    assert(
-      VaultStore.decodeCipher(v1, password).toOption.get sameElements VaultStore.decodeCipher(v2, password).toOption.get
+    assertIO(
+      for {
+        // Using the same password should return the same VaultStore
+        v1        <- walletApi.buildMainKeyVaultStore(mainKey, password)
+        v2        <- walletApi.buildMainKeyVaultStore(mainKey, password)
+        v1Decoded <- VaultStore.decodeCipher(v1, password).map(_.toOption.get)
+        v2Decoded <- VaultStore.decodeCipher(v2, password).map(_.toOption.get)
+        // Using a different password should decode the VaultStore to the same key
+        v3        <- walletApi.buildMainKeyVaultStore(mainKey, "password2".getBytes)
+        v3Decoded <- VaultStore.decodeCipher(v3, "password2".getBytes).map(_.toOption.get)
+      } yield {
+        val validVs2 = (v1 == v2) && (v1Decoded sameElements v2Decoded)
+        val validVs3 = (v1 != v3) && (v1Decoded sameElements v3Decoded)
+        validVs2 && validVs3
+      },
+      true
     )
   }
 
   test(
     "deleteWallet: Deleting a wallet when a wallet of that name does not exist > Error"
   ) {
-    val deleteRes = walletApi.deleteWallet("name")
-    assert(deleteRes.isLeft)
-    assert(deleteRes.left.toOption.get == WalletApi.FailedToDeleteWallet(MockWalletKeyApi.MainKeyVaultDeleteFailure))
+    assertIO(
+      walletApi
+        .deleteWallet("name")
+        .map(_.left.toOption.get == WalletApi.FailedToDeleteWallet(MockWalletKeyApi.MainKeyVaultDeleteFailure)),
+      true
+    )
   }
 
   test(
     "deleteWallet: Deleting a wallet > Verify wallet no longer exists at the specified name"
   ) {
-    val saveRes = walletApi.createAndSaveNewWallet[Id]("password".getBytes, name = "name")
-    assert(saveRes.isRight)
-    val beforeDelete = walletApi.loadWallet("name")
-    assert(beforeDelete.isRight)
-    val deleteRes = walletApi.deleteWallet("name")
-    assert(deleteRes.isRight)
-    val afterDelete = walletApi.loadWallet("name")
-    assert(afterDelete.isLeft)
-    assert(
-      afterDelete.left.toOption.get == WalletApi.FailedToLoadWallet(MockWalletKeyApi.MainKeyVaultStoreNotInitialized)
+    assertIO(
+      for {
+        saveRes      <- walletApi.createAndSaveNewWallet[F]("password".getBytes, name = "name")
+        beforeDelete <- walletApi.loadWallet("name")
+        deleteRes    <- walletApi.deleteWallet("name")
+        afterDelete  <- walletApi.loadWallet("name")
+      } yield {
+        val validDelete = afterDelete.left.toOption.get == WalletApi.FailedToLoadWallet(
+          MockWalletKeyApi.MainKeyVaultStoreNotInitialized
+        )
+        saveRes.isRight && beforeDelete.isRight && deleteRes.isRight && validDelete
+      },
+      true
     )
   }
 
   test(
     "updateWallet: Updating a wallet when a wallet of that name does not exist > Error"
   ) {
-    val vs = walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
-    val w1 = walletApi.updateWallet(vs, "name")
-    assert(w1.isLeft)
-    assert(w1.left.toOption.get == WalletApi.FailedToUpdateWallet(MockWalletKeyApi.MainKeyVaultStoreNotInitialized))
+    assertIO(
+      for {
+        vs <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, "password".getBytes)
+        w1 <- walletApi.updateWallet(vs, "name")
+      } yield w1.isLeft && (w1.left.toOption.get == WalletApi.FailedToUpdateWallet(
+        MockWalletKeyApi.MainKeyVaultStoreNotInitialized
+      )),
+      true
+    )
   }
 
   test(
     "updateWallet: Updating a wallet > Verify old wallet no longer exists at the specified name"
   ) {
     val password = "password".getBytes
-    val oldWallet = walletApi.createAndSaveNewWallet[Id](password, name = "w1")
-    assert(oldWallet.isRight)
-    // same password, different key
-    val newWallet = walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, password)
-    val updateRes = walletApi.updateWallet(newWallet, "w1")
-    assert(updateRes.isRight)
-    val loadedWalletRes = walletApi.loadWallet("w1")
-    assert(loadedWalletRes.isRight)
-    val loadedWallet = loadedWalletRes.toOption.get
-    assert(loadedWallet != oldWallet.toOption.get.mainKeyVaultStore)
-    assert(loadedWallet == newWallet)
+    assertIO(
+      for {
+        oldWallet <- walletApi.createAndSaveNewWallet[F](password, name = "w1")
+        // same password, different key
+        newWallet       <- walletApi.buildMainKeyVaultStore("dummyKeyPair".getBytes, password)
+        updateRes       <- walletApi.updateWallet(newWallet, "w1")
+        loadedWalletRes <- walletApi.loadWallet("w1")
+      } yield {
+        val loadedWallet = loadedWalletRes.toOption.get
+        val validLoadedWallet =
+          (loadedWallet != oldWallet.toOption.get.mainKeyVaultStore) && (loadedWallet == newWallet)
+        oldWallet.isRight && updateRes.isRight && loadedWalletRes.isRight && validLoadedWallet
+      },
+      true
+    )
   }
 
   test(
@@ -230,91 +301,122 @@ class WalletApiSpec extends munit.FunSuite with MockHelpers {
   ) {
     val oldPassword = "oldPassword".getBytes
     val newPassword = "newPassword".getBytes
-    val oldWallet = walletApi.createAndSaveNewWallet[Id](oldPassword)
-    assert(oldWallet.isRight)
-    val oldVaultStore = oldWallet.toOption.get.mainKeyVaultStore
-    val mainKey = walletApi.extractMainKey(oldVaultStore, oldPassword).toOption.get
-    // verify old wallet has been saved
-    assert(walletApi.loadWallet().toOption.get == oldVaultStore)
-    val updateRes = walletApi.updateWalletPassword[Id](oldPassword, newPassword)
-    assert(updateRes.isRight)
-    val newVaultStore = updateRes.toOption.get
-    val loadedWallet = walletApi.loadWallet().toOption.get
-    // Verify the old wallet has been replaced
-    assert(loadedWallet != oldVaultStore)
-    assert(loadedWallet == newVaultStore)
-    // Verify the old password does not work for the loaded wallet
-    val decodeOldPassword = walletApi.extractMainKey(loadedWallet, oldPassword)
-    assert(decodeOldPassword.isLeft)
-    assert(decodeOldPassword.left.toOption.get == WalletApi.FailedToDecodeWallet(VaultStore.InvalidMac))
-    // Verify the new password works for the loaded wallet
-    val decodeNewPassword = walletApi.extractMainKey(loadedWallet, newPassword)
-    assert(decodeNewPassword.isRight)
-    assert(decodeNewPassword.toOption.get == mainKey)
+
+    assertIO(
+      for {
+        oldWallet <- walletApi.createAndSaveNewWallet[F](oldPassword)
+        oldVaultStore = oldWallet.toOption.get.mainKeyVaultStore
+        mainKey         <- walletApi.extractMainKey(oldVaultStore, oldPassword).map(_.toOption.get)
+        loadedOldWallet <- walletApi.loadWallet().map(_.toOption.get)
+        updateRes       <- walletApi.updateWalletPassword[F](oldPassword, newPassword)
+        loadedWallet    <- walletApi.loadWallet().map(_.toOption.get)
+        // Verify the old password does not work for the loaded wallet
+        decodeOldPassword <- walletApi.extractMainKey(loadedWallet, oldPassword)
+        // Verify the new password works for the loaded wallet
+        decodeNewPassword <- walletApi.extractMainKey(loadedWallet, newPassword)
+      } yield {
+        val validOldWallet = oldWallet.isRight && (loadedOldWallet == oldVaultStore)
+        val validUpdate =
+          updateRes.isRight && (loadedWallet != oldVaultStore) && (loadedWallet == updateRes.toOption.get)
+        val validDecode = (decodeOldPassword.left.toOption.get == WalletApi.FailedToDecodeWallet(
+          VaultStore.InvalidMac
+        )) && (decodeNewPassword.toOption.get == mainKey)
+        validOldWallet && validUpdate && validDecode
+      },
+      true
+    )
   }
 
   test(
     "updateWalletPassword: Failure saving > Wallet is accessible with the old password"
   ) {
     val password = "password".getBytes
-    val oldVaultStore = walletApi.createNewWallet(password).toOption.get.mainKeyVaultStore
-    // manually save the wallet to the mock data api with the error name
-    MockWalletKeyApi.mainKeyVaultStoreInstance += ("error" -> oldVaultStore.asJson)
-    val updateRes = walletApi.updateWalletPassword[Id](password, "newPassword".getBytes, "error")
-    assert(updateRes.isLeft)
-    assert(updateRes.left.toOption.get == WalletApi.FailedToUpdateWallet(MockWalletKeyApi.MainKeyVaultSaveFailure))
-    // verify the wallet is still accessible with the old password
-    val loadedWallet = walletApi.loadAndExtractMainKey[Id](password, "error")
-    assert(loadedWallet.isRight)
+    assertIO(
+      for {
+        oldVaultStore <- walletApi.createNewWallet(password).map(_.toOption.get.mainKeyVaultStore)
+        updateRes <- {
+          // manually save the wallet to the mock data api with the error name
+          MockWalletKeyApi.mainKeyVaultStoreInstance += ("error" -> oldVaultStore.asJson)
+          walletApi.updateWalletPassword[F](password, "newPassword".getBytes, "error")
+        }
+        // verify the wallet is still accessible with the old password
+        loadedWallet <- walletApi.loadAndExtractMainKey[F](password, "error")
+      } yield {
+        val validUpdate =
+          updateRes.left.toOption.get == WalletApi.FailedToUpdateWallet(MockWalletKeyApi.MainKeyVaultSaveFailure)
+        val validLoad = loadedWallet.isRight
+        validUpdate && validLoad
+      },
+      true
+    )
   }
 
   test("importWallet: import using mnemonic from createNewWallet > Same Main Key") {
     val oldPassword = "old-password".getBytes
-    val wallet = walletApi.createNewWallet(oldPassword).toOption.get
-    val mnemonic = wallet.mnemonic
-    val mainKey = walletApi.extractMainKey(wallet.mainKeyVaultStore, oldPassword).toOption.get
     val newPassword = "new-password".getBytes
-    val importedWallet = walletApi.importWallet(mnemonic, newPassword)
-    assert(importedWallet.isRight)
-    assert(wallet.mainKeyVaultStore != importedWallet.toOption.get) // Should be different due to password
-    val importedMainKey = walletApi.extractMainKey(importedWallet.toOption.get, newPassword)
-    assert(importedMainKey.isRight)
-    val testMainKey = importedMainKey.toOption.get
-    // Verify the main key is the same
-    assert(mainKey == testMainKey)
     val signingInstance: ExtendedEd25519 = new ExtendedEd25519
-    val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(mainKey).signingKey, testMsg)
-    val testSignature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).signingKey, testMsg)
-    assert(java.util.Arrays.equals(signature, testSignature))
-
-    assert(signingInstance.verify(signature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).verificationKey))
-    assert(signingInstance.verify(testSignature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(mainKey).verificationKey))
+    assertIO(
+      for {
+        wallet <- walletApi.createNewWallet(oldPassword).map(_.toOption.get)
+        mnemonic = wallet.mnemonic
+        mainKey         <- walletApi.extractMainKey(wallet.mainKeyVaultStore, oldPassword).map(_.toOption.get)
+        importedWallet  <- walletApi.importWallet(mnemonic, newPassword)
+        importedMainKey <- walletApi.extractMainKey(importedWallet.toOption.get, newPassword)
+      } yield {
+        // Should be different due to password
+        val validImportedWallet = (importedWallet.isRight) && (wallet.mainKeyVaultStore != importedWallet.toOption.get)
+        val testMainKey = importedMainKey.toOption.get
+        // Verify the main key is the same
+        val validMainKey = (importedMainKey.isRight) && (mainKey == testMainKey)
+        val signature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(mainKey).signingKey, testMsg)
+        val testSignature = signingInstance.sign(WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).signingKey, testMsg)
+        val validSignature = (java.util.Arrays.equals(signature, testSignature)) && signingInstance.verify(
+          signature,
+          testMsg,
+          WalletApi.pbKeyPairToCryotoKeyPair(testMainKey).verificationKey
+        ) && signingInstance.verify(testSignature, testMsg, WalletApi.pbKeyPairToCryotoKeyPair(mainKey).verificationKey)
+        validImportedWallet && validMainKey && validSignature
+      },
+      true
+    )
 
   }
 
   test("importWallet: an invalid mnemonic produces correct error") {
     val password = "password".getBytes
-    val wallet = walletApi.createNewWallet(password).toOption.get
-    val mnemonic = wallet.mnemonic :+ "extraWord"
-    val importedWallet = walletApi.importWallet(mnemonic, password)
-    assert(importedWallet.isLeft)
-    assert(
-      importedWallet.left.toOption.get == WalletApi.FailedToInitializeWallet(PhraseToEntropyFailure(InvalidWordLength))
+    assertIO(
+      for {
+        wallet <- walletApi.createNewWallet(password).map(_.toOption.get)
+        mnemonic = wallet.mnemonic :+ "extraWord"
+        importedWallet <- walletApi.importWallet(mnemonic, password)
+      } yield importedWallet.isLeft && importedWallet.left.toOption.get == WalletApi.FailedToInitializeWallet(
+        PhraseToEntropyFailure(InvalidWordLength)
+      ),
+      true
     )
   }
 
   test("importWalletAndSave: verify a save failure returns the correct error") {
     val password = "password".getBytes
-    val wallet = walletApi.createNewWallet(password).toOption.get
-    val importedWallet = walletApi.importWalletAndSave[Id](wallet.mnemonic, password, name = "error")
-    assert(importedWallet.isLeft)
-    assert(importedWallet.left.toOption.get == WalletApi.FailedToSaveWallet(MockWalletKeyApi.MainKeyVaultSaveFailure))
+    assertIO(
+      for {
+        wallet         <- walletApi.createNewWallet(password).map(_.toOption.get)
+        importedWallet <- walletApi.importWalletAndSave[F](wallet.mnemonic, password, name = "error")
+      } yield importedWallet.isLeft && (importedWallet.left.toOption.get == WalletApi.FailedToSaveWallet(
+        MockWalletKeyApi.MainKeyVaultSaveFailure
+      )),
+      true
+    )
   }
 
   test("saveMnemonic: verify a simple save") {
     val name = "test"
-    val res = walletApi.saveMnemonic(IndexedSeq("a", "b", "c"), name)
-    assert(res.isRight)
-    assert(MockWalletKeyApi.mnemonicInstance.contains(name))
+    assertIO(
+      for {
+        res <- walletApi.saveMnemonic(IndexedSeq("a", "b", "c"), name)
+      } yield res.isRight && MockWalletKeyApi.mnemonicInstance.contains(name),
+      true
+    )
+
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val quivr4s = project
     commonSettings,
     publishSettings,
     Test / publishArtifact := true,
-    Test / parallelExecution := false,
+//    Test / parallelExecution := false,
     libraryDependencies ++=
       Dependencies.Quivr4s.sources ++
         Dependencies.Quivr4s.tests

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val quivr4s = project
     commonSettings,
     publishSettings,
     Test / publishArtifact := true,
-//    Test / parallelExecution := false,
+    Test / parallelExecution := false,
     libraryDependencies ++=
       Dependencies.Quivr4s.sources ++
         Dependencies.Quivr4s.tests


### PR DESCRIPTION
## Purpose

there is a [flaky test in the wallet API](https://github.com/Topl/BramblSc/actions/runs/5809330070/job/15747898079#step:8:271) that fails with parallel execution
![image](https://github.com/Topl/BramblSc/assets/17934976/f6625249-c8a4-404e-84dd-a7a8ce1353fb). It is caused by using an implicit ExtendedEd25519 in the WalletApi. 

## Approach

Instead of using implicit ExtendedEd25519, use a CatsUnsafeResource queue to manage its use.

Note: Adding CatsUnsafeResource (and updating WalletApi_ was a small change, most of the changes in this PR is updating the tests to align with the changes to WalletApi (Replacing Id[_] with IO[_]).

## Testing

- Ran tests locally 20x in a row with parallel execution => flaky test did not fail
- Ran tests locally 20x in a row without parallel execution => flaky test did not fail
- Temporarily updated the dependencies in bifrost and ensured all checks pas
- Locally updated the dependencies in brambl-cli and ensured all the unit tests pass

## Tickets
* TSDK-550
* TSDK-572