### PR TITLE
TSDK-569 Series Constructor Minting Transaction

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
@@ -7,24 +7,3 @@ package co.topl.brambl.builders
  * @param message The error message
  */
 abstract class BuilderError(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
-
-object BuilderError {
-
-  /**
-   * A Builder error indicating that an IoTransaction's input
-   * ([[co.topl.brambl.models.transaction.SpentTransactionOutput SpentTransactionOutput]])
-   * was not successfully built.
-   *
-   * @param message The error message indicating why the build is unsuccessful
-   */
-  case class InputBuilderError(message: String, cause: Throwable = null) extends BuilderError(message, cause)
-
-  /**
-   * A Builder error indicating that a IoTransaction's output
-   * ([[co.topl.brambl.models.transaction.UnspentTransactionOutput UnspentTransactionOutput]])
-   * was not successfully built.
-   *
-   * @param message The error message indicating why the build is unsuccessful
-   */
-  case class OutputBuilderError(message: String, cause: Throwable = null) extends BuilderError(message, cause)
-}


### PR DESCRIPTION
## Purpose

Add capability to TransactionBuilder to create a Series Minting transaction.

## Approach

- Added function `buildSimpleSeriesMintingTransaction` which mirrors buildSimpleGroupMintingTransaction from https://github.com/Topl/BramblSc/pull/99 for Group Constructor minting.
- Added Tests
- Modified `validateGroupMintingParams` to `validateConstructorMintingParams` since these parameter validations are identical for the 2 functions.
- (somewhat unrelated) removed object BuilderError since its not used anywhere in the builders package


## Testing

- added new tests
- ensured all existing tests pass

## Tickets
* closes TSDK-569
