### PR TITLE
TSDK-570 Add Asset minting to Transaction builder

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -344,7 +344,7 @@ object TransactionBuilderApi {
           stxoAttestation <- EitherT.right[BuilderError](unprovenAttestation(registrationLock))
           datum           <- EitherT.right[BuilderError](datum())
           utxoMinted <- EitherT.right[BuilderError](
-            groupOutput(mintedConstructorLockAddress, quantityToMint, groupPolicy.computeId)
+            groupOutput(mintedConstructorLockAddress, quantityToMint, groupPolicy.computeId, groupPolicy.fixedSeries)
           )
         } yield IoTransaction(
           inputs = Seq(
@@ -449,7 +449,12 @@ object TransactionBuilderApi {
             )
           )
           groupOutput <- EitherT.right[BuilderError](
-            groupOutput(groupTxo.transactionOutput.address, groupToken.quantity, groupToken.groupId)
+            groupOutput(
+              groupTxo.transactionOutput.address,
+              groupToken.quantity,
+              groupToken.groupId,
+              groupToken.fixedSeries
+            )
           )
           seriesOutputSeq <- {
             val inputQuantity = BigInt(seriesToken.quantity.value.toByteArray)
@@ -563,11 +568,14 @@ object TransactionBuilderApi {
       private def groupOutput(
         lockAddress: LockAddress,
         quantity:    Int128,
-        groupId:     GroupId
+        groupId:     GroupId,
+        fixedSeries: Option[SeriesId]
       ): F[UnspentTransactionOutput] =
         UnspentTransactionOutput(
           lockAddress,
-          Value.defaultInstance.withGroup(Value.Group(groupId = groupId, quantity = quantity))
+          Value.defaultInstance.withGroup(
+            Value.Group(groupId = groupId, quantity = quantity, fixedSeries = fixedSeries)
+          )
         ).pure[F]
 
       private def seriesOutput(

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -25,9 +25,6 @@ import co.topl.brambl.models.Event.{GroupPolicy, SeriesPolicy}
 import co.topl.brambl.models.box.Value.Series
 import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
 import com.google.protobuf.struct.Struct
-import io.circe.Json
-import io.circe._
-import io.circe.syntax._
 
 /**
  * Defines a builder for [[IoTransaction]]s
@@ -496,8 +493,8 @@ object TransactionBuilderApi {
             )
           ),
           outputs = seriesOutputSeq :+ utxoMinted :+ groupOutput,
-          datum = datum
-          // TODO: Minting statements should be added to Transaction
+          datum = datum,
+          mintingStatements = Seq(mintingStatement)
         )
       ).value
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -267,6 +267,13 @@ object TransactionBuilderApi {
           else ().validNec[UserInputError]
         case _ => ().validNec[UserInputError]
       }
+
+    def fungibilityType(testType: Option[FungibilityType]): ValidatedNec[UserInputError, Unit] =
+      Validated.condNec(
+        testType.isEmpty || testType.get == FungibilityType.GROUP_AND_SERIES,
+        (),
+        UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES")
+      )
   }
 
   def make[F[_]: Monad](
@@ -570,7 +577,8 @@ object TransactionBuilderApi {
           fixedSeriesMatch(
             groupTxo.transactionOutput.value.value.group.flatMap(_.fixedSeries),
             seriesTxo.transactionOutput.value.value.series.map(_.seriesId)
-          )
+          ),
+          fungibilityType(seriesTxo.transactionOutput.value.value.series.map(_.fungibility))
         ).fold.toEither
 
       private def groupOutput(

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -17,12 +17,11 @@ import co.topl.brambl.syntax.{
 }
 import com.google.protobuf.ByteString
 import quivr.models.{Int128, Proof}
-import co.topl.brambl.generators.IdentifierGenerator
 import co.topl.brambl.models.box.FungibilityType.{GROUP, GROUP_AND_SERIES, SERIES}
 import co.topl.genus.services.Txo
 import co.topl.genus.services.TxoState.UNSPENT
 
-class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers with IdentifierGenerator {
+class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers {
   val txBuilder: TransactionBuilderApi[Id] = TransactionBuilderApi.make[Id](0, 0)
 
   test("buildSimpleLvlTransaction > No change") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -398,9 +398,138 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
     assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
   }
-  test("buildSimpleAssetMintingTransaction > success, mint token supply quantity (series in output)") {}
-  test("buildSimpleAssetMintingTransaction > success, mint multiple token supply quantity (series in output)") {}
-  test("buildSimpleAssetMintingTransaction > success, mint ALL token supply quantity (series not in output)") {}
+
+  test("buildSimpleAssetMintingTransaction > success, mint token supply quantity (series in output)") {
+    val fullQuantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val outQuantity = Int128(ByteString.copyFrom(BigInt(9).toByteArray))
+    val mintedQuantity = Int128(ByteString.copyFrom(BigInt(5).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesOut = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, outQuantity, 5.some))
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, mintedQuantity)
+    val mintedValue = Value.defaultInstance.withAsset(
+      Value.Asset(mockGroupPolicy.computeId.some, mockSeriesPolicy.computeId.some, mintedQuantity)
+    )
+
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withMintingStatements(Seq(statement))
+      .withInputs(
+        List(
+          SpentTransactionOutput(groupAddr, attFull, groupValue),
+          SpentTransactionOutput(seriesAddr, attFull, seriesValue)
+        )
+      )
+      .withOutputs(
+        List(
+          UnspentTransactionOutput(inLockFullAddress, seriesOut),
+          UnspentTransactionOutput(trivialLockAddress, mintedValue),
+          UnspentTransactionOutput(inLockFullAddress, groupValue)
+        )
+      )
+    val txRes = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
+  }
+
+  test("buildSimpleAssetMintingTransaction > success, mint multiple token supply quantity (series in output)") {
+    val fullQuantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val outQuantity = Int128(ByteString.copyFrom(BigInt(5).toByteArray))
+    val mintedQuantity = Int128(ByteString.copyFrom(BigInt(25).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesOut = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, outQuantity, 5.some))
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, mintedQuantity)
+    val mintedValue = Value.defaultInstance.withAsset(
+      Value.Asset(mockGroupPolicy.computeId.some, mockSeriesPolicy.computeId.some, mintedQuantity)
+    )
+
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withMintingStatements(Seq(statement))
+      .withInputs(
+        List(
+          SpentTransactionOutput(groupAddr, attFull, groupValue),
+          SpentTransactionOutput(seriesAddr, attFull, seriesValue)
+        )
+      )
+      .withOutputs(
+        List(
+          UnspentTransactionOutput(inLockFullAddress, seriesOut),
+          UnspentTransactionOutput(trivialLockAddress, mintedValue),
+          UnspentTransactionOutput(inLockFullAddress, groupValue)
+        )
+      )
+    val txRes = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
+  }
+
+  test("buildSimpleAssetMintingTransaction > success, mint ALL token supply quantity (series not in output)") {
+    val fullQuantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val mintedQuantity = Int128(ByteString.copyFrom(BigInt(50).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, mintedQuantity)
+    val mintedValue = Value.defaultInstance.withAsset(
+      Value.Asset(mockGroupPolicy.computeId.some, mockSeriesPolicy.computeId.some, mintedQuantity)
+    )
+
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withMintingStatements(Seq(statement))
+      .withInputs(
+        List(
+          SpentTransactionOutput(groupAddr, attFull, groupValue),
+          SpentTransactionOutput(seriesAddr, attFull, seriesValue)
+        )
+      )
+      .withOutputs(
+        List(
+          UnspentTransactionOutput(trivialLockAddress, mintedValue),
+          UnspentTransactionOutput(inLockFullAddress, groupValue)
+        )
+      )
+    val txRes = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
+  }
   test("buildSimpleAssetMintingTransaction > success, group and series fungible (IDs set, alloys unset)") {}
   test("buildSimpleAssetMintingTransaction > success, group fungible (groupId and seriesAlloy set)") {}
   test("buildSimpleAssetMintingTransaction > success, series fungible (seriesId and groupAllow set)") {}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -133,7 +133,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint group constructor tokens",
-          UserInputError("registrationTxo does not match registrationUtxo")
+          List(UserInputError("registrationTxo does not match registrationUtxo"))
         )
       )
     )
@@ -159,7 +159,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint group constructor tokens",
-          UserInputError("registrationUtxo does not contain LVLs")
+          List(UserInputError("registrationUtxo does not contain LVLs"))
         )
       )
     )
@@ -183,7 +183,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint group constructor tokens",
-          UserInputError("registrationLock does not correspond to registrationTxo")
+          List(UserInputError("registrationLock does not correspond to registrationTxo"))
         )
       )
     )
@@ -207,7 +207,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint group constructor tokens",
-          UserInputError("quantityToMint must be positive")
+          List(UserInputError("quantityToMint must be positive"))
         )
       )
     )
@@ -273,7 +273,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint series constructor tokens",
-          UserInputError("registrationTxo does not match registrationUtxo")
+          List(UserInputError("registrationTxo does not match registrationUtxo"))
         )
       )
     )
@@ -299,7 +299,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint series constructor tokens",
-          UserInputError("registrationUtxo does not contain LVLs")
+          List(UserInputError("registrationUtxo does not contain LVLs"))
         )
       )
     )
@@ -323,7 +323,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint series constructor tokens",
-          UserInputError("registrationLock does not correspond to registrationTxo")
+          List(UserInputError("registrationLock does not correspond to registrationTxo"))
         )
       )
     )
@@ -347,7 +347,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       Left(
         UnableToBuildTransaction(
           "Unable to build transaction to mint series constructor tokens",
-          UserInputError("quantityToMint must be positive")
+          List(UserInputError("quantityToMint must be positive"))
         )
       )
     )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -578,7 +578,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
   }
 
-  test("buildSimpleAssetMintingTransaction > success, group fungible (groupId and seriesAlloy set)") {
+  test("buildSimpleAssetMintingTransaction > fail, group fungible (currently not supported)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
     val seriesAddr = dummyTxoAddress.copy(index = 1)
@@ -596,34 +596,21 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
 
     val outAddr = trivialLockAddress
     val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
-    val seriesAlloy =
-      merkleRootFromBlake2bEvidence(seriesIdValueImmutable).sizedEvidence(List(mockSeriesPolicy.computeId)).digest.value
-    val mintedValue = Value.defaultInstance.withAsset(
-      Value.Asset(mockGroupPolicy.computeId.some, None, quantity, None, seriesAlloy.some, fungibility = GROUP)
-    )
 
-    val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(statement))
-      .withInputs(
-        List(
-          SpentTransactionOutput(groupAddr, attFull, groupValue),
-          SpentTransactionOutput(seriesAddr, attFull, seriesValue)
-        )
-      )
-      .withOutputs(
-        List(
-          UnspentTransactionOutput(inLockFullAddress, seriesValue),
-          UnspentTransactionOutput(trivialLockAddress, mintedValue),
-          UnspentTransactionOutput(inLockFullAddress, groupValue)
-        )
-      )
-    val txRes = txBuilder
+    val testTx = txBuilder
       .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
-    assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
+        )
+      )
+    )
   }
 
-  test("buildSimpleAssetMintingTransaction > success, series fungible (seriesId and groupAllow set)") {
+  test("buildSimpleAssetMintingTransaction > success, series fungible (currently not supported)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
     val seriesAddr = dummyTxoAddress.copy(index = 1)
@@ -641,33 +628,18 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
 
     val outAddr = trivialLockAddress
     val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
-    val groupAlloy = merkleRootFromBlake2bEvidence(groupIdentifierImmutable)
-      .sizedEvidence(List(mockGroupPolicy.computeId))
-      .digest
-      .value
-    val mintedValue = Value.defaultInstance.withAsset(
-      Value.Asset(None, mockSeriesPolicy.computeId.some, quantity, groupAlloy.some, None, fungibility = SERIES)
-    )
 
-    val expectedTx = IoTransaction.defaultInstance
-      .withDatum(txDatum)
-      .withMintingStatements(Seq(statement))
-      .withInputs(
-        List(
-          SpentTransactionOutput(groupAddr, attFull, groupValue),
-          SpentTransactionOutput(seriesAddr, attFull, seriesValue)
-        )
-      )
-      .withOutputs(
-        List(
-          UnspentTransactionOutput(inLockFullAddress, seriesValue),
-          UnspentTransactionOutput(trivialLockAddress, mintedValue),
-          UnspentTransactionOutput(inLockFullAddress, groupValue)
-        )
-      )
-    val txRes = txBuilder
+    val testTx = txBuilder
       .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
-    assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
+        )
+      )
+    )
   }
 
   test("buildSimpleAssetMintingTransaction > success, fixedSeries provided") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -363,13 +363,13 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
   test("buildSimpleAssetMintingTransaction > success, token supply unlimited (full series in output)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -407,14 +407,14 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     val outQuantity = Int128(ByteString.copyFrom(BigInt(9).toByteArray))
     val mintedQuantity = Int128(ByteString.copyFrom(BigInt(5).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesOut = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, outQuantity, 5.some))
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -452,14 +452,14 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     val outQuantity = Int128(ByteString.copyFrom(BigInt(5).toByteArray))
     val mintedQuantity = Int128(ByteString.copyFrom(BigInt(25).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesOut = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, outQuantity, 5.some))
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -496,13 +496,13 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     val fullQuantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
     val mintedQuantity = Int128(ByteString.copyFrom(BigInt(50).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, fullQuantity, 5.some))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, fullQuantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -537,7 +537,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
   test("buildSimpleAssetMintingTransaction > success, group and series fungible (IDs set, alloys unset)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy =
       SeriesPolicy("Mock Series Policy", None, seriesAddr, fungibility = GROUP_AND_SERIES)
     val seriesValue = Value.defaultInstance.withSeries(
@@ -546,7 +546,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -582,14 +582,14 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
   test("buildSimpleAssetMintingTransaction > success, group fungible (groupId and seriesAlloy set)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr, fungibility = GROUP)
     val seriesValue =
       Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, fungibility = GROUP))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -627,14 +627,14 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
   test("buildSimpleAssetMintingTransaction > success, series fungible (seriesId and groupAllow set)") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr, fungibility = SERIES)
     val seriesValue =
       Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, fungibility = SERIES))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
     val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
@@ -674,13 +674,13 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
   test("buildSimpleAssetMintingTransaction > success, fixedSeries provided") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val fixedSeries = mockSeriesPolicy.computeId.some
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr, fixedSeries)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity, fixedSeries))
@@ -713,26 +713,295 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
     assert(txRes.isRight && txRes.toOption.get.computeId == expectedTx.computeId)
   }
-  test("buildSimpleAssetMintingTransaction > invalid groupTxo") {}
-  test("buildSimpleAssetMintingTransaction > invalid seriesTxo") {}
-  test("buildSimpleAssetMintingTransaction > invalid groupUtxo") {}
-  test("buildSimpleAssetMintingTransaction > invalid seriesUtxo") {}
-  test("buildSimpleAssetMintingTransaction > invalid groupLock") {}
-  test("buildSimpleAssetMintingTransaction > invalid seriesLock") {}
-  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (non positive)") {}
-  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (not a multiple of token supply)") {}
-  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (exceeds available)") {}
 
-  test("buildSimpleAssetMintingTransaction > invalid seriesId (fixedSeries provided)") {
+  test("buildSimpleAssetMintingTransaction > invalid groupTxo") {
     val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
 
-    val seriesAddr = dummyTxoAddress.copy(index = 0)
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
     val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
     val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
     val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
     val seriesLock = inPredicateLockFull
 
-    val groupAddr = dummyTxoAddress.copy(index = 1)
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, dummyTxoAddress)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"groupTxo does not match groupTokenUtxo"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid seriesTxo") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, dummyTxoAddress)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"seriesTxo does not match seriesTokenUtxo"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid groupUtxo") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, value), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"groupTxo does not contain Group Constructor Tokens"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid seriesUtxo") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, value), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"seriesTxo does not contain Series Constructor Tokens"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid groupLock") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = trivialOutLock.getPredicate
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"groupLock does not correspond to groupTxo"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid seriesLock") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = trivialOutLock.getPredicate
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantity)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"seriesLock does not correspond to seriesTxo"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (non positive)") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val quantityInvalid = Int128(ByteString.copyFrom(BigInt(-1).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantityInvalid)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"quantity to mint must be positive"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (not a multiple of token supply)") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val quantityInvalid = Int128(ByteString.copyFrom(BigInt(7).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, 5.some))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantityInvalid)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"quantity to mint must be a multiple of token supply"))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid quantity to mint (exceeds available)") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+    val quantityInvalid = Int128(ByteString.copyFrom(BigInt(55).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", 5.some, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, 5.some))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
+    val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr)
+    val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
+    val groupTxo = Txo(UnspentTransactionOutput(inLockFullAddress, groupValue), UNSPENT, groupAddr)
+    val groupLock = inPredicateLockFull
+
+    val outAddr = trivialLockAddress
+    val statement: AssetMintingStatement = AssetMintingStatement(groupAddr, seriesAddr, quantityInvalid)
+
+    val testTx = txBuilder
+      .buildSimpleAssetMintingTransaction(statement, groupTxo, seriesTxo, groupLock, seriesLock, outAddr, None, None)
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          "Unable to build transaction to mint asset tokens",
+          List(UserInputError(s"quantity to mint must be less than total token supply available."))
+        )
+      )
+    )
+  }
+
+  test("buildSimpleAssetMintingTransaction > invalid seriesId (fixedSeries provided)") {
+    val quantity = Int128(ByteString.copyFrom(BigInt(10).toByteArray))
+
+    val seriesAddr = dummyTxoAddress.copy(index = 1)
+    val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, seriesAddr)
+    val seriesValue = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
+    val seriesTxo = Txo(UnspentTransactionOutput(inLockFullAddress, seriesValue), UNSPENT, seriesAddr)
+    val seriesLock = inPredicateLockFull
+
+    val groupAddr = dummyTxoAddress.copy(index = 2)
     val fixedSeries = mockSeriesPolicy.copy("different series").computeId.some
     val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", groupAddr, fixedSeries)
     val groupValue = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity, fixedSeries))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val catsCoreVersion = "2.10.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "2.0.0-alpha4+3-ee5641bf-SNAPSHOT" // requires protobuf release, commit on main
+    val protobufSpecsVersion = "2.0.0-alpha4+4-007e03f0-SNAPSHOT"
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose

Added the ability to create a transaction to mint TAMv2 Asset tokens

## Approach

- Added new function signature `buildSimpleAssetMintingTransaction`
- Refactored the User Input validations to reduce code reuse (certain validations are common). Note that validating the metadata is a nice-to-have and will be implemented in a future ticket (TSDK-585)
- Added tests

## Testing

- updated the existing tests for minting Group and Series constructor tokens to align with the changes to User input validation
- Ensured all existing tests pass
- Identified and added 18 new test cases for asset minting. These cover both success and failure cases.

## Tickets
* Closes TSDK-570