### PR TITLE
TSDK-578 Transfer Tokens

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/BuilderError.scala
@@ -7,3 +7,7 @@ package co.topl.brambl.builders
  * @param message The error message
  */
 abstract class BuilderError(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+case class UserInputError(message: String) extends BuilderError(message, null)
+
+case class BuilderRuntimeError(message: String, cause: Throwable = null) extends BuilderError(message, cause)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -66,6 +66,63 @@ trait TransactionBuilderApi[F[_]] {
   def lvlOutput(lockAddress: LockAddress, amount: Int128): F[UnspentTransactionOutput]
 
   /**
+   * Builds a group constructor unspent transaction output for the given parameters
+   * @param lockAddress The lock address to use to build the group constructor output
+   * @param quantity The quantity to use to build the group constructor output
+   * @param groupId The group id to use to build the group constructor output
+   * @param fixedSeries The fixed series to use to build the group constructor output
+   * @return An unspent transaction output containing group constructor tokens
+   */
+  def groupOutput(
+    lockAddress: LockAddress,
+    quantity:    Int128,
+    groupId:     GroupId,
+    fixedSeries: Option[SeriesId]
+  ): F[UnspentTransactionOutput]
+
+  /**
+   * Builds a series constructor unspent transaction output for the given parameters
+   * @param lockAddress The lock address to use to build the series constructor output
+   * @param quantity The quantity to use to build the series constructor output
+   * @param seriesId The series id to use to build the series constructor output
+   * @param tokenSupply The token supply to use to build the series constructor output
+   * @param fungibility The fungibility type to use to build the series constructor output
+   * @param quantityDescriptor The quantity descriptor type to use to build the series constructor output
+   * @return
+   */
+  def seriesOutput(
+    lockAddress:        LockAddress,
+    quantity:           Int128,
+    seriesId:           SeriesId,
+    tokenSupply:        Option[Int],
+    fungibility:        FungibilityType,
+    quantityDescriptor: QuantityDescriptorType
+  ): F[UnspentTransactionOutput]
+
+  /**
+   * Builds an asset unspent transaction output for the given parameters
+   * @param lockAddress The lock address to use to build the asset output
+   * @param quantity The quantity to use to build the asset output
+   * @param groupId The group id to use to build the asset output
+   * @param seriesId The series id to use to build the asset output
+   * @param fungibilityType The fungibility type to use to build the asset output
+   * @param quantityDescriptorType The quantity descriptor type to use to build the asset output
+   * @param metadata The metadata to use to build the asset output
+   * @param commitment The commitment to use to build the asset output
+   * @return An unspent transaction output containing asset tokens
+   */
+  def assetOutput(
+    lockAddress:            LockAddress,
+    quantity:               Int128,
+    groupId:                GroupId,
+    seriesId:               SeriesId,
+    fungibilityType:        FungibilityType,
+    quantityDescriptorType: QuantityDescriptorType,
+    metadata:               Option[Struct],
+    commitment:             Option[ByteString]
+  ): F[UnspentTransactionOutput]
+
+  /**
    * Builds a datum with default values for a transaction. The schedule is defaulted to use the current timestamp, with
    * min and max slot being 0 and Long.MaxValue respectively.
    *
@@ -108,7 +165,7 @@ trait TransactionBuilderApi[F[_]] {
     amount:               Long,
     recipientLockAddress: LockAddress,
     changeLockAddress:    LockAddress
-  )
+  ): F[Either[BuilderError, IoTransaction]]
 
   /**
    * Builds a transaction to transfer a certain amount of Group Constructor Tokens (given by groupId). The transaction
@@ -131,7 +188,7 @@ trait TransactionBuilderApi[F[_]] {
     amount:               Long,
     recipientLockAddress: LockAddress,
     changeLockAddress:    LockAddress
-  )
+  ): F[Either[BuilderError, IoTransaction]]
 
   /**
    * Builds a transaction to transfer a certain amount of Series Constructor Tokens (given by seriesId). The transaction
@@ -154,7 +211,7 @@ trait TransactionBuilderApi[F[_]] {
     amount:               Long,
     recipientLockAddress: LockAddress,
     changeLockAddress:    LockAddress
-  )
+  ): F[Either[BuilderError, IoTransaction]]
 
   /**
    * Builds a transaction to transfer a certain amount of Asset Tokens (given by groupId and/or seriesId). The
@@ -182,7 +239,7 @@ trait TransactionBuilderApi[F[_]] {
     amount:               Long,
     recipientLockAddress: LockAddress,
     changeLockAddress:    LockAddress
-  )
+  ): F[Either[BuilderError, IoTransaction]]
 
   /**
    * Builds a simple transaction to mint Group Constructor tokens.
@@ -433,7 +490,7 @@ object TransactionBuilderApi {
         amount:               Long,
         recipientLockAddress: LockAddress,
         changeLockAddress:    LockAddress
-      ): Unit = ???
+      ): F[Either[BuilderError, IoTransaction]] = ???
 
       override def buildGroupTransferTransaction(
         groupId:              GroupId,
@@ -442,7 +499,7 @@ object TransactionBuilderApi {
         amount:               Long,
         recipientLockAddress: LockAddress,
         changeLockAddress:    LockAddress
-      ): Unit = ???
+      ): F[Either[BuilderError, IoTransaction]] = ???
 
       override def buildSeriesTransferTransaction(
         seriesId:             SeriesId,
@@ -451,7 +508,7 @@ object TransactionBuilderApi {
         amount:               Long,
         recipientLockAddress: LockAddress,
         changeLockAddress:    LockAddress
-      ): Unit = ???
+      ): F[Either[BuilderError, IoTransaction]] = ???
 
       override def buildAssetTransferTransaction(
         groupId:              Option[GroupId],
@@ -461,7 +518,7 @@ object TransactionBuilderApi {
         amount:               Long,
         recipientLockAddress: LockAddress,
         changeLockAddress:    LockAddress
-      ): Unit = ???
+      ): F[Either[BuilderError, IoTransaction]] = ???
 
       override def buildSimpleGroupMintingTransaction(
         registrationTxo:              Txo,
@@ -712,7 +769,7 @@ object TransactionBuilderApi {
           fungibilityType(seriesTxo.transactionOutput.value.value.series.map(_.fungibility))
         ).fold.toEither
 
-      private def groupOutput(
+      override def groupOutput(
         lockAddress: LockAddress,
         quantity:    Int128,
         groupId:     GroupId,
@@ -725,7 +782,7 @@ object TransactionBuilderApi {
           )
         ).pure[F]
 
-      private def seriesOutput(
+      override def seriesOutput(
         lockAddress:        LockAddress,
         quantity:           Int128,
         seriesId:           SeriesId,
@@ -746,7 +803,7 @@ object TransactionBuilderApi {
           )
         ).pure[F]
 
-      private def assetOutput(
+      override def assetOutput(
         lockAddress:            LockAddress,
         quantity:               Int128,
         groupId:                GroupId,

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -92,6 +92,99 @@ trait TransactionBuilderApi[F[_]] {
   ): F[IoTransaction]
 
   /**
+   * Builds a transaction to transfer a certain amount of LVLs. The transaction will also transfer any other tokens that
+   * are encumbered by the same predicate as the LVLs to the change address.
+   *
+   * @param txos  All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
+   *              necessary quantity (given by amount) of LVLs, else an error will be returned.
+   * @param lockPredicateFrom The Lock Predicate encumbering the txos
+   * @param amount The amount of LVLs to transfer to the recipient
+   * @param recipientLockAddress The LockAddress of the recipient
+   * @param changeLockAddress A LockAddress to send the txos that are not going to the recipient
+   */
+  def buildLvlTransferTransaction(
+    txos:                 Seq[Txo],
+    lockPredicateFrom:    Lock.Predicate,
+    amount:               Long,
+    recipientLockAddress: LockAddress,
+    changeLockAddress:    LockAddress
+  )
+
+  /**
+   * Builds a transaction to transfer a certain amount of Group Constructor Tokens (given by groupId). The transaction
+   * will also transfer any other tokens that are encumbered by the same predicate as the Group Constructor Tokens to
+   * the change address.
+   *
+   * @param groupId The GroupId of the Group Constructor Tokens to transfer to the recipient
+   * @param txos  All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
+   *              necessary quantity (given by amount) of the identified Group Constructor Tokens, else an error will be
+   *              returned.
+   * @param lockPredicateFrom The Lock Predicate encumbering the txos
+   * @param amount The amount of identified Group Constructor Tokens to transfer to the recipient
+   * @param recipientLockAddress The LockAddress of the recipient
+   * @param changeLockAddress A LockAddress to send the txos that are not going to the recipient
+   */
+  def buildGroupTransferTransaction(
+    groupId:              GroupId,
+    txos:                 Seq[Txo],
+    lockPredicateFrom:    Lock.Predicate,
+    amount:               Long,
+    recipientLockAddress: LockAddress,
+    changeLockAddress:    LockAddress
+  )
+
+  /**
+   * Builds a transaction to transfer a certain amount of Series Constructor Tokens (given by seriesId). The transaction
+   * will also transfer any other tokens that are encumbered by the same predicate as the Series Constructor Tokens to
+   * the change address.
+   *
+   * @param seriesId The SeriesId of the Series Constructor Tokens to transfer to the recipient
+   * @param txos  All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
+   *              necessary quantity (given by amount) of the identified Series Constructor Tokens, else an error will be
+   *              returned.
+   * @param lockPredicateFrom The Lock Predicate encumbering the txos
+   * @param amount The amount of identified Series Constructor Tokens to transfer to the recipient
+   * @param recipientLockAddress The LockAddress of the recipient
+   * @param changeLockAddress A LockAddress to send the txos that are not going to the recipient
+   */
+  def buildSeriesTransferTransaction(
+    seriesId:             SeriesId,
+    txos:                 Seq[Txo],
+    lockPredicateFrom:    Lock.Predicate,
+    amount:               Long,
+    recipientLockAddress: LockAddress,
+    changeLockAddress:    LockAddress
+  )
+
+  /**
+   * Builds a transaction to transfer a certain amount of Asset Tokens (given by groupId and/or seriesId). The
+   * transaction will also transfer any other tokens that are encumbered by the same predicate as the Asset Tokens to
+   * the change address.
+   *
+   * We currently only support assets with fungibility type GROUP_AND_SERIES.
+   *
+   * @param groupId The GroupId of the Asset Tokens (if fungibility is type GROUP or GROUP_AND_SERIES) to transfer to
+   *                the recipient. If fungibility is type SERIES, this parameter is ignored.
+   * @param seriesId The SeriesId of the Asset Tokens (if fungibility is type SERIES or GROUP_AND_SERIES) to transfer to
+   *                 the recipient. If fungibility is type GROUP, this parameter is ignored.
+   * @param txos  All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
+   *              necessary quantity (given by amount) of the identified Asset Tokens, else an error will be returned.
+   * @param lockPredicateFrom The Lock Predicate encumbering the txos
+   * @param amount The amount of identified Asset Tokens to transfer to the recipient
+   * @param recipientLockAddress The LockAddress of the recipient
+   * @param changeLockAddress A LockAddress to send the txos that are not going to the recipient
+   */
+  def buildAssetTransferTransaction(
+    groupId:              Option[GroupId],
+    seriesId:             Option[SeriesId],
+    txos:                 Seq[Txo],
+    lockPredicateFrom:    Lock.Predicate,
+    amount:               Long,
+    recipientLockAddress: LockAddress,
+    changeLockAddress:    LockAddress
+  )
+
+  /**
    * Builds a simple transaction to mint Group Constructor tokens.
    * If successful, the transaction will have a single input (the registrationUtxo) and a single output (the minted
    * group constructor tokens).
@@ -144,6 +237,8 @@ trait TransactionBuilderApi[F[_]] {
    * If successful, the transaction will have two inputs (the group and series constructor token UTXOs) and 2-3 outputs.
    * The first output will be the minted asset tokens. The second output will be the group constructor tokens (since
    * they are never burned). The potential third output will be the series constructor tokens that were not burned.
+   *
+   * We currently only support assets with fungibility type GROUP_AND_SERIES.
    *
    * @param mintingStatement      The minting statement that specifies the asset to mint.
    * @param groupTxo              The TXO that corresponds to the groupTokenUtxo (in the asset minting statement) to use
@@ -331,6 +426,42 @@ object TransactionBuilderApi {
           )
           .withDatum(datum)
       } yield ioTransaction
+
+      override def buildLvlTransferTransaction(
+        txos:                 Seq[Txo],
+        lockPredicateFrom:    Lock.Predicate,
+        amount:               Long,
+        recipientLockAddress: LockAddress,
+        changeLockAddress:    LockAddress
+      ): Unit = ???
+
+      override def buildGroupTransferTransaction(
+        groupId:              GroupId,
+        txos:                 Seq[Txo],
+        lockPredicateFrom:    Lock.Predicate,
+        amount:               Long,
+        recipientLockAddress: LockAddress,
+        changeLockAddress:    LockAddress
+      ): Unit = ???
+
+      override def buildSeriesTransferTransaction(
+        seriesId:             SeriesId,
+        txos:                 Seq[Txo],
+        lockPredicateFrom:    Lock.Predicate,
+        amount:               Long,
+        recipientLockAddress: LockAddress,
+        changeLockAddress:    LockAddress
+      ): Unit = ???
+
+      override def buildAssetTransferTransaction(
+        groupId:              Option[GroupId],
+        seriesId:             Option[SeriesId],
+        txos:                 Seq[Txo],
+        lockPredicateFrom:    Lock.Predicate,
+        amount:               Long,
+        recipientLockAddress: LockAddress,
+        changeLockAddress:    LockAddress
+      ): Unit = ???
 
       override def buildSimpleGroupMintingTransaction(
         registrationTxo:              Txo,

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -562,7 +562,7 @@ object TransactionBuilderApi {
                       Int128(
                         ByteString.copyFrom(
                           (BigInt(quantity.toByteArray) + BigInt(
-                            value.value.lvl.get.quantity.value.toByteArray
+                            value.value.group.get.quantity.value.toByteArray
                           )).toByteArray
                         )
                       )
@@ -574,7 +574,7 @@ object TransactionBuilderApi {
                       Int128(
                         ByteString.copyFrom(
                           (BigInt(quantity.toByteArray) + BigInt(
-                            value.value.lvl.get.quantity.value.toByteArray
+                            value.value.series.get.quantity.value.toByteArray
                           )).toByteArray
                         )
                       )
@@ -586,7 +586,7 @@ object TransactionBuilderApi {
                       Int128(
                         ByteString.copyFrom(
                           (BigInt(quantity.toByteArray) + BigInt(
-                            value.value.lvl.get.quantity.value.toByteArray
+                            value.value.asset.get.quantity.value.toByteArray
                           )).toByteArray
                         )
                       )

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -11,6 +11,8 @@ import co.topl.brambl.syntax.{
   longAsInt128,
   valueToQuantitySyntaxOps,
   valueToTypeIdentifierSyntaxOps,
+  GroupFungible,
+  SeriesFungible,
   ValueTypeIdentifier
 }
 import co.topl.genus.services.Txo
@@ -117,6 +119,16 @@ object UserInputValidations {
       UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES")
     )
 
+  def identifierFungibilityType(testType: ValueTypeIdentifier): ValidatedNec[UserInputError, Unit] =
+    Validated.condNec(
+      testType match {
+        case GroupFungible(_) | SeriesFungible(_) => false
+        case _                                    => true
+      },
+      (),
+      UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES")
+    )
+
   def allValidFungibilityTypes(testValues: Seq[Value]): ValidatedNec[UserInputError, Unit] =
     Validated.condNec(
       // Any asset tokens must have valid fungibility
@@ -139,6 +151,7 @@ object UserInputValidations {
         positiveQuantity(Some(amount), "quantity to transfer"),
         allInputLocksMatch(txos.map(_.transactionOutput.address), fromLockAddr, "fromLockAddr"),
         validTransferSupply(amount, transferValues),
+        identifierFungibilityType(transferIdentifier),
         allValidFungibilityTypes(allValues)
       ).fold.toEither
     } match {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -3,9 +3,7 @@ package co.topl.brambl.builders
 import cats.Id
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.builders.TransactionBuilderApi.{UnableToBuildTransaction, UserInputError}
-import co.topl.brambl.common.ContainsEvidence.merkleRootFromBlake2bEvidence
-import co.topl.brambl.common.ContainsImmutable.instances.{groupIdentifierImmutable, seriesIdValueImmutable}
+import co.topl.brambl.builders.TransactionBuilderApi.UnableToBuildTransaction
 import co.topl.brambl.models.Datum
 import co.topl.brambl.models.Event.{GroupPolicy, SeriesPolicy}
 import co.topl.brambl.models.box.{AssetMintingStatement, Attestation, Value}
@@ -138,8 +136,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint group constructor tokens",
-          List(UserInputError("registrationTxo does not match registrationUtxo"))
+          Seq(UserInputError("registrationTxo does not match registrationUtxo"))
         )
       )
     )
@@ -164,8 +161,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint group constructor tokens",
-          List(UserInputError("registrationUtxo does not contain LVLs"))
+          Seq(UserInputError("registrationUtxo does not contain LVLs"))
         )
       )
     )
@@ -188,8 +184,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint group constructor tokens",
-          List(UserInputError("registrationLock does not correspond to registrationTxo"))
+          Seq(UserInputError("registrationLock does not correspond to registrationTxo"))
         )
       )
     )
@@ -212,8 +207,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint group constructor tokens",
-          List(UserInputError("quantityToMint must be positive"))
+          Seq(UserInputError("quantityToMint must be positive"))
         )
       )
     )
@@ -278,8 +272,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint series constructor tokens",
-          List(UserInputError("registrationTxo does not match registrationUtxo"))
+          Seq(UserInputError("registrationTxo does not match registrationUtxo"))
         )
       )
     )
@@ -304,8 +297,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint series constructor tokens",
-          List(UserInputError("registrationUtxo does not contain LVLs"))
+          Seq(UserInputError("registrationUtxo does not contain LVLs"))
         )
       )
     )
@@ -328,8 +320,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint series constructor tokens",
-          List(UserInputError("registrationLock does not correspond to registrationTxo"))
+          Seq(UserInputError("registrationLock does not correspond to registrationTxo"))
         )
       )
     )
@@ -352,8 +343,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint series constructor tokens",
-          List(UserInputError("quantityToMint must be positive"))
+          Seq(UserInputError("quantityToMint must be positive"))
         )
       )
     )
@@ -603,8 +593,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
+          Seq(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
         )
       )
     )
@@ -635,8 +624,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
+          Seq(UserInputError(s"Unsupported fungibility type. We currently only support GROUP_AND_SERIES"))
         )
       )
     )
@@ -709,8 +697,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"groupTxo does not match groupTokenUtxo"))
+          Seq(UserInputError(s"groupTxo does not match groupTokenUtxo"))
         )
       )
     )
@@ -740,8 +727,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"seriesTxo does not match seriesTokenUtxo"))
+          Seq(UserInputError(s"seriesTxo does not match seriesTokenUtxo"))
         )
       )
     )
@@ -769,8 +755,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"groupTxo does not contain Group Constructor Tokens"))
+          Seq(UserInputError(s"groupTxo does not contain Group Constructor Tokens"))
         )
       )
     )
@@ -798,8 +783,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"seriesTxo does not contain Series Constructor Tokens"))
+          Seq(UserInputError(s"seriesTxo does not contain Series Constructor Tokens"))
         )
       )
     )
@@ -829,8 +813,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"groupLock does not correspond to groupTxo"))
+          Seq(UserInputError(s"groupLock does not correspond to groupTxo"))
         )
       )
     )
@@ -860,8 +843,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"seriesLock does not correspond to seriesTxo"))
+          Seq(UserInputError(s"seriesLock does not correspond to seriesTxo"))
         )
       )
     )
@@ -892,8 +874,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"quantity to mint must be positive"))
+          Seq(UserInputError(s"quantity to mint must be positive"))
         )
       )
     )
@@ -925,8 +906,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(
+          Seq(
             UserInputError(s"quantity of input series constructor tokens must be positive"),
             UserInputError(s"quantity to mint must be less than total token supply available.")
           )
@@ -960,8 +940,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"quantity to mint must be a multiple of token supply"))
+          Seq(UserInputError(s"quantity to mint must be a multiple of token supply"))
         )
       )
     )
@@ -992,8 +971,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"quantity to mint must be less than total token supply available."))
+          Seq(UserInputError(s"quantity to mint must be less than total token supply available."))
         )
       )
     )
@@ -1024,8 +1002,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       testTx,
       Left(
         UnableToBuildTransaction(
-          "Unable to build transaction to mint asset tokens",
-          List(UserInputError(s"fixedSeries does not match provided Series ID"))
+          Seq(UserInputError(s"fixedSeries does not match provided Series ID"))
         )
       )
     )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpec.scala
@@ -1055,7 +1055,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"Invalid value type")))))
   }
@@ -1067,7 +1068,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"Invalid value type")))))
   }
@@ -1079,7 +1081,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"Invalid value type")))))
   }
@@ -1091,7 +1094,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"Invalid value type")))))
   }
@@ -1103,7 +1107,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       0,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
@@ -1115,7 +1120,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       0,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
@@ -1127,7 +1133,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       0,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
@@ -1139,7 +1146,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       0,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(testTx, Left(UnableToBuildTransaction(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
@@ -1150,7 +1158,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1165,7 +1174,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1180,7 +1190,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1195,7 +1206,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1209,7 +1221,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1232,7 +1245,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1255,7 +1269,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1278,7 +1293,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1301,7 +1317,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assert(
       testTx.left.toOption.get
@@ -1317,13 +1334,17 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       4,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
       Left(
         UnableToBuildTransaction(
-          Seq(UserInputError(s"All tokens selected to transfer do not have enough funds to transfer"))
+          Seq(
+            UserInputError(s"All tokens selected to transfer do not have enough funds to transfer"),
+            UserInputError(s"Not enough LVLs in input to satisfy fee")
+          )
         )
       )
     )
@@ -1336,7 +1357,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       4,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1355,7 +1377,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       4,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1374,7 +1397,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       4,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     assertEquals(
       testTx,
@@ -1386,13 +1410,93 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
     )
   }
 
+  test("buildLvlTransferTransaction > fee not satisfied") {
+    val testTx = txBuilder.buildLvlTransferTransaction(
+      mockTxos,
+      inPredicateLockFull,
+      1,
+      inLockFullAddress,
+      trivialLockAddress,
+      2
+    )
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          Seq(UserInputError(s"Not enough LVLs in input to satisfy fee"))
+        )
+      )
+    )
+  }
+
+  test("buildGroupTransferTransaction > fee not satisfied") {
+    val testTx = txBuilder.buildGroupTransferTransaction(
+      GroupType(mockGroupPolicy.computeId),
+      mockTxos,
+      inPredicateLockFull,
+      1,
+      inLockFullAddress,
+      trivialLockAddress,
+      3
+    )
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          Seq(UserInputError(s"Not enough LVLs in input to satisfy fee"))
+        )
+      )
+    )
+  }
+
+  test("buildSeriesTransferTransaction > fee not satisfied") {
+    val testTx = txBuilder.buildSeriesTransferTransaction(
+      SeriesType(mockSeriesPolicy.computeId),
+      mockTxos,
+      inPredicateLockFull,
+      1,
+      inLockFullAddress,
+      trivialLockAddress,
+      3
+    )
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          Seq(UserInputError(s"Not enough LVLs in input to satisfy fee"))
+        )
+      )
+    )
+  }
+
+  test("buildAssetTransferTransaction > fee not satisfied") {
+    val testTx = txBuilder.buildAssetTransferTransaction(
+      GroupAndSeriesFungible(mockGroupPolicy.computeId, mockSeriesPolicy.computeId),
+      mockTxos,
+      inPredicateLockFull,
+      1,
+      inLockFullAddress,
+      trivialLockAddress,
+      3
+    )
+    assertEquals(
+      testTx,
+      Left(
+        UnableToBuildTransaction(
+          Seq(UserInputError(s"Not enough LVLs in input to satisfy fee"))
+        )
+      )
+    )
+  }
+
   test("buildLvlTransferTransaction > [complex] duplicate inputs are merged and split correctly") {
     val testTx = txBuilder.buildLvlTransferTransaction(
       mockTxos,
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      1
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1400,7 +1504,6 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       .withOutputs(
         List(
           UnspentTransactionOutput(inLockFullAddress, value), // recipient
-          UnspentTransactionOutput(trivialLockAddress, value),
           UnspentTransactionOutput(trivialLockAddress, groupValue.copy(groupValue.value.setQuantity(quantity * 2))),
           UnspentTransactionOutput(
             trivialLockAddress,
@@ -1436,7 +1539,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      1
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1445,7 +1549,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
         List(
           UnspentTransactionOutput(inLockFullAddress, groupValue), // recipient
           UnspentTransactionOutput(trivialLockAddress, groupValue),
-          UnspentTransactionOutput(trivialLockAddress, value.copy(value.value.setQuantity(quantity * 2))),
+          UnspentTransactionOutput(trivialLockAddress, value),
           UnspentTransactionOutput(
             trivialLockAddress,
             groupValue.copy(groupValue.getGroup.withGroupId(mockGroupPolicyAlt.computeId))
@@ -1480,7 +1584,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      1
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1489,7 +1594,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
         List(
           UnspentTransactionOutput(inLockFullAddress, seriesValue), // recipient
           UnspentTransactionOutput(trivialLockAddress, seriesValue),
-          UnspentTransactionOutput(trivialLockAddress, value.copy(value.value.setQuantity(quantity * 2))),
+          UnspentTransactionOutput(trivialLockAddress, value),
           UnspentTransactionOutput(trivialLockAddress, groupValue.copy(groupValue.value.setQuantity(quantity * 2))),
           UnspentTransactionOutput(
             trivialLockAddress,
@@ -1524,7 +1629,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      1
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1533,7 +1639,7 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
         List(
           UnspentTransactionOutput(inLockFullAddress, assetGroupSeries), // recipient
           UnspentTransactionOutput(trivialLockAddress, assetGroupSeries),
-          UnspentTransactionOutput(trivialLockAddress, value.copy(value.value.setQuantity(quantity * 2))),
+          UnspentTransactionOutput(trivialLockAddress, value),
           UnspentTransactionOutput(trivialLockAddress, groupValue.copy(groupValue.value.setQuantity(quantity * 2))),
           UnspentTransactionOutput(
             trivialLockAddress,
@@ -1565,7 +1671,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1582,7 +1689,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1599,7 +1707,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
@@ -1616,7 +1725,8 @@ class TransactionBuilderInterpreterSpec extends munit.FunSuite with MockHelpers 
       inPredicateLockFull,
       1,
       inLockFullAddress,
-      trivialLockAddress
+      trivialLockAddress,
+      0
     )
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)


### PR DESCRIPTION
## Purpose

Transfer tokens while considering different token types. Specifically, The user can transfer X amount of a specific type of token to a recipient address while providing ALL tokens at the same LockAddress. Any tokens not going to the recipient will go to a change address


## Approach

- Added `buildLvlTransferTransaction`, `buildGroupTransferTransaction`, `buildSeriesTransferTransaction`, and `buildAssetTransferTransaction` to the Transaction Builder API
- All 4 of these functions under-the-hood will use private function `buildTransferTransaction` which handles the actual implementation (and takes in addition a `ValueTypeIdentifier` to specify which token is meant to be transferred to the recipient)
- At a high level, this function 
    - Expects all provided Txos to correspond with the provided `lockPredicateFrom`. With this lock predicate, we create the attestation for all inputs. Each provided Txo becomes an input
    - To create the UTXOs, we first merge all Txos of the same type (i.e, same group ID if type is Group Constructor Token). Then we retrieve the merged TXO that corresponds to the type we want to transfer. With this, if the quantity exceed the amount to transfer, we split it into 2. With all of these values, we turn them into UTXOs with their corresponding LockAddresses.
- Made the existing functions `groupOutput`, `seriesOutput`, and `assetOutput` public (to align with the `lvlOutput` function)
- Minor changes (that do not affect their existing algorithms) to some existing functions in TransactionBuilder to use new SyntaxOps which reduces the verbosity of their code
- Moved `UserInputValidations` into its own file + added validations specifically for transfer
-  Added tests

## Testing
- Added tests for the 4 new functions `buildLvlTransferTransaction`, `buildGroupTransferTransaction`, `buildSeriesTransferTransaction`, and `buildAssetTransferTransaction`. We test user input failures and 1 complex (merge and split) case and 1 simple (single input) case
- Ensured all existing tests pass
- Ran tests in brambl-cli on the main branch to ensure backwards compatibility.
    - Added the stubs for the newly added functions
    - ran unit tests and integrations tests. ensured all successful

## Tickets
* closes TSDK-578