### PR TITLE
TSDK-578 Added Syntax Ops for  Box.Value and Int128

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
@@ -1,0 +1,73 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.models.box.FungibilityType.{GROUP, GROUP_AND_SERIES, SERIES}
+import co.topl.brambl.models.{GroupId, SeriesId}
+import co.topl.brambl.models.box.Value._
+import quivr.models.Int128
+
+import scala.language.implicitConversions
+
+trait BoxValueSyntax {
+  implicit def lvlAsBoxVal(lvl:  LVL): Value = Value.Lvl(lvl)
+  implicit def groupAsBoxVal(g:  Group): Value = Value.Group(g)
+  implicit def seriesAsBoxVal(s: Series): Value = Value.Series(s)
+  implicit def assetAsBoxVal(a:  Asset): Value = Value.Asset(a)
+
+  implicit def valueToQuantitySyntaxOps(v: Value): ValueToQuantitySyntaxOps = new ValueToQuantitySyntaxOps(v)
+
+  implicit def valueToTypeIdentifierSyntaxOps(v: Value): ValueToTypeIdentifierSyntaxOps =
+    new ValueToTypeIdentifierSyntaxOps(v)
+
+}
+
+class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
+
+  def quantity: Int128 = value match {
+    case Value.Lvl(l)    => l.quantity
+    case Value.Group(g)  => g.quantity
+    case Value.Series(s) => s.quantity
+    case Value.Asset(a)  => a.quantity
+    case _               => throw new Exception("Invalid value type")
+  }
+
+  def setQuantity(quantity: Int128): Value = value match {
+    case Value.Lvl(l)    => l.withQuantity(quantity)
+    case Value.Group(g)  => g.withQuantity(quantity)
+    case Value.Series(s) => s.withQuantity(quantity)
+    case Value.Asset(a)  => a.withQuantity(quantity)
+    case _               => throw new Exception("Invalid value type")
+  }
+}
+
+class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
+
+  def typeIdentifier: ValueTypeIdentifier = value match {
+    case Value.Lvl(_)    => LvlType
+    case Value.Group(g)  => GroupType(g.groupId)
+    case Value.Series(s) => SeriesType(s.seriesId)
+    case Value.Asset(a) =>
+      (a.fungibility, a.groupId, a.seriesId) match {
+        case (GROUP_AND_SERIES, Some(gId), Some(sId)) => GroupAndSeriesFungible(gId, sId)
+        case (GROUP, Some(gId), _)                    => GroupFungible(gId)
+        case (SERIES, _, Some(sId))                   => SeriesFungible(sId)
+        case _                                        => throw new Exception("Invalid asset")
+      }
+    case _ => throw new Exception("Invalid value type")
+  }
+}
+
+trait ValueTypeIdentifier
+
+case object LvlType extends ValueTypeIdentifier
+
+case class GroupType(groupId: GroupId) extends ValueTypeIdentifier
+
+case class SeriesType(series: SeriesId) extends ValueTypeIdentifier
+
+trait AssetType extends ValueTypeIdentifier
+
+case class GroupAndSeriesFungible(groupId: GroupId, series: SeriesId) extends AssetType
+
+case class GroupFungible(groupId: GroupId) extends AssetType
+
+case class SeriesFungible(series: SeriesId) extends AssetType

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/Int128Syntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/Int128Syntax.scala
@@ -1,0 +1,12 @@
+package co.topl.brambl.syntax
+
+import com.google.protobuf.ByteString
+import quivr.models.Int128
+
+import scala.language.implicitConversions
+
+trait Int128Syntax {
+  implicit def int128AsBigInt(int128: Int128): BigInt = BigInt(int128.value.toByteArray)
+  implicit def bigIntAsInt128(bigInt: BigInt): Int128 = Int128(ByteString.copyFrom(bigInt.toByteArray))
+  implicit def longAsInt128(long:     Long): Int128 = BigInt(long)
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
@@ -5,4 +5,6 @@ package object syntax
     with TransactionIdSyntax
     with TransactionSyntax
     with GroupPolicySyntax
-    with SeriesPolicySyntax {}
+    with SeriesPolicySyntax
+    with BoxValueSyntax
+    with Int128Syntax {}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/BoxValueSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/BoxValueSyntaxSpec.scala
@@ -1,0 +1,57 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.Value.{Value => BoxValue}
+import com.google.protobuf.ByteString
+import quivr.models.Int128
+
+class BoxValueSyntaxSpec extends munit.FunSuite with MockHelpers {
+
+  val mockNewQuantity: Int128 = Int128(ByteString.copyFrom(BigInt(100).toByteArray))
+
+  test("lvlAsBoxVal") {
+    assertEquals(value.getLvl: BoxValue, value.value)
+  }
+
+  test("groupAsBoxVal") {
+    assertEquals(groupValue.getGroup: BoxValue, groupValue.value)
+  }
+
+  test("seriesAsBoxVal") {
+    assertEquals(seriesValue.getSeries: BoxValue, seriesValue.value)
+  }
+
+  test("assetAsBoxVal") {
+    assertEquals(assetGroupSeries.getAsset: BoxValue, assetGroupSeries.value)
+  }
+
+  test("get quantity") {
+    assertEquals(value.value.quantity, quantity)
+    assertEquals(groupValue.value.quantity, quantity)
+    assertEquals(seriesValue.value.quantity, quantity)
+    assertEquals(assetGroupSeries.value.quantity, quantity)
+    intercept[Exception](BoxValue.Topl(Value.TOPL(mockNewQuantity)).quantity)
+  }
+
+  test("setQuantity") {
+    assertEquals(value.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
+    assertEquals(groupValue.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
+    assertEquals(seriesValue.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
+    assertEquals(assetGroupSeries.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
+    intercept[Exception](BoxValue.Topl(Value.TOPL(mockNewQuantity)).setQuantity(mockNewQuantity))
+  }
+
+  test("typeIdentifier") {
+    assertEquals(value.value.typeIdentifier, LvlType)
+    assertEquals(groupValue.value.typeIdentifier, GroupType(mockGroupPolicy.computeId))
+    assertEquals(seriesValue.value.typeIdentifier, SeriesType(mockSeriesPolicy.computeId))
+    assertEquals(
+      assetGroupSeries.value.typeIdentifier,
+      GroupAndSeriesFungible(mockGroupPolicy.computeId, mockSeriesPolicy.computeId)
+    )
+    assertEquals(assetGroup.value.typeIdentifier, GroupFungible(mockGroupPolicy.computeId))
+    assertEquals(assetSeries.value.typeIdentifier, SeriesFungible(mockSeriesPolicy.computeId))
+    intercept[Exception](BoxValue.Topl(Value.TOPL(mockNewQuantity)).typeIdentifier)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/Int128SyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/Int128SyntaxSpec.scala
@@ -1,0 +1,24 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.MockHelpers
+import com.google.protobuf.ByteString
+import quivr.models.Int128
+
+class Int128SyntaxSpec extends munit.FunSuite with MockHelpers {
+
+  val mockLong: Long = 100
+  val mockBigInt: BigInt = BigInt(mockLong)
+  val mockInt128: Int128 = Int128(ByteString.copyFrom(mockBigInt.toByteArray))
+
+  test("int128AsBigInt") {
+    assertEquals(mockInt128: BigInt, mockBigInt)
+  }
+
+  test("bigIntAsInt128") {
+    assertEquals(mockBigInt: Int128, mockInt128)
+  }
+
+  test("longAsInt128") {
+    assertEquals(mockLong: Int128, mockInt128)
+  }
+}


### PR DESCRIPTION
## Purpose

Added Box.Value and Int128 syntax ops to reduce the level of verbosity 

## Approach

Added Box.Value (Value.Value.types -> Value, Value -> quantity, Value -> ValueTypeIdentifier) and Int128 (BigInt <-> Int128, long -> Int128) syntax ops

## Testing

TBD

## Tickets
* Added as part of TSDK-578 work