### PR TITLE
Quick Fix: Preserve Transaction fields in Credentialler

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/CredentiallerInterpreter.scala
@@ -33,7 +33,7 @@ object CredentiallerInterpreter {
       unprovenTx.inputs
         .map(proveInput(_, signable))
         .sequence
-        .map(IoTransaction.defaultInstance.withInputs(_).withOutputs(unprovenTx.outputs).withDatum(unprovenTx.datum))
+        .map(unprovenTx.withInputs)
     }
 
     override def validate(tx: IoTransaction, ctx: Context[F]): F[List[ValidationError]] = for {


### PR DESCRIPTION
## Purpose

Signature validation was failing due to the transaction signature changing after using the Credentialler to prove a transaction. The cause was that we were stripping all other fields (other than inputs, outputs, and datum) on the transaction. This was not caught before since we previously did not have any other fields on a transaction. The issue arose since we are now introducing Policies and Statements into the Tx.

## Approach

Instead of recreating the Proven Transaction using IoTransaction.defaultinstance (and populating some fields), we copy the unproven transaction and only override the inputs.

## Testing

- Ensured existing tests pass
- Added a new test case to check preserving fields

## Tickets
* N/a