### PR TITLE
BN-1229 groupEqualFundsValidation

### DIFF
--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -357,20 +357,32 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1)
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1)
+      )
     )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -417,15 +429,25 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List.empty
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List.empty)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -478,21 +500,33 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1) // check here.
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1) // check here.
+      )
     )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -545,21 +579,32 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2) // check here.
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(2) // check here.
+      )
     )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -624,22 +669,34 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2) // check here.
+    val value_3_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(2) // check here.
+      )
     )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val output_2: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_2_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -705,22 +762,33 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2) // check here.
+    val value_3_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(2) // check here.
+      )
     )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val output_2: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_2_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -103,7 +103,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
       )
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
 
   }
 
@@ -149,15 +149,16 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
       )
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
 
   }
 
   /**
    * Case 2 validations that are failing;
-   * reference in policy contains (2) LVLs, but the constructor token quantity  == 1
+   * reference in policy contains (2) LVLs, the constructor token quantity == 10000000
+   * there is no constraint about the amount of constructor token quantity == 10000000 and LVL quantity
    */
-  test("Invalid data-input case 4, minting a Group constructor Token") {
+  test("Valid data-input case 4, minting a Group constructor Token") {
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
 
     // TODO discuss: is this correct or not, when we mint a Group the quantity should be igual to LVL input spent
@@ -172,7 +173,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
       Value.defaultInstance.withGroup(
         Value.Group(
           groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
+          quantity = BigInt(10000000)
         )
       )
 
@@ -196,9 +197,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
         )
       )
     )
-    assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
-
+    assertEquals(assertError, false)
   }
 
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -103,7 +103,7 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
       )
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -117,6 +117,54 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
       Value.defaultInstance.withLvl(
         Value.LVL(
           quantity = BigInt(0)
+        )
+      )
+
+    val value_1_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+
+    val testTx = txFull.copy(
+      inputs = List(input_1),
+      outputs = List(output_1),
+      groupPolicies = List(Datum.GroupPolicy(groupPolicy))
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+
+  }
+
+  /**
+   * Case 2 validations that are failing;
+   * reference in policy contains (2) LVLs, but the constructor token quantity  == 1
+   */
+  test("Invalid data-input case 4, minting a Group constructor Token") {
+    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+
+    // TODO discuss: is this correct or not, when we mint a Group the quantity should be igual to LVL input spent
+    val value_1_in: Value =
+      Value.defaultInstance.withLvl(
+        Value.LVL(
+          quantity = BigInt(2)
         )
       )
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -50,24 +50,35 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
           quantity = BigInt(1)
         )
       )
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
 
     // Note: duplicate sto address
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_1, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_1, attFull, value_2_in)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
 
     // Note: duplicate minting statements
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_1,
-      quantity = BigInt(1)
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_1,
+        quantity = BigInt(1)
+      )
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
-    )
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -115,22 +126,33 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
 
     // Note: duplicate minting statements
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_1,
-      quantity = BigInt(1)
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_1,
+        quantity = BigInt(1)
+      )
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
-    )
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -178,9 +200,23 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
 
     // Note: duplicate minting statements, but in two statements mintingStatement_1 and mintingStatement_2
     val mintingStatement_1 = AssetMintingStatement(
@@ -195,11 +231,9 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       quantity = BigInt(1)
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1, mintingStatement_2)
-    )
+    val mintingStatements = List(mintingStatement_1, mintingStatement_2)
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap


### PR DESCRIPTION
## Purpose

Well-formedness

-  A. For each Group: input group + minted group == total ouputs group
-  validate that groups are never burned
 
https://topl.atlassian.net/wiki/spaces/LABS/pages/678658061/Validation+TAMv2+Transactions+-+Meeting+Fernando+Edmundo+2023-09-08

## Approach

## Testing
preparePr

## Tickets
*BN-1229
