### PR TITLE
BN-1230 series transfer validation

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.Datum.GroupPolicy
-import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.{SeriesId, TransactionOutputAddress}
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.syntax._
@@ -41,6 +41,7 @@ object TransactionSyntaxInterpreter {
       dataLengthValidation,
       assetEqualFundsValidation,
       groupEqualFundsValidation,
+      seriesEqualFundsValidation,
       assetNoRepeatedUtxosValidation,
       mintingValidation
     )
@@ -334,6 +335,48 @@ object TransactionSyntaxInterpreter {
           groupsOut.filter(_.groupId == gId).map(_.quantity: BigInt).sum
       } else {
         groupsOut.filter(_.groupId == gId).map(_.quantity: BigInt).sum > 0
+      }
+    }
+
+    Validated.condNec(
+      res,
+      (),
+      TransactionSyntaxError.InsufficientInputFunds(
+        transaction.inputs.map(_.value.value).toList,
+        transaction.outputs.map(_.value.value).toList
+      )
+    )
+
+  }
+
+  /**
+   * SeriesEqualFundsValidation
+   *  - Check Moving Series Tokens: Let s be a series identifier, then the number of Series Constructor Tokens with group identifier s
+   * in the input is equal to the number of the number of Series Constructor Tokens with identifier s in the output.
+   *  - Check Minting Constructor Tokens: Let s be a series identifier and p the series policy whose digest is equal to s, all of the following statements are true:
+   *    The policy p is attached to the transaction.
+   *    The number of series constructor tokens with identifiers in the output of the transaction is strictly bigger than 0.
+   *    The registration UTXO referenced in p is present in the inputs and contains LVLs.
+   *
+   * @param transaction
+   * @return
+   */
+  private def seriesEqualFundsValidation(transaction: IoTransaction): ValidatedNec[TransactionSyntaxError, Unit] = {
+
+    val seriesIn = transaction.inputs.filter(_.value.value.isSeries).map(_.value.getSeries)
+    val seriesOut = transaction.outputs.filter(_.value.value.isSeries).map(_.value.getSeries)
+
+    val sIds =
+      seriesIn.groupBy(_.seriesId).keySet ++
+      seriesOut.groupBy(_.seriesId).keySet ++
+      transaction.seriesPolicies.map(_.event.computeId).toSet
+
+    val res = sIds.forall { sId =>
+      if (!transaction.seriesPolicies.map(_.event.computeId).contains(sId)) {
+        seriesIn.filter(_.seriesId == sId).map(_.quantity: BigInt).sum ==
+          seriesOut.filter(_.seriesId == sId).map(_.quantity: BigInt).sum
+      } else {
+        seriesOut.filter(_.seriesId == sId).map(_.quantity: BigInt).sum > 0
       }
     }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -188,11 +188,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      mintingStatements = Seq.empty
-    )
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), mintingStatements = Seq.empty)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -229,31 +225,19 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
     val value_2_in: Value =
       Value.defaultInstance.withAsset(
-        Value.Asset(
-          quantity = BigInt(1),
-          groupId = Some(groupPolicy.computeId),
-          fungibility = FungibilityType.GROUP
-        )
+        Value.Asset(quantity = BigInt(1), groupId = Some(groupPolicy.computeId), fungibility = FungibilityType.GROUP)
       )
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
-        Value.Asset(
-          groupId = Some(groupPolicy.computeId),
-          fungibility = FungibilityType.GROUP,
-          quantity = BigInt(1)
-        )
+        Value.Asset(groupId = Some(groupPolicy.computeId), fungibility = FungibilityType.GROUP, quantity = BigInt(1))
       )
 
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = Seq.empty
-    )
+    val testTx = txFull.copy(inputs = List(input_1, input_2), outputs = List(output_1), mintingStatements = Seq.empty)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -303,11 +287,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
     val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
 
-    val testTx = txFull.copy(
-      inputs = List(input_1),
-      outputs = List(output_1),
-      mintingStatements = List.empty
-    )
+    val testTx = txFull.copy(inputs = List(input_1), outputs = List(output_1), mintingStatements = List.empty)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -333,20 +313,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -358,12 +328,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val inputs = List(
       SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
@@ -371,16 +339,12 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     )
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
-    val mintingStatements = List(
-      AssetMintingStatement(
-        groupTokenUtxo = txoAddress_1,
-        seriesTokenUtxo = txoAddress_2,
-        quantity = BigInt(1)
-      )
-    )
+    val mintingStatements =
+      List(AssetMintingStatement(groupTokenUtxo = txoAddress_1, seriesTokenUtxo = txoAddress_2, quantity = BigInt(1)))
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
@@ -413,12 +377,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -430,12 +389,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val inputs = List(
       SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
@@ -444,7 +401,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List.empty)
@@ -476,20 +434,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -501,12 +449,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val mintingStatements = List(
       AssetMintingStatement(
@@ -523,7 +469,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
@@ -555,20 +502,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -580,12 +517,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val mintingStatements = List(
       AssetMintingStatement(
@@ -601,7 +536,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     )
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
@@ -624,7 +560,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
   }
 
   /**
-   * Reasons: This is expected to fail, but should works
+   * Reasons:
    * - input Assets = 0
    * - minted Assets = 2
    * - asset output = 2
@@ -677,6 +613,9 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
+    val value_4_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
     val mintingStatements = List(
       AssetMintingStatement(
         groupTokenUtxo = txoAddress_1,
@@ -693,7 +632,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
       UnspentTransactionOutput(trivialLockAddress, value_2_out),
-      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+      UnspentTransactionOutput(trivialLockAddress, value_3_out),
+      UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
@@ -716,11 +656,11 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
   }
 
   /**
-   * Reasons: This is expected to fail, but should works
+   * Reasons:
    * - input Assets = 0
    * - minted Assets = 2
    * - asset output = 2
-   * - but FungibilityType are not the same
+   * - Fungibility Type is not the same
    */
   test("Invalid data-input case, input + minted == output") {
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
@@ -747,8 +687,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         Value.Asset(
           groupId = Some(groupPolicy.computeId),
           seriesId = Some(seriesPolicy.computeId),
-          quantity = BigInt(1), // check here
-          fungibility = FungibilityType.GROUP
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP // check here
         )
       )
 
@@ -757,18 +697,16 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         Value.Asset(
           groupId = Some(groupPolicy.computeId),
           seriesId = Some(seriesPolicy.computeId),
-          quantity = BigInt(1), // check here
-          fungibility = FungibilityType.GROUP_AND_SERIES
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES // check here
         )
       )
 
     val value_3_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_4_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val mintingStatements = List(
       AssetMintingStatement(
@@ -785,7 +723,8 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
       UnspentTransactionOutput(trivialLockAddress, value_2_out),
-      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+      UnspentTransactionOutput(trivialLockAddress, value_3_out),
+      UnspentTransactionOutput(trivialLockAddress, value_4_out)
     )
 
     val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -161,7 +161,6 @@ class TransactionSyntaxInterpreterMintingCaseASpec extends munit.FunSuite with M
   test("Valid data-input case 4, minting a Group constructor Token") {
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
 
-    // TODO discuss: is this correct or not, when we mint a Group the quantity should be igual to LVL input spent
     val value_1_in: Value =
       Value.defaultInstance.withLvl(
         Value.LVL(

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -27,20 +27,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -51,12 +41,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
         )
       )
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     // Note: duplicate sto address
     val inputs = List(
@@ -66,7 +54,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
 
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     // Note: duplicate minting statements
@@ -102,20 +91,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -127,12 +106,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val inputs = List(
       SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
@@ -140,7 +117,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     )
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     // Note: duplicate minting statements
@@ -176,20 +154,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -201,12 +169,10 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       )
 
     val value_2_out: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val inputs = List(
       SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
@@ -215,7 +181,8 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
 
     val outputs = List(
       UnspentTransactionOutput(trivialLockAddress, value_1_out),
-      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
 
     // Note: duplicate minting statements, but in two statements mintingStatement_1 and mintingStatement_2

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
@@ -1,0 +1,139 @@
+package co.topl.brambl.validation
+
+import cats.Id
+import cats.implicits._
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.box.{AssetMintingStatement, Value}
+import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.models.{Event, TransactionOutputAddress}
+import co.topl.brambl.syntax._
+import scala.language.implicitConversions
+
+/**
+ * Test to coverage this specific syntax validation: Transfer series
+ *  - seriesEqualFundsValidation
+ */
+class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with MockHelpers {
+
+  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+
+  test("Valid data-input case, transfer a simple series ") {
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+
+    val value_1_in: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val value_1_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Valid data-input case 2, transfer a simple series ") {
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+
+    val value_1_in: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2)))
+
+    val value_1_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("InValid data-input case 2, transfer a simple series ") {
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)
+
+    val value_1_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(3))
+      ) // check quantity
+
+    val value_1_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+
+  }
+
+}


### PR DESCRIPTION
## Purpose

SeriesEqualFundsValidation
   *  - Check Moving Series Tokens: Let s be a series identifier, then the number of Series Constructor Tokens with group identifier s in the input is equal to the number of the number of Series Constructor Tokens with identifier s in the output.
   *  - Check Minting Constructor Tokens: Let s be a series identifier and p the series policy whose digest is equal to s, all of the following statements are true:
   *   -  The policy p is attached to the transaction.
   *   - The number of series constructor tokens with identifiers in the output of the transaction is strictly bigger than 0.
   *   -  The registration UTXO referenced in p is present in the inputs and contains LVLs.

## Testing
fix unit test

## Tickets
BN 1230
