### PR TITLE
TSDK-597 Support Immutable Assets in buildTransferAllTransaction

### DIFF
--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -186,11 +186,13 @@ trait MockHelpers {
 
   val assetGroup: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = GROUP))
 
+  val assetGroupImmutable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = IMMUTABLE))
   val assetGroupFractionable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = FRACTIONABLE))
   val assetGroupAccumulator: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = ACCUMULATOR))
 
   val assetSeries: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = SERIES))
 
+  val assetSeriesImmutable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = IMMUTABLE))
   val assetSeriesFractionable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE))
   val assetSeriesAccumulator: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR))
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
@@ -48,7 +48,22 @@ class AggregationOpsSpec extends TransactionBuilderInterpreterSpecBase {
         assetSeriesFractionable,
         assetSeriesFractionable.copy()
       ),
-      assetSeriesFractionableAlt.value.typeIdentifier -> Seq(assetSeriesFractionableAlt)
+      assetSeriesFractionableAlt.value.typeIdentifier -> Seq(assetSeriesFractionableAlt),
+      assetGroupSeriesImmutable.value.typeIdentifier -> Seq(
+        assetGroupSeriesImmutable,
+        assetGroupSeriesImmutable.copy()
+      ),
+      assetGroupSeriesImmutableAlt.value.typeIdentifier -> Seq(assetGroupSeriesImmutableAlt),
+      assetGroupImmutable.value.typeIdentifier -> Seq(
+        assetGroupImmutable,
+        assetGroupImmutable.copy()
+      ),
+      assetGroupImmutableAlt.value.typeIdentifier -> Seq(assetGroupImmutableAlt),
+      assetSeriesImmutable.value.typeIdentifier -> Seq(
+        assetSeriesImmutable,
+        assetSeriesImmutable.copy()
+      ),
+      assetSeriesImmutableAlt.value.typeIdentifier -> Seq(assetSeriesImmutableAlt)
     )
     assertEquals(testMap, expectedMap)
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
@@ -140,7 +140,16 @@ class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderI
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -196,7 +205,16 @@ class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderI
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -252,7 +270,16 @@ class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderI
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -280,7 +307,7 @@ class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderI
     assertEquals(testTx.toOption.get.computeId, expectedTx.computeId)
   }
 
-  test("buildTransferAmountTransaction > IMMUTABLE asset quantity descriptor in transfer type".fail) {
+  test("buildTransferAmountTransaction > IMMUTABLE asset quantity descriptor in transfer type") {
     val testTx = txBuilder.buildTransferAmountTransaction(
       assetGroupSeriesImmutable.value.typeIdentifier,
       mockTxos,

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -7,47 +7,33 @@ import co.topl.brambl.syntax.{
   int128AsBigInt,
   ioTransactionAsTransactionSyntaxOps,
   valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps
+  valueToTypeIdentifierSyntaxOps,
+  LvlType
 }
 
 class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
   test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      0,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withAmount(0)
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
 
   test("buildTransferAmountTransaction > a txo isnt tied to lockPredicateFrom") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos :+ valToTxo(lvlValue, trivialLockAddress),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(lvlValue, trivialLockAddress))
+      .run
     assertEquals(
       testTx,
       Left(UserInputErrors(Seq(UserInputError(s"every lock does not correspond to fromLockAddr"))))
@@ -55,15 +41,10 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
   }
 
   test("buildTransferAmountTransaction > non sufficient funds") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      4,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withAmount(4)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -75,15 +56,10 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
   }
 
   test("buildTransferAmountTransaction > fee not satisfied") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      3
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withFee(3)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -95,62 +71,22 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
   }
 
   test("buildTransferAmountTransaction > [complex] duplicate inputs are merged and split correctly") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      1
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(groupValue))
         ++
+        // change due to excess fee and transfer input
+        buildChangeUtxos(List(lvlValue, groupValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue,
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, groupValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -161,15 +97,11 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
 
   test("buildTransferAmountTransaction > [simplest case] no change, only 1 output") {
     val txos = Seq(valToTxo(groupValue))
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      groupValue.value.typeIdentifier,
-      txos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withTxos(txos)
+      .withFee(0)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos(txos))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -140,7 +140,16 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -7,47 +7,30 @@ import co.topl.brambl.syntax.{
   int128AsBigInt,
   ioTransactionAsTransactionSyntaxOps,
   valueToQuantitySyntaxOps,
+  valueToTypeIdentifierSyntaxOps,
   LvlType
 }
 
 class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
   test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos,
-      inPredicateLockFull,
-      0,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withAmount(0)
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
 
   test("buildTransferAmountTransaction > a txo isnt tied to lockPredicateFrom") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos :+ valToTxo(lvlValue, trivialLockAddress),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTxos(mockTxos :+ valToTxo(lvlValue, trivialLockAddress))
+      .run
     assertEquals(
       testTx,
       Left(UserInputErrors(Seq(UserInputError(s"every lock does not correspond to fromLockAddr"))))
@@ -55,15 +38,9 @@ class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderIn
   }
 
   test("buildTransferAmountTransaction > non sufficient funds") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos,
-      inPredicateLockFull,
-      4,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withAmount(4)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -78,15 +55,9 @@ class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderIn
   }
 
   test("buildTransferAmountTransaction > fee not satisfied") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      2
-    )
+    val testTx = buildTransferAmountTransaction
+      .withFee(2)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -98,62 +69,16 @@ class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderIn
   }
 
   test("buildTransferAmountTransaction > [complex] duplicate inputs are merged and split correctly") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      1
-    )
+    val testTx = buildTransferAmountTransaction.run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(lvlValue))
         ++
-        buildChangeUtxos(
-          List(
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
-        )
+        // change values unaffected by recipient transfer and fee
+        buildChangeUtxos(mockChange.filterNot(_.value.typeIdentifier == LvlType))
       )
     assertEquals(
       sortedTx(testTx.toOption.get).computeId,
@@ -163,15 +88,10 @@ class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderIn
 
   test("buildTransferAmountTransaction > [simplest case] no change, only 1 output") {
     val txos = Seq(valToTxo(lvlValue))
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      LvlType,
-      txos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTxos(txos)
+      .withFee(0)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos(txos))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -142,7 +142,16 @@ class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderIn
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
@@ -7,47 +7,33 @@ import co.topl.brambl.syntax.{
   int128AsBigInt,
   ioTransactionAsTransactionSyntaxOps,
   valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps
+  valueToTypeIdentifierSyntaxOps,
+  LvlType
 }
 
 class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
   test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      0,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withAmount(0)
+      .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"quantity to transfer must be positive")))))
   }
 
   test("buildTransferAmountTransaction > a txo isnt tied to lockPredicateFrom") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos :+ valToTxo(lvlValue, trivialLockAddress),
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(lvlValue, trivialLockAddress))
+      .run
     assertEquals(
       testTx,
       Left(UserInputErrors(Seq(UserInputError(s"every lock does not correspond to fromLockAddr"))))
@@ -55,15 +41,10 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
   }
 
   test("buildTransferAmountTransaction > non sufficient funds") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      4,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withAmount(4)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -75,15 +56,10 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
   }
 
   test("buildTransferAmountTransaction > fee not satisfied") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      3
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withFee(3)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -95,62 +71,22 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
   }
 
   test("buildTransferAmountTransaction > [complex] duplicate inputs are merged and split correctly") {
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      mockTxos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      1
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(seriesValue))
         ++
+        // change due to excess fee and transfer input
+        buildChangeUtxos(List(lvlValue, seriesValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue,
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, seriesValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -161,15 +97,11 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > [simplest case] no change, only 1 output") {
     val txos = Seq(valToTxo(seriesValue))
-    val testTx = txBuilder.buildTransferAmountTransaction(
-      seriesValue.value.typeIdentifier,
-      txos,
-      inPredicateLockFull,
-      1,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTxos(txos)
+      .withFee(0)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos(txos))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
@@ -140,7 +140,16 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -3,19 +3,25 @@ package co.topl.brambl.builders
 import cats.Id
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.MockHelpers
+import co.topl.brambl.builders.TransactionBuilderInterpreterSpecBase.{
+  BuildTransferAllTransaction,
+  BuildTransferAmountTransaction
+}
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances.valueImmutable
 import co.topl.brambl.models.Event.{GroupPolicy, SeriesPolicy}
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.{Lock, Value}
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models.LockAddress
-import co.topl.brambl.models.box.Value.Value.Asset
 import co.topl.brambl.syntax.{
   assetAsBoxVal,
   groupAsBoxVal,
   groupPolicyAsGroupPolicySyntaxOps,
   seriesAsBoxVal,
-  seriesPolicyAsSeriesPolicySyntaxOps
+  seriesPolicyAsSeriesPolicySyntaxOps,
+  valueToTypeIdentifierSyntaxOps,
+  LvlType,
+  ValueTypeIdentifier
 }
 import co.topl.genus.services.Txo
 import co.topl.genus.services.TxoState.UNSPENT
@@ -25,6 +31,12 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
 
   val RecipientAddr: LockAddress = inLockFullAddress
   val ChangeAddr: LockAddress = trivialLockAddress
+
+  def buildTransferAmountTransaction: BuildTransferAmountTransaction[Id] =
+    BuildTransferAmountTransaction(txBuilder, LvlType, mockTxos, inPredicateLockFull, 1, RecipientAddr, ChangeAddr, 1)
+
+  def buildTransferAllTransaction: BuildTransferAllTransaction[Id] =
+    BuildTransferAllTransaction(txBuilder, mockTxos, inPredicateLockFull, RecipientAddr, ChangeAddr, 1, None)
 
   def valToTxo(value: Value, lockAddr: LockAddress = inLockFullAddress): Txo =
     Txo(valToUtxo(value, lockAddr), UNSPENT, dummyTxoAddress)
@@ -122,4 +134,102 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
   )
 
   val mockTxos: Seq[Txo] = mockValues.map(valToTxo(_))
+
+  val mockChange: Seq[Value] = mockValues
+    .map(_.value)
+    .groupBy(_.typeIdentifier)
+    .view
+    .mapValues(DefaultAggregationOps.aggregate)
+    .values
+    .flatten
+    .toSeq
+    .map(Value.defaultInstance.withValue)
+
+}
+
+/**
+ * Helpers for the TransactionBuilder test cases
+ */
+object TransactionBuilderInterpreterSpecBase {
+
+  case class BuildTransferAllTransaction[F[_]](
+    txBuilder:         TransactionBuilderApi[F],
+    txos:              Seq[Txo],
+    lockPredicateFrom: Lock.Predicate,
+    recipientLockAddr: LockAddress,
+    changeLockAddr:    LockAddress,
+    fee:               Long,
+    tokenIdentifier:   Option[ValueTypeIdentifier]
+  ) {
+
+    def withTokenIdentifier(tokenIdentifier: ValueTypeIdentifier): BuildTransferAllTransaction[F] =
+      this.copy(tokenIdentifier = tokenIdentifier.some)
+
+    def noTokenIdentifier: BuildTransferAllTransaction[F] =
+      this.copy(tokenIdentifier = None)
+
+    def withTxos(txos: Seq[Txo]): BuildTransferAllTransaction[F] = this.copy(txos = txos)
+
+    def withFromPredicate(lockPredicateFrom: Lock.Predicate): BuildTransferAllTransaction[F] =
+      this.copy(lockPredicateFrom = lockPredicateFrom)
+
+    def withRecipientLockAddr(recipientLockAddr: LockAddress): BuildTransferAllTransaction[F] =
+      this.copy(recipientLockAddr = recipientLockAddr)
+
+    def withChangeLockAddr(changeLockAddr: LockAddress): BuildTransferAllTransaction[F] =
+      this.copy(changeLockAddr = changeLockAddr)
+
+    def withFee(fee: Long): BuildTransferAllTransaction[F] = this.copy(fee = fee)
+
+    def run: F[Either[BuilderError, IoTransaction]] =
+      txBuilder.buildTransferAllTransaction(
+        txos,
+        lockPredicateFrom,
+        recipientLockAddr,
+        changeLockAddr,
+        fee,
+        tokenIdentifier
+      )
+  }
+
+  case class BuildTransferAmountTransaction[F[_]](
+    txBuilder:         TransactionBuilderApi[F],
+    tokenIdentifier:   ValueTypeIdentifier,
+    txos:              Seq[Txo],
+    lockPredicateFrom: Lock.Predicate,
+    amount:            Long,
+    recipientLockAddr: LockAddress,
+    changeLockAddr:    LockAddress,
+    fee:               Long
+  ) {
+
+    def withTokenIdentifier(tokenIdentifier: ValueTypeIdentifier): BuildTransferAmountTransaction[F] =
+      this.copy(tokenIdentifier = tokenIdentifier)
+
+    def withTxos(txos: Seq[Txo]): BuildTransferAmountTransaction[F] = this.copy(txos = txos)
+
+    def withFromPredicate(lockPredicateFrom: Lock.Predicate): BuildTransferAmountTransaction[F] =
+      this.copy(lockPredicateFrom = lockPredicateFrom)
+
+    def withAmount(amount: Long): BuildTransferAmountTransaction[F] = this.copy(amount = amount)
+
+    def withRecipientLockAddr(recipientLockAddr: LockAddress): BuildTransferAmountTransaction[F] =
+      this.copy(recipientLockAddr = recipientLockAddr)
+
+    def withChangeLockAddr(changeLockAddr: LockAddress): BuildTransferAmountTransaction[F] =
+      this.copy(changeLockAddr = changeLockAddr)
+
+    def withFee(fee: Long): BuildTransferAmountTransaction[F] = this.copy(fee = fee)
+
+    def run: F[Either[BuilderError, IoTransaction]] = txBuilder
+      .buildTransferAmountTransaction(
+        tokenIdentifier,
+        txos,
+        lockPredicateFrom,
+        amount,
+        recipientLockAddr,
+        changeLockAddr,
+        fee
+      )
+  }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -70,6 +70,10 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
   val assetGroupFractionableAlt: Value = toAltAsset(assetGroupFractionable)
   val assetSeriesFractionableAlt: Value = toAltAsset(assetSeriesFractionable)
 
+  val assetGroupSeriesImmutableAlt: Value = toAltAsset(assetGroupSeriesImmutable)
+  val assetGroupImmutableAlt: Value = toAltAsset(assetGroupImmutable)
+  val assetSeriesImmutableAlt: Value = toAltAsset(assetSeriesImmutable)
+
   val mockValues: Seq[Value] = Seq(
     lvlValue,
     lvlValue.copy(), // exact duplicate
@@ -105,7 +109,16 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
     assetGroupFractionableAlt, // diff group and series
     assetSeriesFractionable,
     assetSeriesFractionable.copy(),
-    assetSeriesFractionableAlt // diff group and series
+    assetSeriesFractionableAlt, // diff group and series
+    assetGroupSeriesImmutable,
+    assetGroupSeriesImmutable.copy(),
+    assetGroupSeriesImmutableAlt, // diff group and series
+    assetGroupImmutable,
+    assetGroupImmutable.copy(),
+    assetGroupImmutableAlt, // diff group and series
+    assetSeriesImmutable,
+    assetSeriesImmutable.copy(),
+    assetSeriesImmutableAlt // diff group and series
   )
 
   val mockTxos: Seq[Txo] = mockValues.map(valToTxo(_))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
@@ -1081,6 +1081,207 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
     )
   }
 
+  test("buildTransferAllTransaction > Transfer all Assets (immutable, group and series fungible)") {
+    val testTx = txBuilder.buildTransferAllTransaction(
+      mockTxos,
+      inPredicateLockFull,
+      RecipientAddr,
+      ChangeAddr,
+      1,
+      assetGroupSeriesImmutable.value.typeIdentifier.some
+    )
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withInputs(buildStxos())
+      .withOutputs(
+        buildRecipientUtxos(
+          List(
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy() // Have not been aggregated together
+          )
+        )
+        ++
+        buildChangeUtxos(
+          List(
+            lvlValue,
+            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
+            groupValueAlt,
+            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
+            seriesValueAlt,
+            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
+            assetGroupSeriesAlt,
+            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
+            assetGroupAlt,
+            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
+            assetSeriesAlt,
+            assetGroupSeriesAccumulator,
+            assetGroupSeriesAccumulator.copy(),
+            assetGroupSeriesAccumulatorAlt,
+            assetGroupAccumulator,
+            assetGroupAccumulator.copy(),
+            assetGroupAccumulatorAlt,
+            assetSeriesAccumulator,
+            assetSeriesAccumulator.copy(),
+            assetSeriesAccumulatorAlt,
+            assetGroupSeriesFractionable,
+            assetGroupSeriesFractionable.copy(),
+            assetGroupSeriesFractionableAlt,
+            assetGroupFractionable,
+            assetGroupFractionable.copy(),
+            assetGroupFractionableAlt,
+            assetSeriesFractionable,
+            assetSeriesFractionable.copy(),
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
+          )
+        )
+      )
+    assertEquals(
+      sortedTx(testTx.toOption.get).computeId,
+      sortedTx(expectedTx).computeId
+    )
+  }
+
+  test("buildTransferAllTransaction > Transfer all Assets (immutable, group fungible)") {
+    val testTx = txBuilder.buildTransferAllTransaction(
+      mockTxos,
+      inPredicateLockFull,
+      RecipientAddr,
+      ChangeAddr,
+      1,
+      assetGroupImmutable.value.typeIdentifier.some
+    )
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withInputs(buildStxos())
+      .withOutputs(
+        buildRecipientUtxos(
+          List(
+            assetGroupImmutable,
+            assetGroupImmutable.copy() // Have not been aggregated together
+          )
+        )
+        ++
+        buildChangeUtxos(
+          List(
+            lvlValue,
+            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
+            groupValueAlt,
+            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
+            seriesValueAlt,
+            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
+            assetGroupSeriesAlt,
+            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
+            assetGroupAlt,
+            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
+            assetSeriesAlt,
+            assetGroupSeriesAccumulator,
+            assetGroupSeriesAccumulator.copy(),
+            assetGroupSeriesAccumulatorAlt,
+            assetGroupAccumulator,
+            assetGroupAccumulator.copy(),
+            assetGroupAccumulatorAlt,
+            assetSeriesAccumulator,
+            assetSeriesAccumulator.copy(),
+            assetSeriesAccumulatorAlt,
+            assetGroupSeriesFractionable,
+            assetGroupSeriesFractionable.copy(),
+            assetGroupSeriesFractionableAlt,
+            assetGroupFractionable,
+            assetGroupFractionable.copy(),
+            assetGroupFractionableAlt,
+            assetSeriesFractionable,
+            assetSeriesFractionable.copy(),
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
+          )
+        )
+      )
+    assertEquals(
+      sortedTx(testTx.toOption.get).computeId,
+      sortedTx(expectedTx).computeId
+    )
+  }
+
+  test("buildTransferAllTransaction > Transfer all Assets (immutable, series fungible)") {
+    val testTx = txBuilder.buildTransferAllTransaction(
+      mockTxos,
+      inPredicateLockFull,
+      RecipientAddr,
+      ChangeAddr,
+      1,
+      assetSeriesImmutable.value.typeIdentifier.some
+    )
+    val expectedTx = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withInputs(buildStxos())
+      .withOutputs(
+        buildRecipientUtxos(
+          List(
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy() // Have not been aggregated together
+          )
+        )
+        ++
+        buildChangeUtxos(
+          List(
+            lvlValue,
+            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
+            groupValueAlt,
+            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
+            seriesValueAlt,
+            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
+            assetGroupSeriesAlt,
+            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
+            assetGroupAlt,
+            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
+            assetSeriesAlt,
+            assetGroupSeriesAccumulator,
+            assetGroupSeriesAccumulator.copy(),
+            assetGroupSeriesAccumulatorAlt,
+            assetGroupAccumulator,
+            assetGroupAccumulator.copy(),
+            assetGroupAccumulatorAlt,
+            assetSeriesAccumulator,
+            assetSeriesAccumulator.copy(),
+            assetSeriesAccumulatorAlt,
+            assetGroupSeriesFractionable,
+            assetGroupSeriesFractionable.copy(),
+            assetGroupSeriesFractionableAlt,
+            assetGroupFractionable,
+            assetGroupFractionable.copy(),
+            assetGroupFractionableAlt,
+            assetSeriesFractionable,
+            assetSeriesFractionable.copy(),
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutableAlt
+          )
+        )
+      )
+    assertEquals(
+      sortedTx(testTx.toOption.get).computeId,
+      sortedTx(expectedTx).computeId
+    )
+  }
+
   test("buildTransferAllTransaction > Transfer ALL tokens") {
     val testTx = txBuilder.buildTransferAllTransaction(
       mockTxos,

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl.builders
 
-import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax.{
   bigIntAsInt128,
@@ -14,13 +13,9 @@ import co.topl.brambl.syntax.{
 class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInterpreterSpecBase {
 
   test("buildTransferAllTransaction > All locks don't match") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos :+ valToTxo(lvlValue, trivialLockAddress),
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1
-    )
+    val testTx = buildTransferAllTransaction
+      .withTxos(mockTxos :+ valToTxo(lvlValue, trivialLockAddress))
+      .run
     assertEquals(
       testTx,
       Left(
@@ -34,13 +29,10 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > empty TXOs, tokenIdentifier not provided") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      Seq.empty,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      0
-    )
+    val testTx = buildTransferAllTransaction
+      .withTxos(Seq.empty)
+      .withFee(0)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -54,14 +46,11 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > empty TXOs, tokenIdentifier is provided") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      Seq.empty,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      0,
-      LvlType.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTxos(Seq.empty)
+      .withTokenIdentifier(LvlType)
+      .withFee(0)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -75,14 +64,10 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > tokenIdentifier is provided but does not exist in TXOs") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      Seq(valToTxo(lvlValue)),
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      0,
-      groupValue.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTxos(Seq(valToTxo(lvlValue)))
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -96,13 +81,9 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > not enough LVLs to satisfy fee") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      3
-    )
+    val testTx = buildTransferAllTransaction
+      .withFee(3)
+      .run
     assertEquals(
       testTx,
       Left(
@@ -116,59 +97,15 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > exactly amount of LVLs to satisfy fee, tokenIdentifier not provided") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      2
-    )
+    val testTx = buildTransferAllTransaction
+      .withFee(2)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
-        buildRecipientUtxos(
-          // No more LVLs for recipient. All other tokens go to recipient
-          List(
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
-        )
+        // No more LVLs for recipient. All other tokens go to recipient
+        buildRecipientUtxos(mockChange.filterNot(_.value.typeIdentifier == LvlType))
       )
     assertEquals(
       sortedTx(testTx.toOption.get).computeId,
@@ -177,60 +114,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > exactly amount of LVLs to satisfy fee, tokenIdentifier is LVLs") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      2,
-      LvlType.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withFee(2)
+      .withTokenIdentifier(LvlType)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
         // No more LVLs for recipient. All other tokens go to change
-        buildChangeUtxos(
-          List(
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
-        )
+        buildChangeUtxos(mockChange.filterNot(_.value.typeIdentifier == LvlType))
       )
     assertEquals(
       sortedTx(testTx.toOption.get).computeId,
@@ -239,60 +132,20 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > exactly amount of LVLs to satisfy fee, tokenIdentifier is not LVLs") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      2,
-      groupValue.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withFee(2)
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // To recipient
         buildRecipientUtxos(List(groupValue.copy(groupValue.value.setQuantity(quantity * 2))))
         ++
         // No more LVLs for change
         buildChangeUtxos(
-          List(
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, groupValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -302,60 +155,22 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Group") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      groupValue.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(groupValue.copy(groupValue.value.setQuantity(quantity * 2))))
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, groupValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -365,60 +180,22 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Series") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      seriesValue.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(seriesValue.copy(seriesValue.value.setQuantity(quantity * 2))))
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, seriesValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -428,61 +205,18 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all LVLs") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      LvlType.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(LvlType)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(lvlValue))
         ++
-        buildChangeUtxos(
-          List(
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
-        )
+        // change values unaffected by recipient transfer and fee
+        buildChangeUtxos(mockChange.filterNot(_.value.typeIdentifier == LvlType))
       )
     assertEquals(
       sortedTx(testTx.toOption.get).computeId,
@@ -491,60 +225,22 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (liquid, group fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroup.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroup.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(assetGroup.copy(assetGroup.value.setQuantity(quantity * 2))))
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, assetGroup.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -554,60 +250,22 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (liquid, series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetSeries.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetSeries.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(assetSeries.copy(assetSeries.value.setQuantity(quantity * 2))))
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange.filterNot(v => List(LvlType, assetSeries.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -617,60 +275,23 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (liquid, group and series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupSeries.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(List(assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2))))
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetGroupSeries.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -680,18 +301,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (accumulator, group and series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupSeriesAccumulator.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupSeriesAccumulator.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupSeriesAccumulator,
@@ -699,44 +316,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
+          mockChange.filterNot(v =>
+            List(LvlType, assetGroupSeriesAccumulator.value.typeIdentifier).contains(v.value.typeIdentifier)
           )
         )
       )
@@ -747,18 +333,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (accumulator, group fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupAccumulator.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupAccumulator.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupAccumulator,
@@ -766,45 +348,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetGroupAccumulator.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -814,18 +364,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (accumulator, series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetSeriesAccumulator.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetSeriesAccumulator.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetSeriesAccumulator,
@@ -833,45 +379,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetSeriesAccumulator.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -881,18 +395,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (fractionable, group and series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupSeriesFractionable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupSeriesFractionable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupSeriesFractionable,
@@ -900,44 +410,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
+          mockChange.filterNot(v =>
+            List(LvlType, assetGroupSeriesFractionable.value.typeIdentifier).contains(v.value.typeIdentifier)
           )
         )
       )
@@ -948,18 +427,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (fractionable, group fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupFractionable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupFractionable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupFractionable,
@@ -967,45 +442,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetGroupFractionable.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -1015,18 +458,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (fractionable, series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetSeriesFractionable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetSeriesFractionable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetSeriesFractionable,
@@ -1034,44 +473,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
+          mockChange.filterNot(v =>
+            List(LvlType, assetSeriesFractionable.value.typeIdentifier).contains(v.value.typeIdentifier)
           )
         )
       )
@@ -1082,18 +490,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (immutable, group and series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupSeriesImmutable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupSeriesImmutable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupSeriesImmutable,
@@ -1101,44 +505,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
+          mockChange.filterNot(v =>
+            List(LvlType, assetGroupSeriesImmutable.value.typeIdentifier).contains(v.value.typeIdentifier)
           )
         )
       )
@@ -1149,18 +522,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (immutable, group fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetGroupImmutable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetGroupImmutable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetGroupImmutable,
@@ -1168,45 +537,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetGroupImmutable.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -1216,18 +553,14 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer all Assets (immutable, series fungible)") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1,
-      assetSeriesImmutable.value.typeIdentifier.some
-    )
+    val testTx = buildTransferAllTransaction
+      .withTokenIdentifier(assetSeriesImmutable.value.typeIdentifier)
+      .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
+        // to recipient
         buildRecipientUtxos(
           List(
             assetSeriesImmutable,
@@ -1235,45 +568,13 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
           )
         )
         ++
+        // change due to excess fee
+        buildChangeUtxos(List(lvlValue))
+        ++
+        // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutableAlt
-          )
+          mockChange
+            .filterNot(v => List(LvlType, assetSeriesImmutable.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -1283,59 +584,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
   }
 
   test("buildTransferAllTransaction > Transfer ALL tokens") {
-    val testTx = txBuilder.buildTransferAllTransaction(
-      mockTxos,
-      inPredicateLockFull,
-      RecipientAddr,
-      ChangeAddr,
-      1
-    )
+    val testTx = buildTransferAllTransaction.run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
-        buildRecipientUtxos(
-          List(
-            lvlValue,
-            groupValue.copy(groupValue.value.setQuantity(quantity * 2)),
-            groupValueAlt,
-            seriesValue.copy(seriesValue.value.setQuantity(quantity * 2)),
-            seriesValueAlt,
-            assetGroupSeries.copy(assetGroupSeries.value.setQuantity(quantity * 2)),
-            assetGroupSeriesAlt,
-            assetGroup.copy(assetGroup.value.setQuantity(quantity * 2)),
-            assetGroupAlt,
-            assetSeries.copy(assetSeries.value.setQuantity(quantity * 2)),
-            assetSeriesAlt,
-            assetGroupSeriesAccumulator,
-            assetGroupSeriesAccumulator.copy(),
-            assetGroupSeriesAccumulatorAlt,
-            assetGroupAccumulator,
-            assetGroupAccumulator.copy(),
-            assetGroupAccumulatorAlt,
-            assetSeriesAccumulator,
-            assetSeriesAccumulator.copy(),
-            assetSeriesAccumulatorAlt,
-            assetGroupSeriesFractionable,
-            assetGroupSeriesFractionable.copy(),
-            assetGroupSeriesFractionableAlt,
-            assetGroupFractionable,
-            assetGroupFractionable.copy(),
-            assetGroupFractionableAlt,
-            assetSeriesFractionable,
-            assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt,
-            assetGroupSeriesImmutable,
-            assetGroupSeriesImmutable.copy(),
-            assetGroupSeriesImmutableAlt,
-            assetGroupImmutable,
-            assetGroupImmutable.copy(),
-            assetGroupImmutableAlt,
-            assetSeriesImmutable,
-            assetSeriesImmutable.copy(),
-            assetSeriesImmutableAlt
-          )
-        )
+        // all (except fee) go to recipient
+        buildRecipientUtxos(mockChange.filterNot(_.value.typeIdentifier == LvlType))
+        ++
+        // lvl in excess of fee goes to recipient
+        buildRecipientUtxos(List(lvlValue))
       )
     assertEquals(
       sortedTx(testTx.toOption.get).computeId,

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
@@ -157,7 +157,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -210,7 +219,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -264,7 +282,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -318,7 +345,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -372,7 +408,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -426,7 +471,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -480,7 +534,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -534,7 +597,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -588,7 +660,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -646,7 +727,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -704,7 +794,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -762,7 +861,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -820,7 +928,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -878,7 +995,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -936,7 +1062,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionable,
             assetGroupFractionable.copy(),
             assetGroupFractionableAlt,
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )
@@ -988,7 +1123,16 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
             assetGroupFractionableAlt,
             assetSeriesFractionable,
             assetSeriesFractionable.copy(),
-            assetSeriesFractionableAlt
+            assetSeriesFractionableAlt,
+            assetGroupSeriesImmutable,
+            assetGroupSeriesImmutable.copy(),
+            assetGroupSeriesImmutableAlt,
+            assetGroupImmutable,
+            assetGroupImmutable.copy(),
+            assetGroupImmutableAlt,
+            assetSeriesImmutable,
+            assetSeriesImmutable.copy(),
+            assetSeriesImmutableAlt
           )
         )
       )


### PR DESCRIPTION
## Purpose

Ensure we support Fractionable Assets in `buildTransferAllTransaction`.

## Approach

Mirrors https://github.com/Topl/BramblSc/pull/124 but for Immutable assets.

Existing implementation already supports. This PR adds/updates tests to ensure this.

- update Mock Data to also include immutable assets (group and series, group only, and series only fungible)
- Updated existing tests to consider the new mock data
- added new tests for buildTransferAllTransaction when immutable assets are identified to transfer

## Testing

ensure all tests pass

## Tickets
* closes TSDK-598