### PR TITLE
Bn 1204 validations only for minting case 3 step 3 alternative 2 DO not merge

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -408,7 +408,10 @@ object TransactionSyntaxInterpreter {
       seriesIdOnMintedStatements(a).exists(s =>
         s.tokenSupply match {
           case Some(tokenSupplied) =>
-            (s.quantity: BigInt) * (tokenSupplied: BigInt) % (a.quantity: BigInt) == 0
+            // Is minted quantity a multiple of token supply?
+            (a.quantity: BigInt) % (tokenSupplied: BigInt) == 0 &&
+            // Is there enough series supply to mint asset quantity?
+            (s.quantity: BigInt) * (tokenSupplied: BigInt) >= (a.quantity: BigInt)
           case None => true
         }
       )

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -425,7 +425,18 @@ object TransactionSyntaxInterpreter {
                   .sum
 
               val burned = sIn - sOut
-              burned * tokenSupplied == (ams.quantity: BigInt)
+
+              // all asset minting statements quantity with the same series id
+              def quantity(s: Value.Series) = transaction.mintingStatements.map { ams =>
+                val filterSeries = transaction.inputs
+                  .filter(_.address == ams.seriesTokenUtxo)
+                  .filter(_.value.value.isSeries)
+                  .map(_.value.getSeries)
+                  .filter(_.seriesId == s.seriesId)
+                if (filterSeries.isEmpty) BigInt(0) else ams.quantity: BigInt
+              }
+
+              burned * tokenSupplied == quantity(s).sum
 
             case None => true
           }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -329,20 +329,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -353,20 +343,34 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(1)
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1))
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(1)
+      )
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -441,7 +445,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
   }
 
   /**
-   * Reasons: This is expected to fail, but should works
+   * Reasons: This is expected to fail
    * - input Assets = 0
    * - minted Assets = 1
    * - asset output = 2
@@ -503,7 +507,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -517,20 +521,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
     val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
 
     val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
 
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -541,21 +535,34 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
         )
       )
 
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2) // check here.
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1))
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1),
-      mintingStatements = List(mintingStatement_1)
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
     )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(2) // check here.
+      )
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -570,87 +577,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
-
-  }
-
-  /**
-   * Reasons: This is expected to fail, but should works
-   * - input Assets = 0
-   * - minted Assets = 2
-   * - asset output = 2
-   */
-  test("Valid data-input case, input + minted == output") {
-    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
-    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
-    val value_1_in: Value =
-      Value.defaultInstance.withGroup(
-        Value.Group(
-          groupId = groupPolicy.computeId,
-          quantity = BigInt(1)
-        )
-      )
-
-    val value_2_in: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1),
-          fungibility = FungibilityType.GROUP_AND_SERIES
-        )
-      )
-
-    val value_1_out: Value =
-      Value.defaultInstance.withAsset(
-        Value.Asset(
-          groupId = Some(groupPolicy.computeId),
-          seriesId = Some(seriesPolicy.computeId),
-          quantity = BigInt(1), // check here
-          fungibility = FungibilityType.GROUP_AND_SERIES
-        )
-      )
-
-    val value_2_out: Value =
-      Value.defaultInstance.withAsset(
-        Value.Asset(
-          groupId = Some(groupPolicy.computeId),
-          seriesId = Some(seriesPolicy.computeId),
-          quantity = BigInt(1), // check here
-          fungibility = FungibilityType.GROUP_AND_SERIES
-        )
-      )
-
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2) // check here.
-    )
-
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val output_2: UnspentTransactionOutput = UnspentTransactionOutput(trivialLockAddress, value_2_out)
-
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
-    )
-
-    val validator = TransactionSyntaxInterpreter.make[Id]()
-    val result = validator.validate(testTx).swap
-
-    val assertError = result.exists(
-      _.toList.contains(
-        TransactionSyntaxError.InsufficientInputFunds(
-          testTx.inputs.map(_.value.value).toList,
-          testTx.outputs.map(_.value.value).toList
-        )
-      )
-    )
-
-    assertEquals(assertError, false)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -731,7 +658,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import co.topl.brambl.MockHelpers
 import co.topl.brambl.models.box.{AssetMintingStatement, Value}
 import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.{Event, TransactionOutputAddress}
 import co.topl.brambl.syntax._
 import scala.language.implicitConversions
 
@@ -391,7 +391,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         )
       )
 
-    // Here we are not burning the series, we spend 1. Burned Series, this output is wrong
+    // TODO, Here we are not burning the series, we spend 1. Burned Series, this output is wrong
     val value_4_out: Value =
       Value.defaultInstance.withSeries(
         Value.Series(
@@ -440,7 +440,6 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = Some(10))
       )
 
-    // case 1 token supply Limited
     // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -506,7 +505,6 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = Some(10))
       )
 
-    // case 1 token supply Limited
     // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
     val value_1_out: Value =
       Value.defaultInstance.withAsset(
@@ -558,6 +556,72 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     assertEquals(assertError, true)
     // 2 InsufficientInputFunds validation rules are catch
     assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+
+  }
+
+  test("Invalid data-input case 3, minting a Asset Token Limited") {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(3))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2), tokenSupply = Some(3))
+      )
+
+    // possible value is 3, 6.
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(2) // Invalid Data
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(2)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
 
   }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -110,7 +110,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         )
       )
 
-    // Here we burning the series, keep comment to understand the test
+    // Here we burning the series, burned == 1 keep comment to understand the test
     // when we burn a series, means quantity =0, but this output is not produced
     //    val value_3_out: Value =
     //      Value.defaultInstance.withSeries(
@@ -187,22 +187,24 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     //        )
     //      )
 
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
-
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(20)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2),
-      mintingStatements = List(mintingStatement_1)
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(20)
+      )
     )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -346,10 +348,6 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  /**
-   * TODO I will keep test 5, but is wrong, because It should be handle in Transfer Series validation
-   * - here we burn the series, in the output there should be no instances of Series
-   */
   test("Valid data-input case 5, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
@@ -383,44 +381,25 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         )
       )
 
-    // TODO, Here we are not burning the series, we spend 1. Burned Series, this output is wrong
-    val value_3_out: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1),
-          tokenSupply = Some(10)
-        )
-      )
-
-    // TODO, Here we are not burning the series, we spend 1. Burned Series, this output is wrong
-    val value_4_out: Value =
-      Value.defaultInstance.withSeries(
-        Value.Series(
-          seriesId = seriesPolicy.computeId,
-          quantity = BigInt(1),
-          tokenSupply = Some(10)
-        )
-      )
-
-    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
-    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
-    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
-    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
-    val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
-    val output_4 = UnspentTransactionOutput(trivialLockAddress, value_4_out)
-
-    val mintingStatement_1 = AssetMintingStatement(
-      groupTokenUtxo = txoAddress_1,
-      seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(20)
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, value_1_in),
+      SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
     )
 
-    val testTx = txFull.copy(
-      inputs = List(input_1, input_2),
-      outputs = List(output_1, output_2, output_3, output_4),
-      mintingStatements = List(mintingStatement_1)
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
     )
+
+    val mintingStatements = List(
+      AssetMintingStatement(
+        groupTokenUtxo = txoAddress_1,
+        seriesTokenUtxo = txoAddress_2,
+        quantity = BigInt(20)
+      )
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
 
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
@@ -471,16 +450,6 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
         )
       )
 
-    // transfer asset with input value_3_in
-    val value_4_out: Value =
-      Value.defaultInstance.withAsset(
-        Value.Asset(
-          groupId = Some(groupPolicy_A.computeId),
-          seriesId = Some(seriesPolicy_A.computeId),
-          quantity = BigInt(1)
-        )
-      )
-
     // quantity should be equal value_1_in
     val value_2_out: Value =
       Value.defaultInstance.withGroup(
@@ -497,6 +466,16 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
           seriesId = seriesPolicy.computeId,
           quantity = BigInt(1),
           tokenSupply = Some(10)
+        )
+      )
+
+    // transfer asset with input value_3_in
+    val value_4_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy_A.computeId),
+          seriesId = Some(seriesPolicy_A.computeId),
+          quantity = BigInt(1)
         )
       )
 
@@ -591,7 +570,8 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
       )
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    // 2 InsufficientInputFunds validation rules are catch
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -657,8 +637,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     )
 
     assertEquals(assertError, true)
-    // 2 InsufficientInputFunds validation rules are catch
-    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
 
   }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -14,7 +14,6 @@ import scala.language.implicitConversions
  *  - Validations only for minting, After projection  (only if for all inputs and outputs isMint == true)
  *    Case 3: Series
  *  - asset minted correspond to token supply in series policy
- *  -  the number of series constructor tokens burned matches the number of assets minted (only applies for limited token supply)
  */
 class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with MockHelpers {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -637,7 +637,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -748,7 +748,9 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
     // series change
     val value_2_out: Value =
-      Value.defaultInstance.withSeries(Value.Series(seriesId = s1.computeId, quantity = BigInt(1)))
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = s1.computeId, quantity = BigInt(1), tokenSupply = Some(1))
+      )
 
     // minted asset
     val value_3_out: Value =
@@ -911,6 +913,204 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * A transaction with 2 minting statements that point to distinct UTXOs, but their series UTXOs have the same seriesId.
+   */
+  test("Valid data-input case 5, minting 2 Asset Token Limited, with 2 groups and 2 series") {
+    val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
+    val utxo1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+    val utxo2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+    val utxo3 = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
+    val utxo4 = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+
+    val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo1)
+    val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo2)
+
+    val sC = Event.SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
+
+    // inputs
+    val inValue1_GA: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gA.computeId, quantity = BigInt(1)))
+
+    val inValue2_GB: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gB.computeId, quantity = BigInt(1)))
+
+    val inValue3_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(3), tokenSupply = Some(5))
+      )
+
+    val inValue4_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(3), tokenSupply = Some(5))
+      )
+
+    // outputs
+    val outValue1_GA: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gA.computeId, quantity = BigInt(1)))
+
+    val outValue2_GB: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gB.computeId, quantity = BigInt(1)))
+
+    val outValue3_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(1), tokenSupply = Some(5))
+      )
+
+    val outValue4_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(2), tokenSupply = Some(5))
+      )
+
+    val outValue5_A1: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(groupId = Some(gA.computeId), seriesId = Some(sC.computeId), quantity = BigInt(10))
+      )
+
+    val outValue6_A2: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(groupId = Some(gB.computeId), seriesId = Some(sC.computeId), quantity = BigInt(5))
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(utxo1, attFull, inValue1_GA),
+      SpentTransactionOutput(utxo2, attFull, inValue2_GB),
+      SpentTransactionOutput(utxo3, attFull, inValue3_SC),
+      SpentTransactionOutput(utxo4, attFull, inValue4_SC)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, outValue1_GA),
+      UnspentTransactionOutput(trivialLockAddress, outValue2_GB),
+      UnspentTransactionOutput(trivialLockAddress, outValue3_SC),
+      UnspentTransactionOutput(trivialLockAddress, outValue4_SC),
+      UnspentTransactionOutput(trivialLockAddress, outValue5_A1),
+      UnspentTransactionOutput(trivialLockAddress, outValue6_A2)
+    )
+
+    val mintingStatements = List(
+      AssetMintingStatement(groupTokenUtxo = utxo1, seriesTokenUtxo = utxo3, quantity = BigInt(10)),
+      AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(5))
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+  }
+
+  /**
+   * A transaction with 2 minting statements that point to distinct UTXOs, but their series UTXOs have the same seriesId.
+   */
+  test("Invalid data-input case 5, minting 2 Asset Token Limited, with 2 groups and 2 series") {
+    val utxo = TransactionOutputAddress(0, 0, 0, dummyTxIdentifier)
+    val utxo1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+    val utxo2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+    val utxo3 = TransactionOutputAddress(3, 0, 0, dummyTxIdentifier)
+    val utxo4 = TransactionOutputAddress(4, 0, 0, dummyTxIdentifier)
+
+    val gA = Event.GroupPolicy(label = "policyGA", registrationUtxo = utxo)
+    val gB = Event.GroupPolicy(label = "policyGB", registrationUtxo = utxo)
+    val sC = Event.SeriesPolicy(label = "policyS1", registrationUtxo = utxo, tokenSupply = Some(5))
+
+    // inputs
+    val inValue1_GA: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gA.computeId, quantity = BigInt(1)))
+
+    val inValue2_GB: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gB.computeId, quantity = BigInt(1)))
+
+    val inValue3_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(3), tokenSupply = Some(5))
+      )
+
+    val inValue4_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(3), tokenSupply = Some(5))
+      )
+
+    // outputs
+    val outValue1_GA: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gA.computeId, quantity = BigInt(1)))
+
+    val outValue2_GB: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = gB.computeId, quantity = BigInt(1)))
+
+    // Invalid because quantity here should be 2
+    val outValue3_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(1), tokenSupply = Some(5))
+      )
+
+    // Invalid because quantity here should be 1
+    val outValue4_SC: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = sC.computeId, quantity = BigInt(2), tokenSupply = Some(5))
+      )
+
+    val outValue5_A1: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(groupId = Some(gA.computeId), seriesId = Some(sC.computeId), quantity = BigInt(5))
+      )
+
+    val outValue6_A2: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(groupId = Some(gB.computeId), seriesId = Some(sC.computeId), quantity = BigInt(10))
+      )
+
+    val inputs = List(
+      SpentTransactionOutput(utxo1, attFull, inValue1_GA),
+      SpentTransactionOutput(utxo2, attFull, inValue2_GB),
+      SpentTransactionOutput(utxo3, attFull, inValue3_SC),
+      SpentTransactionOutput(utxo4, attFull, inValue4_SC)
+    )
+
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, outValue1_GA),
+      UnspentTransactionOutput(trivialLockAddress, outValue2_GB),
+      UnspentTransactionOutput(trivialLockAddress, outValue3_SC),
+      UnspentTransactionOutput(trivialLockAddress, outValue4_SC),
+      UnspentTransactionOutput(trivialLockAddress, outValue5_A1),
+      UnspentTransactionOutput(trivialLockAddress, outValue6_A2)
+    )
+
+    val mintingStatements = List(
+      AssetMintingStatement(groupTokenUtxo = utxo1, seriesTokenUtxo = utxo3, quantity = BigInt(5)), // check here
+      AssetMintingStatement(groupTokenUtxo = utxo2, seriesTokenUtxo = utxo4, quantity = BigInt(10)) // check here
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = mintingStatements)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    // TODO discuss again with Edmundo why this case is invalid?
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
   }
 
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -76,7 +76,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Valid data-input case 1, minting a Asset Token Limited".only) {
+  test("Valid data-input case 1, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -143,7 +143,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Valid data-input case 2, minting a Asset Token Limited".only) {
+  test("Valid data-input case 2, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -210,7 +210,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Valid data-input case 3, minting a Asset Token Limited".only) {
+  test("Valid data-input case 3, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -278,7 +278,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Valid data-input case 4, minting a Asset Token Limited".only) {
+  test("Valid data-input case 4, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -349,7 +349,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
    * TODO I will keep test 5, but is wrong, because It should be handle in Transfer Series validation
    * - here we burn the series, in the output there should be no instances of Series
    */
-  test("Valid data-input case 5, minting a Asset Token Limited".only) {
+  test("Valid data-input case 5, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -428,7 +428,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Invalid data-input case 1, minting a Asset Token Limited".only) {
+  test("Invalid data-input case 1, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
@@ -494,7 +494,7 @@ class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with M
 
   }
 
-  test("Invalid data-input case 2, minting a Asset Token Limited".only) {
+  test("Invalid data-input case 2, minting a Asset Token Limited") {
     val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
     val seriesPolicy =
       Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -1,0 +1,565 @@
+package co.topl.brambl.validation
+
+import cats.Id
+import cats.implicits._
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.box.{AssetMintingStatement, Value}
+import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.syntax._
+import scala.language.implicitConversions
+
+/**
+ * Test to coverage this specific syntax validation:
+ *  - Validations only for minting, After projection  (only if for all inputs and outputs isMint == true)
+ *    Case 3: Series
+ *  - asset minted correspond to token supply in series policy
+ *  -  the number of series constructor tokens burned matches the number of assets minted (only applies for limited token supply)
+ */
+class TransactionSyntaxInterpreterMintingCaseCSpec extends munit.FunSuite with MockHelpers {
+
+  private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
+  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+
+  test("Valid data-input case 1, minting a Asset Token Unlimited") {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = None)
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = None)
+      )
+
+    // case 1 token supply Unlimited
+    // quantity could be any val 18, 1888, 999, and should be valid
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1)
+        )
+      )
+
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(1)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2, output_3),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Valid data-input case 1, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(10)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    // Here we burning the series, keep comment to understand the test
+    // when we burn a series, means quantity =0, but this output is not produced
+    //    val value_3_out: Value =
+    //      Value.defaultInstance.withSeries(
+    //        Value.Series(
+    //          seriesId = seriesPolicy.computeId,
+    //          quantity = BigInt(0) //  (assetQuantity(10) / tokenSupply(10)) - seriesQuantity(1) = 0
+    //        )
+    //      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(10)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Valid data-input case 2, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(20)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    // Here we burning the series, keep comment to understand the test
+    // when we burn a 1 series, means quantity =0, but this output is not produced
+    //    val value_3_out: Value =
+    //      Value.defaultInstance.withSeries(
+    //        Value.Series(
+    //          seriesId = seriesPolicy.computeId,
+    //          quantity = BigInt(0) //  (assetQuantity(10) / tokenSupply(10)) - seriesQuantity(1) = 0
+    //        )
+    //      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(20)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Valid data-input case 3, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(10)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    // Here we are not burning the series, we spend 1.
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          tokenSupply = Some(10)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(10)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2, output_3),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Valid data-input case 4, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(20)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    // Here we burning the series, keep comment to understand the test, we burn 2
+//    val value_3_out: Value =
+//      Value.defaultInstance.withSeries(
+//        Value.Series(
+//          seriesId = seriesPolicy.computeId,
+//          quantity = BigInt(0), // 2-2= 0
+//          tokenSupply = Some(10)
+//        )
+//      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(20)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  /**
+   * TODO I will keep test 5, but is wrong, because It should be handle in Transfer Series validation
+   * - here we burn the series, in the output there should be no instances of Series
+   */
+  test("Valid data-input case 5, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(2), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(20)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    // TODO, Here we are not burning the series, we spend 1. Burned Series, this output is wrong
+    val value_3_out: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          tokenSupply = Some(10)
+        )
+      )
+
+    // Here we are not burning the series, we spend 1. Burned Series, this output is wrong
+    val value_4_out: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          tokenSupply = Some(10)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    val output_3 = UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    val output_4 = UnspentTransactionOutput(trivialLockAddress, value_4_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(20)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2, output_3, output_4),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+
+  }
+
+  test("Invalid data-input case 1, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(10)
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(11) // Invalid data
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+
+  }
+
+  test("Invalid data-input case 2, minting a Asset Token Limited".only) {
+    val groupPolicy = Event.GroupPolicy(label = "policyG", registrationUtxo = txoAddress_1)
+    val seriesPolicy =
+      Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2, tokenSupply = Some(10))
+
+    val value_1_in: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val value_2_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1), tokenSupply = Some(10))
+      )
+
+    // case 1 token supply Limited
+    // only possible value is 10, 1*10.  if quantity is 2 = could be 10 or 20. 1*10, 2*10,
+    val value_1_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(11) // Invalid Data
+        )
+      )
+
+    // quantity should be equal value_1_in
+    val value_2_out: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val input_1 = SpentTransactionOutput(txoAddress_1, attFull, value_1_in)
+    val input_2 = SpentTransactionOutput(txoAddress_2, attFull, value_2_in)
+    val output_1 = UnspentTransactionOutput(trivialLockAddress, value_1_out)
+    val output_2 = UnspentTransactionOutput(trivialLockAddress, value_2_out)
+
+    val mintingStatement_1 = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(10)
+    )
+
+    val testTx = txFull.copy(
+      inputs = List(input_1, input_2),
+      outputs = List(output_1, output_2),
+      mintingStatements = List(mintingStatement_1)
+    )
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    // 2 InsufficientInputFunds validation rules are catch
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+
+  }
+
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -78,7 +78,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
       )
     )
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 3)
 
   }
 
@@ -143,7 +143,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 3)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
 
   }
 
@@ -219,7 +219,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
 
     assertEquals(assertError, true)
     assertEquals(assertError_2, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 3)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 4)
 
   }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -85,6 +85,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
   /**
    * In this case there 2 validations that are failing;
    * InsufficientInputFunds, because is not able to pass assetEqualFundsValidation
+   * InsufficientInputFunds, because is not able to pass mintingValidation
    * DuplicateInput because minting statements contains the same txoAddress
    */
   test("Invalid data-input case, input(0) + minted(1) == output(1), asset mining statements are duplicated") {
@@ -142,7 +143,7 @@ class TransactionSyntaxInterpreterRuleBSpec extends munit.FunSuite with MockHelp
     )
 
     assertEquals(assertError, true)
-    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 3)
 
   }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_4.puml
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_4.puml
@@ -1,0 +1,88 @@
+@startuml
+
+title
+    Valid data-input case 4
+    A transaction with 2 minting statements that point to distinct UTXOs, but their series UTXOs have the same seriesId.
+end title
+
+'Asset minting statements
+package AssetMintingStatements {
+    object ams_1
+        ams_1 : seriesUtxo = ABC
+        ams_1 : groupUtxo = XYZ
+        ams_1 : quantity = 1
+
+    object ams_2
+        ams_2 : seriesUtxo = DEF
+        ams_2 : groupUtxo = UVW
+        ams_2 : quantity = 1
+}
+
+package Inputs {
+    object utxo_ABC #pink
+        utxo_ABC : series = s1
+        utxo_ABC : quantity = 2
+        utxo_ABC : tokenSupply = 1
+
+    object utxo_DEF #pink
+        utxo_DEF : series = s1
+        utxo_DEF : quantity = 1
+        utxo_DEF : tokenSupply = 1
+
+    object utxo_XYZ #lightgreen
+        utxo_XYZ : group = g1
+        utxo_XYZ : quantity = 1
+
+    object utxo_UVW #lightgreen
+        utxo_UVW : group = g2
+        utxo_UVW : quantity = 1
+}
+
+package Outputs {
+    'minted asset
+    object output_1 #cyan
+        output_1 : asset = g1_s1
+        output_1 : quantity = 1
+
+    'series change
+    object output_2 #pink
+        output_2 : series = s1
+        output_2 : quantity = 1
+
+    'minted asset
+    object output_3 #cyan
+        output_3 : asset = g2_s1
+        output_3 : quantity = 1
+
+    'group change
+        object output_4 #lightgreen
+        output_4 : group = g1
+        output_4 : quantity = 1
+
+    'group change
+    object output_5 #lightgreen
+        output_5 : group = g2
+        output_5 : quantity = 1
+}
+
+'relationships
+utxo_ABC *-- output_1
+utxo_XYZ *-- output_1
+utxo_ABC *-- output_2
+utxo_DEF *-- output_3
+utxo_UVW *-- output_3
+utxo_XYZ *-- output_4
+utxo_UVW *-- output_5
+
+note bottom of output_1: 1 item was burned
+note bottom of output_3: Burned series
+
+legend
+ |= |= Type |
+ |<#lightgreen>     | Group |
+ |<#pink>           | Series |
+ |<#cyan>           | Asset  |
+
+ endlegend
+
+@enduml

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_4.puml
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_4.puml
@@ -8,13 +8,13 @@ end title
 'Asset minting statements
 package AssetMintingStatements {
     object ams_1
-        ams_1 : seriesUtxo = ABC
         ams_1 : groupUtxo = XYZ
+        ams_1 : seriesUtxo = ABC
         ams_1 : quantity = 1
 
     object ams_2
-        ams_2 : seriesUtxo = DEF
         ams_2 : groupUtxo = UVW
+        ams_2 : seriesUtxo = DEF
         ams_2 : quantity = 1
 }
 
@@ -48,6 +48,7 @@ package Outputs {
     object output_2 #pink
         output_2 : series = s1
         output_2 : quantity = 1
+        output_2 : tokenSupply = 1
 
     'minted asset
     object output_3 #cyan
@@ -66,6 +67,12 @@ package Outputs {
 }
 
 'relationships
+ams_1 *-- utxo_ABC
+ams_1 *-- utxo_XYZ
+
+ams_2 *-- utxo_DEF
+ams_2 *-- utxo_UVW
+
 utxo_ABC *-- output_1
 utxo_XYZ *-- output_1
 utxo_ABC *-- output_2
@@ -74,8 +81,8 @@ utxo_UVW *-- output_3
 utxo_XYZ *-- output_4
 utxo_UVW *-- output_5
 
-note bottom of output_1: 1 item was burned
-note bottom of output_3: Burned series
+note bottom of output_2: 1 series burned
+note bottom of utxo_DEF: Burned series
 
 legend
  |= |= Type |

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_5.puml
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/pumls/valid_case_5.puml
@@ -1,0 +1,106 @@
+@startuml
+
+title
+    Valid data-input case 5
+    A transaction with 2 minting statements that point to distinct UTXOs series,
+    and 2 distinct utxos groups
+    but their series UTXOs have the same seriesId.
+end title
+
+'Asset minting statements
+package AssetMintingStatements {
+    object ams_1
+        ams_1 : groupUtxo = utxo1
+        ams_1 : seriesUtxo = utxo3
+        ams_1 : quantity = 10
+
+    object ams_2
+        ams_2 : groupUtxo = utxo2
+        ams_2 : seriesUtxo = utxo4
+        ams_2 : quantity = 5
+}
+
+package Inputs {
+    object utxo_1 #lightgreen
+        utxo_1 : group = gA
+        utxo_1 : quantity = 1
+
+    object utxo_2 #lightgreen
+        utxo_2 : group = gB
+        utxo_2 : quantity = 1
+
+    object utxo_3 #pink
+        utxo_3 : series = sC
+        utxo_3 : quantity = 3
+        utxo_3 : tokenSupply = 5
+
+    object utxo_4 #pink
+        utxo_4 : series = sC
+        utxo_4 : quantity = 3
+        utxo_4 : tokenSupply = 5
+}
+
+package Outputs {
+
+    object output_1 #lightgreen
+        output_1 : group = gA
+        output_1 : quantity = 1
+
+    object output_2 #lightgreen
+        output_2 : group = gB
+        output_2 : quantity = 1
+
+    object output_3 #pink
+        output_3 : series = sC
+        output_3 : quantity = 1
+        output_3 : tokenSupply = 5
+
+
+    object output_4 #pink
+        output_4 : series = sC
+        output_4 : quantity = 2
+        output_4 : tokenSupply = 5
+
+    object output_5 #cyan
+        output_5 : asset = gA_sC
+        output_5 : quantity = 10
+
+    object output_6 #cyan
+        output_6 : asset = gB_sC
+        output_6 : quantity = 5
+
+}
+
+'relationships
+
+ams_1 *-- utxo_1
+ams_1 *-- utxo_3
+
+ams_2 *-- utxo_2
+ams_2 *-- utxo_4
+
+
+utxo_1 *-- output_1
+utxo_2 *-- output_2
+
+utxo_3 *-- output_3
+utxo_4 *-- output_4
+
+utxo_3 *-- output_5
+utxo_1 *-- output_5
+
+utxo_4 *-- output_6
+utxo_2 *-- output_6
+
+note bottom of output_4: 1 series was burned
+note bottom of output_3: 2 series was burned
+
+legend
+ |= |= Type |
+ |<#lightgreen>     | Group |
+ |<#pink>           | Series |
+ |<#cyan>           | Asset  |
+
+ endlegend
+
+@enduml


### PR DESCRIPTION
## Purpose

Pr to discuss alternative 2 of asset minting validation:
Specific discussion:
- TransactionSyntaxInterpreterMintingCaseCSpec
- test("Invalid data-input case 5, minting 2 Asset Token Limited, with 2 groups and 2 series") 

![image](https://github.com/Topl/BramblSc/assets/8540107/1250876b-9dd2-4c57-b1a9-88cbd7a835e5)


Note: this Pr replaces : https://github.com/Topl/BramblSc/pull/116


## Tickets
*
