### PR TITLE
BN-1252-update-proposal-validation-step-2

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsImmutable.scala
@@ -5,7 +5,6 @@ import co.topl.brambl.models.box.{Attestation, Box, Challenge, FungibilityType, 
 import co.topl.brambl.models.common.ImmutableBytes
 import co.topl.brambl.models.transaction._
 import co.topl.consensus.models._
-import co.topl.node.models.Ratio
 import co.topl.quivr.Tokens
 import com.google.protobuf.ByteString
 import com.google.protobuf.duration.Duration

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/UpdateProposalSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/UpdateProposalSyntax.scala
@@ -1,0 +1,26 @@
+package co.topl.brambl.syntax
+
+import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
+import co.topl.brambl.common.ContainsImmutable.instances.updateProposalImmutable
+import co.topl.brambl.models.UpdateProposalId
+import co.topl.brambl.models.box.Value.UpdateProposal
+import com.google.protobuf.ByteString
+import java.security.MessageDigest
+import scala.language.implicitConversions
+
+trait UpdateProposalSyntax {
+
+  implicit def updateProposalAsUpdateProposalSyntaxOps(
+    updateProposal: UpdateProposal
+  ): UpdateProposalAsUpdateProposalSyntaxOps =
+    new UpdateProposalAsUpdateProposalSyntaxOps(updateProposal)
+}
+
+class UpdateProposalAsUpdateProposalSyntaxOps(val updateProposal: UpdateProposal) extends AnyVal {
+
+  def computeId: UpdateProposalId = {
+    val digest: Array[Byte] = updateProposal.immutable.value.toByteArray
+    val sha256 = MessageDigest.getInstance("SHA-256").digest(digest)
+    UpdateProposalId(ByteString.copyFrom(sha256))
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/package.scala
@@ -8,4 +8,5 @@ package object syntax
     with SeriesPolicySyntax
     with BoxValueSyntax
     with TokenTypeIdentifierSyntax
-    with Int128Syntax {}
+    with Int128Syntax
+    with UpdateProposalSyntax {}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
@@ -3,10 +3,12 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.{UpdateProposalMintingStatement, Value}
 import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
 import co.topl.brambl.syntax._
+import co.topl.consensus.models.{SignatureKesProduct, SignatureKesSum, StakingAddress, StakingRegistration}
+import com.google.protobuf.ByteString
 import scala.language.implicitConversions
 
 /**
@@ -18,7 +20,27 @@ class TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec extends munit.Fu
 
   private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
 
-  test("Valid data-input case 1, minting a proposal updated Token") {
+  // models generators defined on Node. We can not use them on brambl
+  val signature = SignatureKesProduct(
+    superSignature = SignatureKesSum(
+      ByteString.copyFrom(Array.fill(32)(0: Byte)),
+      ByteString.copyFrom(Array.fill(64)(0: Byte)),
+      Seq.empty
+    ),
+    subSignature = SignatureKesSum(
+      ByteString.copyFrom(Array.fill(32)(0: Byte)),
+      ByteString.copyFrom(Array.fill(64)(0: Byte)),
+      Seq.empty
+    ),
+    subRoot = ByteString.copyFrom(Array.fill(32)(0: Byte))
+  )
+
+  /**
+   * There is no proposal update statements
+   * None registration
+   */
+  test("Invalid data-input case 1, minting a proposal updated Token") {
+    // registration is None
     val value_1_in: Value =
       Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = None))
 
@@ -27,7 +49,6 @@ class TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec extends munit.Fu
         Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
       )
 
-    // do define if a topl should be burned or not when minting UpdateProposal
     val value_2_out: Value =
       Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = None))
 
@@ -42,12 +63,21 @@ class TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec extends munit.Fu
     val validator = TransactionSyntaxInterpreter.make[Id]()
     val result = validator.validate(testTx).swap
 
-    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+    val assertError = result.exists(
+      _.toList.contains(TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal)))
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
   }
 
+  /**
+   * There is no proposal update statements
+   * None registration
+   * quantity = 0
+   */
   test("Invalid data-input case 2, minting a proposal updated Token") {
     val value_1_in: Value =
-      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = None))
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(0), registration = None))
 
     val value_1_out: Value =
       Value.defaultInstance.withUpdateProposal(
@@ -67,6 +97,305 @@ class TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec extends munit.Fu
     )
     assertEquals(assertError, true)
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * There is no proposal update statements
+   */
+  test("Invalid data-input case 3, minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in: Value =
+      Value.defaultInstance.withTopl(
+        Value.TOPL(
+          quantity = BigInt(1),
+          registration = Some(stakingRegistration)
+        )
+      )
+
+    val value_1_out = Value.defaultInstance.withUpdateProposal(
+      Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+    )
+
+    // do define if a topl should be burned or not when minting UpdateProposal
+    val value_2_out = Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = None))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal)))
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * Output does not contains the Topl, registration is none
+   */
+  test("Invalid data-input case 4, minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    // do define if a topl should be burned or not when minting UpdateProposal
+    val value_2_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = None))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val stms = List(UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1))
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal)))
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * UpdateProposalMintingStatement repeated
+   */
+  test("Invalid data-input case 5 minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    // do define if a topl should be burned or not when minting UpdateProposal
+    val value_2_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val stms = List(
+      UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1),
+      UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal)))
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * Output updateProposal are duplicated
+   */
+  test("Invalid data-input case 6 minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+    val value_2_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    val value_3_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    )
+
+    val stms = List(
+      UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal, value_2_out.getUpdateProposal))
+      )
+    )
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+  }
+
+  /**
+   * Output Topl are duplicated, 1 != 2, here 2 rules are being catch
+   */
+  test("Invalid data-input case 7 minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    val value_2_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val value_3_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    )
+
+    val stms = List(
+      UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          List(value_1_in.value),
+          List(value_2_out.value, value_3_out.value)
+        )
+      )
+    )
+
+    val assertError_2 = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal))
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(assertError_2, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 2)
+  }
+
+  /**
+   * Output Topl are duplicated
+   */
+  test("Valid data-input case minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(2), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    val value_2_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val value_3_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out),
+      UnspentTransactionOutput(trivialLockAddress, value_3_out)
+    )
+
+    val stms = List(
+      UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          List(value_1_in.value),
+          List(value_2_out.value, value_3_out.value)
+        )
+      )
+    )
+
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
+  }
+
+  test("Valid data-input case minting a proposal updated Token") {
+
+    val address = StakingAddress(ByteString.copyFrom(Array.fill(32)(0: Byte)))
+    val stakingRegistration = StakingRegistration(address, signature)
+    val value_1_in =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val updateProposal = Value.UpdateProposal(label = "Proposal update 1", vrfPrecision = Some(1))
+    val value_1_out = Value.defaultInstance.withUpdateProposal(updateProposal)
+
+    // do define if a topl should be burned or not when minting UpdateProposal
+    val value_2_out =
+      Value.defaultInstance.withTopl(Value.TOPL(quantity = BigInt(1), registration = Some(stakingRegistration)))
+
+    val inputs = List(SpentTransactionOutput(txoAddress_1, attFull, value_1_in))
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, value_1_out),
+      UnspentTransactionOutput(trivialLockAddress, value_2_out)
+    )
+
+    val stms = List(UpdateProposalMintingStatement(updateProposal.computeId, txoAddress_1))
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, updateProposalMintingStatements = stms)
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(TransactionSyntaxError.InvalidUpdateProposal(Seq(value_1_out.getUpdateProposal)))
+    )
+    assertEquals(assertError, false)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 0)
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val catsCoreVersion = "2.10.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "2.0.0-alpha5"
+    val protobufSpecsVersion = "2.0.0-alpha5+5-893f7023-SNAPSHOT" // TODO :branch: BN-1252-update-proposal-validation-step-2
     val mUnitTeVersion = "0.7.29"
   }
 


### PR DESCRIPTION
## Purpose
-  Mint an update proposal using the same utxo is not allowed
-  Each statement should reference a valid input TOPL, and it is not burned
- Transfer update proposal is not allowed, if exists an output should come from a minting statements

## Approach
- new UpdateProposalMintingStatement which will reference the topl utxo

## Testing
- 8 new cases on TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec

## Tickets
* BN-1252