### PR TITLE
TSDK-612 Simplify ValueTypeIdentifier

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["*"]
+    branches: [main]
 
 
 jobs:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: ["*"]
 
 
 jobs:

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
@@ -2,7 +2,7 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.QuantityDescriptorType.LIQUID
 import co.topl.brambl.models.box.Value._
-import co.topl.brambl.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantityDescriptorSyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
@@ -53,7 +53,7 @@ object DefaultAggregationOps extends AggregationOps {
    */
   private def handleAggregation(value: Value, other: Value): Value =
     if (value.typeIdentifier == other.typeIdentifier)
-      if (value.typeIdentifier.getQuantityDescriptor.forall(_ == LIQUID))
+      if (value.getQuantityDescriptor.forall(_ == LIQUID))
         value.setQuantity(value.quantity + other.quantity)
       else throw new Exception("Aggregation of IMMUTABLE, FRACTIONABLE, or ACCUMULATOR assets is not allowed")
     else throw new Exception("Aggregation of different types is not allowed")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
@@ -2,7 +2,13 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.QuantityDescriptorType.LIQUID
 import co.topl.brambl.models.box.Value._
-import co.topl.brambl.syntax.{bigIntAsInt128, int128AsBigInt, valueToQuantityDescriptorSyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{
+  bigIntAsInt128,
+  int128AsBigInt,
+  valueToQuantityDescriptorSyntaxOps,
+  valueToQuantitySyntaxOps,
+  valueToTypeIdentifierSyntaxOps
+}
 
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -204,7 +204,8 @@ trait TransactionBuilderApi[F[_]] {
    *       in TSDK-610 depending if these values can be aggregated and deaggregated by default. Pending discussion.
    *
    * @param tokenIdentifier The Token Identifier denoting the type of token to transfer to the recipient. If this denotes
-   *                        an Asset Token, the quantity descriptor type must be LIQUID, else an error will be returned.
+   *                        an Asset Token, the referenced asset's quantity descriptor type must be LIQUID, else an error
+   *                        will be returned.
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
    *             necessary quantity (given by amount) of the identified Token and at least the quantity of LVLs to
    *             satisfy the fee, else an error will be returned.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -138,7 +138,7 @@ object UserInputValidations {
       UserInputError(s"Not enough LVLs in input to satisfy fee")
     )
 
-  def identifierQuantityDescriptorLiquidOrNone(
+  def distinctIdentifierQuantityDescriptorLiquid(
     values:   Seq[Value],
     testType: ValueTypeIdentifier
   ): ValidatedNec[UserInputError, Unit] = {
@@ -205,7 +205,7 @@ object UserInputValidations {
           "lockPredicateFrom"
         ),
         validTransferSupplyAmount(amount, allValues, transferIdentifier),
-        identifierQuantityDescriptorLiquidOrNone(allValues, transferIdentifier),
+        distinctIdentifierQuantityDescriptorLiquid(allValues, transferIdentifier),
         validFee(fee, allValues, if (transferIdentifier == LvlType) amount else 0)
       ).fold.toEither
     } match {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -6,7 +6,15 @@ import co.topl.brambl.models.box.{AssetMintingStatement, FungibilityType, Lock, 
 import co.topl.brambl.models.{LockAddress, SeriesId, TransactionOutputAddress}
 import co.topl.brambl.models.box.Value._
 import quivr.models.Int128
-import co.topl.brambl.syntax.{LvlType, ValueTypeIdentifier, int128AsBigInt, longAsInt128, valueToQuantityDescriptorSyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{
+  int128AsBigInt,
+  longAsInt128,
+  valueToQuantityDescriptorSyntaxOps,
+  valueToQuantitySyntaxOps,
+  valueToTypeIdentifierSyntaxOps,
+  LvlType,
+  ValueTypeIdentifier
+}
 import co.topl.genus.services.Txo
 
 import scala.util.{Failure, Success, Try}
@@ -130,10 +138,14 @@ object UserInputValidations {
       UserInputError(s"Not enough LVLs in input to satisfy fee")
     )
 
-  def identifierQuantityDescriptorLiquidOrNone(values: Seq[Value], testType: ValueTypeIdentifier): ValidatedNec[UserInputError, Unit] = {
+  def identifierQuantityDescriptorLiquidOrNone(
+    values:   Seq[Value],
+    testType: ValueTypeIdentifier
+  ): ValidatedNec[UserInputError, Unit] = {
     val transferQds = values.filter(_.typeIdentifier == testType).map(_.getQuantityDescriptor).distinct
-    if(transferQds.length > 1) {
-      UserInputError(s"All values identified by the ValueTypeIdentifier must have the same quantity descriptor").invalidNec[Unit]
+    if (transferQds.length > 1) {
+      UserInputError(s"All values identified by the ValueTypeIdentifier must have the same quantity descriptor")
+        .invalidNec[Unit]
     } else {
       val qd = transferQds.headOption.flatten
       Validated.condNec(

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
@@ -1,10 +1,7 @@
 package co.topl.brambl.syntax
 
-import co.topl.brambl.models.box.FungibilityType.{GROUP, GROUP_AND_SERIES, SERIES}
 import co.topl.brambl.models.box.QuantityDescriptorType
-import co.topl.brambl.models.{GroupId, SeriesId}
 import co.topl.brambl.models.box.Value._
-import com.google.protobuf.ByteString
 import quivr.models.Int128
 
 import scala.language.implicitConversions
@@ -16,6 +13,7 @@ trait BoxValueSyntax {
   implicit def assetAsBoxVal(a:  Asset): Value = Value.Asset(a)
 
   implicit def valueToQuantitySyntaxOps(v: Value): ValueToQuantitySyntaxOps = new ValueToQuantitySyntaxOps(v)
+  implicit def valueToQuantityDescriptorSyntaxOps(v: Value): ValueToQuantityDescriptorSyntaxOps = new ValueToQuantityDescriptorSyntaxOps(v)
 }
 
 class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
@@ -34,5 +32,11 @@ class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
     case Value.Series(s) => s.withQuantity(quantity)
     case Value.Asset(a)  => a.withQuantity(quantity)
     case _               => throw new Exception("Invalid value type")
+  }
+}
+class ValueToQuantityDescriptorSyntaxOps(val value: Value) extends AnyVal {
+  def getQuantityDescriptor: Option[QuantityDescriptorType] = value match {
+    case Value.Asset(a)  => Some(a.quantityDescriptor)
+    case _ => None
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
@@ -1,6 +1,6 @@
 package co.topl.brambl.syntax
 
-import co.topl.brambl.models.box.QuantityDescriptorType
+import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
 import co.topl.brambl.models.box.Value._
 import quivr.models.Int128
 
@@ -13,7 +13,10 @@ trait BoxValueSyntax {
   implicit def assetAsBoxVal(a:  Asset): Value = Value.Asset(a)
 
   implicit def valueToQuantitySyntaxOps(v: Value): ValueToQuantitySyntaxOps = new ValueToQuantitySyntaxOps(v)
-  implicit def valueToQuantityDescriptorSyntaxOps(v: Value): ValueToQuantityDescriptorSyntaxOps = new ValueToQuantityDescriptorSyntaxOps(v)
+
+  implicit def valueToQuantityDescriptorSyntaxOps(v: Value): ValueToQuantityDescriptorSyntaxOps =
+    new ValueToQuantityDescriptorSyntaxOps(v)
+  implicit def valueToFungibilitySyntaxOps(v: Value): ValueToFungibilitySyntaxOps = new ValueToFungibilitySyntaxOps(v)
 }
 
 class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
@@ -34,9 +37,19 @@ class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
     case _               => throw new Exception("Invalid value type")
   }
 }
+
 class ValueToQuantityDescriptorSyntaxOps(val value: Value) extends AnyVal {
+
   def getQuantityDescriptor: Option[QuantityDescriptorType] = value match {
-    case Value.Asset(a)  => Some(a.quantityDescriptor)
-    case _ => None
+    case Value.Asset(a) => Some(a.quantityDescriptor)
+    case _              => None
+  }
+}
+
+class ValueToFungibilitySyntaxOps(val value: Value) extends AnyVal {
+
+  def getFungibility: Option[FungibilityType] = value match {
+    case Value.Asset(a) => Some(a.fungibility)
+    case _              => None
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
@@ -22,7 +22,7 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
         // If seriesAlloy is provided, the seriesId is ignored. In this case, groupAlloy should not exist
         case (Some(gId), _, None, Some(sAlloy)) => AssetType(gId.value, sAlloy)
         // If groupAlloy is provided, the groupId is ignored. In this case, seriesAlloy should not exist
-        case (_, Some(sId), Some(gAlloy), None) => AssetType(sId.value, gAlloy)
+        case (_, Some(sId), Some(gAlloy), None) => AssetType(gAlloy, sId.value)
         // if neither groupAlloy or seriesAlloy is provided, the groupId and seriesId are used to identify instead
         case (Some(gId), Some(sId), None, None) => AssetType(gId.value, sId.value)
         // invalid cases

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString
 import scala.language.implicitConversions
 
 trait TokenTypeIdentifierSyntax {
+
   implicit def valueToTypeIdentifierSyntaxOps(v: Value): ValueToTypeIdentifierSyntaxOps =
     new ValueToTypeIdentifierSyntaxOps(v)
 }
@@ -27,9 +28,12 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
         case (Some(gId), Some(sId), None, None) => AssetType(gId.value, sId.value)
         // invalid cases
         case (_, _, Some(_), Some(_)) => throw new Exception("Both groupAlloy and seriesAlloy cannot exist in an asset")
-        case (_, _, None, None) => throw new Exception("Both groupId and seriesId must be provided for non-alloy assets")
-        case (_, None, Some(_), _) => throw new Exception("seriesId must be provided when groupAlloy is used in an asset")
-        case (None, _, _, Some(_)) => throw new Exception("groupId must be provided when seriesAlloy is used in an asset")
+        case (_, _, None, None) =>
+          throw new Exception("Both groupId and seriesId must be provided for non-alloy assets")
+        case (_, None, Some(_), _) =>
+          throw new Exception("seriesId must be provided when groupAlloy is used in an asset")
+        case (None, _, _, Some(_)) =>
+          throw new Exception("groupId must be provided when seriesAlloy is used in an asset")
       }
     case _ => throw new Exception("Invalid value type")
   }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
@@ -1,7 +1,5 @@
 package co.topl.brambl.syntax
 
-import co.topl.brambl.models.box.FungibilityType.{GROUP, GROUP_AND_SERIES, SERIES}
-import co.topl.brambl.models.box.QuantityDescriptorType
 import co.topl.brambl.models.{GroupId, SeriesId}
 import co.topl.brambl.models.box.Value._
 import com.google.protobuf.ByteString
@@ -9,15 +7,8 @@ import com.google.protobuf.ByteString
 import scala.language.implicitConversions
 
 trait TokenTypeIdentifierSyntax {
-
   implicit def valueToTypeIdentifierSyntaxOps(v: Value): ValueToTypeIdentifierSyntaxOps =
     new ValueToTypeIdentifierSyntaxOps(v)
-
-  implicit def typeIdentifierToQuantityDescriptorSyntaxOps(
-    t: ValueTypeIdentifier
-  ): TypeIdentifierToQuantityDescriptorSyntaxOps =
-    new TypeIdentifierToQuantityDescriptorSyntaxOps(t)
-
 }
 
 class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
@@ -27,29 +18,20 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
     case Value.Group(g)  => GroupType(g.groupId)
     case Value.Series(s) => SeriesType(s.seriesId)
     case Value.Asset(a) =>
-      (a.fungibility, a.quantityDescriptor, a.groupId, a.seriesId, a.groupAlloy, a.seriesAlloy) match {
-        case (GROUP_AND_SERIES, qd, Some(gId), Some(sId), _, _) => GroupAndSeriesFungible(gId, sId, qd)
-        // If seriesAlloy is provided, the seriesId is ignored
-        case (GROUP, qd, Some(gId), _, _, Some(sAlloy)) => GroupFungible(gId, sAlloy, qd)
-        // If groupAlloy is provided, the groupId is ignored
-        case (SERIES, qd, _, Some(sId), Some(gAlloy), _) => SeriesFungible(sId, gAlloy, qd)
-        // If seriesAlloy is not provided, the seriesId is used to identify instead
-        case (GROUP, qd, Some(gId), Some(sId), _, None) => GroupFungible(gId, sId.value, qd)
-        // If groupAlloy is not provided, the groupId is used to identify instead
-        case (SERIES, qd, Some(gId), Some(sId), None, _) => SeriesFungible(sId, gId.value, qd)
-        case _                                           => throw new Exception("Invalid asset")
+      (a.groupId, a.seriesId, a.groupAlloy, a.seriesAlloy) match {
+        // If seriesAlloy is provided, the seriesId is ignored. In this case, groupAlloy should not exist
+        case (Some(gId), _, None, Some(sAlloy)) => AssetType(gId.value, sAlloy)
+        // If groupAlloy is provided, the groupId is ignored. In this case, seriesAlloy should not exist
+        case (_, Some(sId), Some(gAlloy), None) => AssetType(sId.value, gAlloy)
+        // if neither groupAlloy or seriesAlloy is provided, the groupId and seriesId are used to identify instead
+        case (Some(gId), Some(sId), None, None) => AssetType(gId.value, sId.value)
+        // invalid cases
+        case (_, _, Some(_), Some(_)) => throw new Exception("Both groupAlloy and seriesAlloy cannot exist in an asset")
+        case (_, _, None, None) => throw new Exception("Both groupId and seriesId must be provided for non-alloy assets")
+        case (_, None, Some(_), _) => throw new Exception("seriesId must be provided when groupAlloy is used in an asset")
+        case (None, _, _, Some(_)) => throw new Exception("groupId must be provided when seriesAlloy is used in an asset")
       }
     case _ => throw new Exception("Invalid value type")
-  }
-}
-
-class TypeIdentifierToQuantityDescriptorSyntaxOps(val typeIdentifier: ValueTypeIdentifier) extends AnyVal {
-
-  def getQuantityDescriptor: Option[QuantityDescriptorType] = typeIdentifier match {
-    case GroupAndSeriesFungible(_, _, qd) => Some(qd)
-    case GroupFungible(_, _, qd)          => Some(qd)
-    case SeriesFungible(_, _, qd)         => Some(qd)
-    case _                                => None
   }
 }
 
@@ -76,36 +58,15 @@ case class GroupType(groupId: GroupId) extends ValueTypeIdentifier
  */
 case class SeriesType(seriesId: SeriesId) extends ValueTypeIdentifier
 
-sealed trait AssetType extends ValueTypeIdentifier
-
 /**
- * A Group and Series fungible asset type, identified by a GroupId, a SeriesId, and a QuantityDescriptorType.
+ * An Asset Token value type, identified by a Group Id (or Group Alloy) and a Series Id (or Series Alloy).
  *
- * @param groupId The GroupId of the asset
- * @param seriesId The SeriesId of the asset
- * @param qdType The QuantityDescriptorType of the asset
- */
-case class GroupAndSeriesFungible(groupId: GroupId, seriesId: SeriesId, qdType: QuantityDescriptorType)
-    extends AssetType
-
-/**
- * A Group fungible asset type, identified by a GroupId, a Series alloy, and a QuantityDescriptorType. If the asset is
- * not an alloy, the series "alloy" is given by the seriesId.
+ * If the asset is not an alloy (i.e, is not the result of a merge), then the GroupId and SeriesId of the asset are used.
+ * Assets with a fungibility of GROUP_AND_SERIES can never be an alloy thus will always use GroupId and SeriesId.
+ * If the asset is an alloy and it's fungibility is GROUP, then the GroupId and the Series Alloy of the asset are used.
+ * If the asset is an alloy and it's fungibility is SERIES, then the Group Alloy and the SeriesId of the asset are used.
  *
- * @param groupId  The GroupId of the asset
- * @param seriesAlloyOrId If the asset is an alloy, the Series alloy. Else the SeriesId of the asset
- * @param qdType The QuantityDescriptorType of the asset
+ * @param groupIdOrAlloy The GroupId or Group Alloy of the asset
+ * @param seriesIdOrAlloy The SeriesId or Series Alloy of the asset
  */
-case class GroupFungible(groupId: GroupId, seriesAlloyOrId: ByteString, qdType: QuantityDescriptorType)
-    extends AssetType
-
-/**
- * A Series fungible asset type, identified by a SeriesId, a Group alloy, and a QuantityDescriptorType. If the asset is
- * not an alloy, the group "alloy" is given by the groupId.
- *
- * @param seriesId The SeriesId of the asset
- * @param groupAlloyOrId If the asset is an alloy, the Group alloy. Else the GroupId of the asset
- * @param qdType The QuantityDescriptorType of the asset
- */
-case class SeriesFungible(seriesId: SeriesId, groupAlloyOrId: ByteString, qdType: QuantityDescriptorType)
-    extends AssetType
+case class AssetType(groupIdOrAlloy: ByteString, seriesIdOrAlloy: ByteString) extends ValueTypeIdentifier

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -447,6 +447,12 @@ object TransactionSyntaxInterpreter {
       ) || transaction.seriesPolicies.exists(_.event.registrationUtxo == stxo.address)))
     }
 
+  private def seriesOnMintedStatements(transaction: IoTransaction): Seq[Value.Series] =
+    transaction.inputs
+      .filter(_.value.value.isSeries)
+      .filter(sto => transaction.mintingStatements.map(_.seriesTokenUtxo).contains(sto.address))
+      .map(_.value.getSeries)
+
   private def mintingOutputsProjection(transaction: IoTransaction): Seq[UnspentTransactionOutput] = {
     val groupIdsOnMintedStatements =
       transaction.inputs
@@ -455,10 +461,7 @@ object TransactionSyntaxInterpreter {
         .map(_.value.getGroup.groupId)
 
     val seriesIdsOnMintedStatements =
-      transaction.inputs
-        .filter(_.value.value.isSeries)
-        .filter(sto => transaction.mintingStatements.map(_.seriesTokenUtxo).contains(sto.address))
-        .map(_.value.getSeries.seriesId)
+      seriesOnMintedStatements(transaction).map(_.seriesId)
 
     transaction.outputs.filter { utxo =>
       !utxo.value.value.isLvl &&
@@ -482,6 +485,7 @@ object TransactionSyntaxInterpreter {
 
     val groups = projectedTransaction.outputs.flatMap(_.value.value.group)
     val series = projectedTransaction.outputs.flatMap(_.value.value.series)
+    val assets = projectedTransaction.outputs.flatMap(_.value.value.asset)
 
     def registrationInPolicyContainsLvls(registrationUtxo: TransactionOutputAddress): Boolean =
       projectedTransaction.inputs.exists { stxo =>
@@ -559,8 +563,16 @@ object TransactionSyntaxInterpreter {
       }
     }
 
+    // Checking if the fields of the actual asset outputs match their series constructors
+    val validAssetFields = assets.forall { asset =>
+      seriesOnMintedStatements(transaction).exists(s =>
+        asset.seriesId.contains(s.seriesId) &&
+        s.fungibility == asset.fungibility && s.quantityDescriptor == asset.quantityDescriptor
+      )
+    }
+
     Validated.condNec(
-      validGroups && validSeries && validAssets,
+      validGroups && validSeries && validAssets && validAssetFields,
       (),
       TransactionSyntaxError.InsufficientInputFunds(
         transaction.inputs.map(_.value.value).toList,

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -279,9 +279,12 @@ object TransactionSyntaxInterpreter {
         .value
     }
 
-    def tupleAndGroup(s: Seq[Value.Value]): Try[Map[ValueTypeIdentifier, BigInt]] =
+    def tupleAndGroup(s: Seq[Value.Value]) =
       Try {
-        s.map(value => (value.typeIdentifier, value.quantity: BigInt))
+        s.map(v => ((v.typeIdentifier, v.getFungibility, v.getQuantityDescriptor), v.quantity: BigInt))
+          // Grouping includes fungibility and quantity descriptor to account for invalid asset configurations
+          // I.e, we validate that the fungibility and quantity descriptor does not differ from their
+          // corresponding asset input (transfer) or series constructor (minting)
           .groupBy(_._1)
           .view
           .mapValues(_.map(_._2).sum)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -179,23 +179,72 @@ trait MockHelpers {
   )
 
   val assetGroupSeriesImmutable: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.computeId.some))
+    assetGroupSeries.copy(
+      assetGroupSeries.getAsset
+        .copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.computeId.some)
+    )
 
   val assetGroupSeriesFractionable: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.computeId.some))
+    assetGroupSeries.copy(
+      assetGroupSeries.getAsset
+        .copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.computeId.some)
+    )
 
   val assetGroupSeriesAccumulator: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.computeId.some))
+    assetGroupSeries.copy(
+      assetGroupSeries.getAsset
+        .copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.computeId.some)
+    )
 
-  val assetGroup: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = GROUP, seriesId = mockSeriesPolicy.copy(fungibility = GROUP).computeId.some))
+  val assetGroup: Value = assetGroupSeries.copy(
+    assetGroupSeries.getAsset
+      .copy(fungibility = GROUP, seriesId = mockSeriesPolicy.copy(fungibility = GROUP).computeId.some)
+  )
 
-  val assetGroupImmutable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.copy(fungibility = GROUP).computeId.some))
-  val assetGroupFractionable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.copy(fungibility = GROUP).computeId.some))
-  val assetGroupAccumulator: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.copy(fungibility = GROUP).computeId.some))
+  val assetGroupImmutable: Value = assetGroup.copy(
+    assetGroup.getAsset.copy(
+      quantityDescriptor = IMMUTABLE,
+      seriesId = mockSeriesPolicyImmutable.copy(fungibility = GROUP).computeId.some
+    )
+  )
 
-  val assetSeries: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = SERIES, seriesId = mockSeriesPolicy.copy(fungibility = SERIES).computeId.some))
+  val assetGroupFractionable: Value = assetGroup.copy(
+    assetGroup.getAsset.copy(
+      quantityDescriptor = FRACTIONABLE,
+      seriesId = mockSeriesPolicyFractionable.copy(fungibility = GROUP).computeId.some
+    )
+  )
 
-  val assetSeriesImmutable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.copy(fungibility = SERIES).computeId.some))
-  val assetSeriesFractionable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.copy(fungibility = SERIES).computeId.some))
-  val assetSeriesAccumulator: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.copy(fungibility = SERIES).computeId.some))
+  val assetGroupAccumulator: Value = assetGroup.copy(
+    assetGroup.getAsset.copy(
+      quantityDescriptor = ACCUMULATOR,
+      seriesId = mockSeriesPolicyAccumulator.copy(fungibility = GROUP).computeId.some
+    )
+  )
+
+  val assetSeries: Value = assetGroupSeries.copy(
+    assetGroupSeries.getAsset
+      .copy(fungibility = SERIES, seriesId = mockSeriesPolicy.copy(fungibility = SERIES).computeId.some)
+  )
+
+  val assetSeriesImmutable: Value = assetSeries.copy(
+    assetSeries.getAsset.copy(
+      quantityDescriptor = IMMUTABLE,
+      seriesId = mockSeriesPolicyImmutable.copy(fungibility = SERIES).computeId.some
+    )
+  )
+
+  val assetSeriesFractionable: Value = assetSeries.copy(
+    assetSeries.getAsset.copy(
+      quantityDescriptor = FRACTIONABLE,
+      seriesId = mockSeriesPolicyFractionable.copy(fungibility = SERIES).computeId.some
+    )
+  )
+
+  val assetSeriesAccumulator: Value = assetSeries.copy(
+    assetSeries.getAsset.copy(
+      quantityDescriptor = ACCUMULATOR,
+      seriesId = mockSeriesPolicyAccumulator.copy(fungibility = SERIES).computeId.some
+    )
+  )
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -166,6 +166,9 @@ trait MockHelpers {
   )
 
   val mockSeriesPolicy: SeriesPolicy = SeriesPolicy("Mock Series Policy", None, dummyTxoAddress)
+  val mockSeriesPolicyImmutable: SeriesPolicy = mockSeriesPolicy.copy(quantityDescriptor = IMMUTABLE)
+  val mockSeriesPolicyFractionable: SeriesPolicy = mockSeriesPolicy.copy(quantityDescriptor = FRACTIONABLE)
+  val mockSeriesPolicyAccumulator: SeriesPolicy = mockSeriesPolicy.copy(quantityDescriptor = ACCUMULATOR)
   val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", dummyTxoAddress)
 
   val seriesValue: Value = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
@@ -176,23 +179,23 @@ trait MockHelpers {
   )
 
   val assetGroupSeriesImmutable: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = IMMUTABLE))
+    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.computeId.some))
 
   val assetGroupSeriesFractionable: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE))
+    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.computeId.some))
 
   val assetGroupSeriesAccumulator: Value =
-    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR))
+    assetGroupSeries.copy(assetGroupSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.computeId.some))
 
-  val assetGroup: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = GROUP))
+  val assetGroup: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = GROUP, seriesId = mockSeriesPolicy.copy(fungibility = GROUP).computeId.some))
 
-  val assetGroupImmutable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = IMMUTABLE))
-  val assetGroupFractionable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = FRACTIONABLE))
-  val assetGroupAccumulator: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = ACCUMULATOR))
+  val assetGroupImmutable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.copy(fungibility = GROUP).computeId.some))
+  val assetGroupFractionable: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.copy(fungibility = GROUP).computeId.some))
+  val assetGroupAccumulator: Value = assetGroup.copy(assetGroup.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.copy(fungibility = GROUP).computeId.some))
 
-  val assetSeries: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = SERIES))
+  val assetSeries: Value = assetGroupSeries.copy(assetGroupSeries.getAsset.copy(fungibility = SERIES, seriesId = mockSeriesPolicy.copy(fungibility = SERIES).computeId.some))
 
-  val assetSeriesImmutable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = IMMUTABLE))
-  val assetSeriesFractionable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE))
-  val assetSeriesAccumulator: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR))
+  val assetSeriesImmutable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = IMMUTABLE, seriesId = mockSeriesPolicyImmutable.copy(fungibility = SERIES).computeId.some))
+  val assetSeriesFractionable: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = FRACTIONABLE, seriesId = mockSeriesPolicyFractionable.copy(fungibility = SERIES).computeId.some))
+  val assetSeriesAccumulator: Value = assetSeries.copy(assetSeries.getAsset.copy(quantityDescriptor = ACCUMULATOR, seriesId = mockSeriesPolicyAccumulator.copy(fungibility = SERIES).computeId.some))
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
@@ -1,6 +1,7 @@
 package co.topl.brambl.builders
 
 import cats.implicits.catsSyntaxOptionId
+import co.topl.brambl.models.box.Value
 import co.topl.brambl.syntax.{bigIntAsInt128, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 
 class AggregationOpsSpec extends TransactionBuilderInterpreterSpecBase {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -100,7 +100,7 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
   def toAltAsset(asset: Value): Value = asset.copy(
     asset.getAsset.copy(
       groupId = mockGroupPolicyAlt.computeId.some,
-      seriesId = mockSeriesPolicyAlt.computeId.some
+      seriesId = mockSeriesPolicyAlt.copy(quantityDescriptor = asset.getAsset.quantityDescriptor, fungibility = asset.getAsset.fungibility).computeId.some
     )
   )
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -100,7 +100,10 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
   def toAltAsset(asset: Value): Value = asset.copy(
     asset.getAsset.copy(
       groupId = mockGroupPolicyAlt.computeId.some,
-      seriesId = mockSeriesPolicyAlt.copy(quantityDescriptor = asset.getAsset.quantityDescriptor, fungibility = asset.getAsset.fungibility).computeId.some
+      seriesId = mockSeriesPolicyAlt
+        .copy(quantityDescriptor = asset.getAsset.quantityDescriptor, fungibility = asset.getAsset.fungibility)
+        .computeId
+        .some
     )
   )
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
@@ -15,18 +15,18 @@ class TokenTypeIdentifierSyntaxSpec extends munit.FunSuite with MockHelpers {
     assertEquals(lvlValue.value.typeIdentifier, LvlType)
     assertEquals(groupValue.value.typeIdentifier, GroupType(gId))
     assertEquals(seriesValue.value.typeIdentifier, SeriesType(sId))
-    assertEquals(assetGroupSeries.value.typeIdentifier, GroupAndSeriesFungible(gId, sId, qd))
-    assertEquals(assetGroup.value.typeIdentifier, GroupFungible(gId, sId.value, qd))
-    assertEquals(assetSeries.value.typeIdentifier, SeriesFungible(sId, gId.value, qd))
+    assertEquals(assetGroupSeries.value.typeIdentifier, AssetType(gId.value, sId.value))
+    assertEquals(assetGroup.value.typeIdentifier, AssetType(gId.value, sId.value))
+    assertEquals(assetSeries.value.typeIdentifier, AssetType(gId.value, sId.value))
     val mockAlloy = ByteString.copyFrom(Array.fill(32)(0.toByte))
     val testAlloy = ByteString.copyFrom(Array.fill(32)(0.toByte))
     assertEquals(
       assetGroup.copy(assetGroup.getAsset.copy(seriesAlloy = mockAlloy.some)).value.typeIdentifier,
-      GroupFungible(gId, testAlloy, qd)
+      AssetType(gId.value, testAlloy)
     )
     assertEquals(
       assetSeries.copy(assetSeries.getAsset.copy(groupAlloy = mockAlloy.some)).value.typeIdentifier,
-      SeriesFungible(sId, testAlloy, qd)
+      AssetType(testAlloy, sId.value)
     )
     intercept[Exception](BoxValue.Topl(Value.TOPL(quantity)).typeIdentifier)
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
@@ -11,13 +11,14 @@ class TokenTypeIdentifierSyntaxSpec extends munit.FunSuite with MockHelpers {
   test("typeIdentifier") {
     val gId = mockGroupPolicy.computeId
     val sId = mockSeriesPolicy.computeId
-    val qd = mockSeriesPolicy.quantityDescriptor
+    val sIdSeries = assetSeries.getAsset.seriesId.get
+    val sIdGroup = assetGroup.getAsset.seriesId.get
     assertEquals(lvlValue.value.typeIdentifier, LvlType)
     assertEquals(groupValue.value.typeIdentifier, GroupType(gId))
     assertEquals(seriesValue.value.typeIdentifier, SeriesType(sId))
     assertEquals(assetGroupSeries.value.typeIdentifier, AssetType(gId.value, sId.value))
-    assertEquals(assetGroup.value.typeIdentifier, AssetType(gId.value, sId.value))
-    assertEquals(assetSeries.value.typeIdentifier, AssetType(gId.value, sId.value))
+    assertEquals(assetGroup.value.typeIdentifier, AssetType(gId.value, sIdGroup.value))
+    assertEquals(assetSeries.value.typeIdentifier, AssetType(gId.value, sIdSeries.value))
     val mockAlloy = ByteString.copyFrom(Array.fill(32)(0.toByte))
     val testAlloy = ByteString.copyFrom(Array.fill(32)(0.toByte))
     assertEquals(
@@ -26,7 +27,7 @@ class TokenTypeIdentifierSyntaxSpec extends munit.FunSuite with MockHelpers {
     )
     assertEquals(
       assetSeries.copy(assetSeries.getAsset.copy(groupAlloy = mockAlloy.some)).value.typeIdentifier,
-      AssetType(testAlloy, sId.value)
+      AssetType(testAlloy, sIdSeries.value)
     )
     intercept[Exception](BoxValue.Topl(Value.TOPL(quantity)).typeIdentifier)
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -686,7 +686,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       Value.defaultInstance.withAsset(
         Value.Asset(
           groupId = Some(groupPolicy.computeId),
-          seriesId = Some(seriesPolicy.computeId),
+          seriesId = Some(seriesPolicy.copy(fungibility = FungibilityType.GROUP).computeId),
           quantity = BigInt(1),
           fungibility = FungibilityType.GROUP // check here
         )
@@ -745,5 +745,10 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     assertEquals(result.map(_.toList.size).getOrElse(0), 1)
 
   }
+
+  // TODO:
+  // output came from no where.. (not in input, not in minted).. It succeeds when it should fail
+  // For example: groupG1, seriesS1 in input. assetG1S1 and assetG1S2 in output. AMS for G1S1. It should fail
+  // Another case, minted is invalid. For example: groupG1, seriesS1 in input. assetG1S1 in output. AMS for G1S1. however, assetG1S1 has the wrong internal fields
 
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -3,10 +3,12 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.box.QuantityDescriptorType.IMMUTABLE
 import co.topl.brambl.models.box.{AssetMintingStatement, FungibilityType, Value}
 import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.models.{Event, TransactionOutputAddress}
 import co.topl.brambl.syntax._
+
 import scala.language.implicitConversions
 
 /**
@@ -686,7 +688,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
       Value.defaultInstance.withAsset(
         Value.Asset(
           groupId = Some(groupPolicy.computeId),
-          seriesId = Some(seriesPolicy.copy(fungibility = FungibilityType.GROUP).computeId),
+          seriesId = Some(seriesPolicy.computeId),
           quantity = BigInt(1),
           fungibility = FungibilityType.GROUP // check here
         )
@@ -746,9 +748,277 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
 
   }
 
-  // TODO:
-  // output came from no where.. (not in input, not in minted).. It succeeds when it should fail
-  // For example: groupG1, seriesS1 in input. assetG1S1 and assetG1S2 in output. AMS for G1S1. It should fail
-  // Another case, minted is invalid. For example: groupG1, seriesS1 in input. assetG1S1 in output. AMS for G1S1. however, assetG1S1 has the wrong internal fields
+  /**
+   * Reasons:
+   * - input Assets = 0
+   * - minted Assets = 1
+   * - asset output = 2
+   *
+   * An asset came from nowhere; different (groupId, seriesId) from AMS minted asset
+   *
+   * The first output's (groupId, seriesId) matches the AMS and satisfies the AMS quantity.
+   * We still expected failure because the second output's (groupId, seriesId) is not from minting or inputs.
+   */
+  test("Invalid data-input case, unexpected asset output") {
+    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val group_in: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
 
+    val series_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES
+        )
+      )
+
+    val minted_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES
+        )
+      )
+    // SeriesId is different from the AMS so it is not the minted asset. There is also no matching input asset.
+    val invalid_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.copy(fungibility = FungibilityType.GROUP).computeId),
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP // check here
+        )
+      )
+
+    val group_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val series_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val mintingStatement = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(1)
+    )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, group_in),
+      SpentTransactionOutput(txoAddress_2, attFull, series_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, group_out),
+      UnspentTransactionOutput(trivialLockAddress, series_out),
+      UnspentTransactionOutput(trivialLockAddress, minted_out),
+      UnspentTransactionOutput(trivialLockAddress, invalid_out)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+
+  }
+
+  /**
+   * Reasons:
+   * - input Assets = 0
+   * - minted Assets = 1
+   * - asset output = 2
+   *
+   * Both output's (groupId, seriesId) match the AMS, but both have invalid fields.
+   */
+  test("Invalid data-input case, invalid fields in minted asset") {
+    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val group_in: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val series_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES
+        )
+      )
+
+    // Both the following outputs match the minted asset's group and series ID but have invalid fields
+    val minted_out_invalidFungibility: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP
+        )
+      )
+    val minted_out_invalidQuantity: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1),
+          quantityDescriptor = IMMUTABLE
+        )
+      )
+
+    val group_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val series_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val mintingStatement = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(2)
+    )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, group_in),
+      SpentTransactionOutput(txoAddress_2, attFull, series_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, group_out),
+      UnspentTransactionOutput(trivialLockAddress, series_out),
+      UnspentTransactionOutput(trivialLockAddress, minted_out_invalidFungibility),
+      UnspentTransactionOutput(trivialLockAddress, minted_out_invalidQuantity)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+
+  }
+
+  /**
+   * Reasons:
+   * - input Assets = 0
+   * - minted Assets = 1
+   * - asset output = 2
+   *
+   * Both output's (groupId, seriesId) match the AMS, but only the first has valid fields.
+   */
+  test("Invalid data-input case, invalid fields in one minted asset") {
+    val groupPolicy = Event.GroupPolicy(label = "groupLabelA", registrationUtxo = txoAddress_1)
+    val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_2)
+    val group_in: Value =
+      Value.defaultInstance.withGroup(
+        Value.Group(
+          groupId = groupPolicy.computeId,
+          quantity = BigInt(1)
+        )
+      )
+
+    val series_in: Value =
+      Value.defaultInstance.withSeries(
+        Value.Series(
+          seriesId = seriesPolicy.computeId,
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES
+        )
+      )
+
+    // Both the following outputs match the minted asset's group and series ID but only the first has valid fields
+    // AMS is satisfied via the first output
+    val minted_out: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1),
+          fungibility = FungibilityType.GROUP_AND_SERIES
+        )
+      )
+    val minted_out_invalid: Value =
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = Some(groupPolicy.computeId),
+          seriesId = Some(seriesPolicy.computeId),
+          quantity = BigInt(1),
+          quantityDescriptor = IMMUTABLE
+        )
+      )
+
+    val group_out: Value =
+      Value.defaultInstance.withGroup(Value.Group(groupId = groupPolicy.computeId, quantity = BigInt(1)))
+
+    val series_out: Value =
+      Value.defaultInstance.withSeries(Value.Series(seriesId = seriesPolicy.computeId, quantity = BigInt(1)))
+
+    val mintingStatement = AssetMintingStatement(
+      groupTokenUtxo = txoAddress_1,
+      seriesTokenUtxo = txoAddress_2,
+      quantity = BigInt(2)
+    )
+
+    val inputs = List(
+      SpentTransactionOutput(txoAddress_1, attFull, group_in),
+      SpentTransactionOutput(txoAddress_2, attFull, series_in)
+    )
+    val outputs = List(
+      UnspentTransactionOutput(trivialLockAddress, group_out),
+      UnspentTransactionOutput(trivialLockAddress, series_out),
+      UnspentTransactionOutput(trivialLockAddress, minted_out),
+      UnspentTransactionOutput(trivialLockAddress, minted_out_invalid)
+    )
+
+    val testTx = txFull.copy(inputs = inputs, outputs = outputs, mintingStatements = List(mintingStatement))
+
+    val validator = TransactionSyntaxInterpreter.make[Id]()
+    val result = validator.validate(testTx).swap
+
+    val assertError = result.exists(
+      _.toList.contains(
+        TransactionSyntaxError.InsufficientInputFunds(
+          testTx.inputs.map(_.value.value).toList,
+          testTx.outputs.map(_.value.value).toList
+        )
+      )
+    )
+
+    assertEquals(assertError, true)
+    assertEquals(result.map(_.toList.size).getOrElse(0), 1)
+
+  }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -898,7 +898,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val mintingStatement = AssetMintingStatement(
       groupTokenUtxo = txoAddress_1,
       seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2)
+      quantity = BigInt(1)
     )
 
     val inputs = List(
@@ -988,7 +988,7 @@ class TransactionSyntaxInterpreterAssetSpec extends munit.FunSuite with MockHelp
     val mintingStatement = AssetMintingStatement(
       groupTokenUtxo = txoAddress_1,
       seriesTokenUtxo = txoAddress_2,
-      quantity = BigInt(2)
+      quantity = BigInt(1)
     )
 
     val inputs = List(

--- a/documentation/docs/reference/transactions/transfer.mdx
+++ b/documentation/docs/reference/transactions/transfer.mdx
@@ -49,7 +49,7 @@ aggregated into a single output to reduce the number of UTXOs.
 
 The parameters are as follows:
 - `tokenIdentifier` - The Token Identifier denoting the type of token to transfer to the recipient. If this denotes an
-Asset Token, the quantity descriptor type must be `LIQUID`.
+Asset Token, the quantity descriptor type of the asset must be `LIQUID`.
 - `txos` - A sequence of TXOs to be the inputs of the created transaction. All TXOs must be encumbered by the same lock
 predicate, given by `lockPredicateFrom`. You can obtain these TXOs from the [RPC queries](../rpc#querying-utxos).
 - `lockPredicateFrom` - The Predicate Lock that encumbers all the TXOs in `txos`.


### PR DESCRIPTION
## Purpose

Simplify the ValueTypeIdentifier definitions for the users. When using the TransactionBuilder users shouldn't need to specify unnecessary fields; only the IDs.

## Approach

- updated ValueTypeIdentifier  definition for Asset Types; they no longer include QuantityDescriptor and are not separated by fungibility types.
- updated tx builder's parameter validation to check Quantity descriptor type via the Value instead of type identifier
- Added updated TransactionSyntaxValidation to reflect change (to ensure asset outputs have the correct fields)
- Added 4 new validation tests to ensure TransactionSyntaxValidation behaves as expected

## Testing

- updated brambl-cli; ensured integration tests successful
- updated node and ensured actions were successful

## Tickets
* TSDK-612