### PR TITLE
TSDK-610 Add Support for TOPLs and new unknown types (UpdateProposals) in TransactionBuilder

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
@@ -7,7 +7,8 @@ import co.topl.brambl.syntax.{
   int128AsBigInt,
   valueToQuantityDescriptorSyntaxOps,
   valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps
+  valueToTypeIdentifierSyntaxOps,
+  UnknownType
 }
 
 import scala.language.implicitConversions
@@ -58,7 +59,9 @@ object DefaultAggregationOps extends AggregationOps {
    * Aggregate 2 values into 1 if allowable. Throw an exception otherwise.
    */
   private def handleAggregation(value: Value, other: Value): Value =
-    if (value.typeIdentifier == other.typeIdentifier)
+    if (value.typeIdentifier == UnknownType)
+      throw new Exception("Aggregation of UnknownType is not allowed")
+    else if (value.typeIdentifier == other.typeIdentifier)
       if (value.getQuantityDescriptor.forall(_ == LIQUID))
         value.setQuantity(value.quantity + other.quantity)
       else throw new Exception("Aggregation of IMMUTABLE, FRACTIONABLE, or ACCUMULATOR assets is not allowed")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -166,20 +166,16 @@ trait TransactionBuilderApi[F[_]] {
    * all tokens provided in txos will go to the recipient. Any remaining tokens in txos that are not transferred to the
    * recipient will be transferred to the change address.
    *
-   * TODO: Add support for TOPLs and UpdateProposals
-   * @note Currently TOPLs and UpdateProposal values are not supported in the txos. This will be added in TSDK-610
-   * @note Currently TOPLs and UpdateProposal values are not supported in tokenIdentifier. This will be added in TSDK-610
-   *
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain some token
-   *             matching tokenIdentifier (if it is provided) and at least the quantity of LVLs to satisfy the fee, else
-   *             an error will be returned.
+   *             matching tokenIdentifier (if it is provided) and at least the quantity of LVLs to satisfy the fee. All
+   *             TXOs must contain values of valid type. Else an error will be returned.
    * @param lockPredicateFrom The Lock Predicate encumbering the txos
    * @param recipientLockAddress The LockAddress of the recipient
    * @param changeLockAddress A LockAddress to send the tokens that are not going to the recipient
    * @param fee The fee to pay for the transaction. The txos must contain enough LVLs to satisfy this fee
    * @param tokenIdentifier An optional token identifier to denote the type of token to transfer to the recipient. If
    *                        None, all tokens in txos will be transferred to the recipient and changeLockAddress will be
-   *                        ignored.
+   *                        ignored. This must not be UnknownType.
    * @return An unproven transaction
    */
   def buildTransferAllTransaction(
@@ -195,20 +191,17 @@ trait TransactionBuilderApi[F[_]] {
    * Builds a transaction to transfer a certain amount of a specified Token (given by tokenIdentifier). The transaction
    * will also transfer any other tokens (in the txos) that are encumbered by the same predicate to the change address.
    *
-   * This function only supports transferring a specific amount of assets (via tokenIdentifier) if their quantity
-   * descriptor type is LIQUID.
-   *
-   * TODO: Add support for TOPLs and UpdateProposals
-   * @note Currently TOPLs and UpdateProposal values are not supported in the txos. This will be added in TSDK-610
-   * @note Currently TOPLs and UpdateProposal values are not supported in tokenIdentifier. This may or may not be added
-   *       in TSDK-610 depending if these values can be aggregated and deaggregated by default. Pending discussion.
+   * @note This function only supports transferring a specific amount of assets (via tokenIdentifier) if their quantity
+   *       descriptor type is LIQUID.
+   * @note This function only support transferring a specific amount of TOPLs (via tokenIdentifier) if their staking
+   *       registration is None.
    *
    * @param tokenIdentifier The Token Identifier denoting the type of token to transfer to the recipient. If this denotes
    *                        an Asset Token, the referenced asset's quantity descriptor type must be LIQUID, else an error
-   *                        will be returned.
+   *                        will be returned. This must not be UnknownType.
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
    *             necessary quantity (given by amount) of the identified Token and at least the quantity of LVLs to
-   *             satisfy the fee, else an error will be returned.
+   *             satisfy the fee. All TXOs must contain values of valid type. Else an error will be returned.
    * @param lockPredicateFrom The Lock Predicate encumbering the txos
    * @param amount The amount of identified Token to transfer to the recipient
    * @param recipientLockAddress The LockAddress of the recipient
@@ -233,7 +226,8 @@ trait TransactionBuilderApi[F[_]] {
    * contain more tokens.
    *
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain some LVLs (as
-   *             specified in the policy), to satisfy the registration fee, else an error will be returned.
+   *             specified in the policy), to satisfy the registration fee. All TXOs must contain values of valid type.
+   *             Else an error will be returned.
    * @param lockPredicateFrom The Predicate Lock that encumbers the funds in the txos. This will be used in
    *                         the attestations of the inputs.
    * @param groupPolicy The group policy for which we are minting constructor tokens. This group policy specifies a
@@ -261,8 +255,8 @@ trait TransactionBuilderApi[F[_]] {
    * contain more tokens.
    *
    * @param txos              All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain
-   *                          some LVLs (as specified in the policy), to satisfy the registration fee, else an error
-   *                          will be returned.
+   *                          some LVLs (as specified in the policy), to satisfy the registration fee. All TXOs must
+   *                          contain values of valid type. Else an error will be returned.
    * @param lockPredicateFrom The Predicate Lock that encumbers the funds in the txos. This will be used in
    *                          the attestations of the inputs.
    * @param seriesPolicy The series policy for which we are minting constructor tokens. This series policy specifies a
@@ -295,7 +289,7 @@ trait TransactionBuilderApi[F[_]] {
    * @param mintingStatement      The minting statement that specifies the asset to mint.
    * @param txos                  All the TXOs encumbered by the Locks given by locks. These TXOs must contain some
    *                              group and series constructors (as referenced in the AMS) to satisfy the minting
-   *                              requirements, else an error will be returned.
+   *                              requirements. All TXOs must contain values of valid type. Else an error will be returned.
    * @param locks             A mapping of Predicate Locks that encumbers the funds in the txos. This will be used in the
    *                              attestations of the txos' inputs.
    * @param fee The transaction fee. The txos must contain enough LVLs to satisfy this fee

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -254,6 +254,7 @@ object UserInputValidations {
           "lockPredicateFrom"
         ),
         positiveQuantity(quantityToMint, "quantityToMint"),
+        noUnknownType(txos.map(_.transactionOutput.value.value.typeIdentifier)),
         validFee(fee, txos.map(_.transactionOutput.value.value))
       ).fold.toEither
     } match {
@@ -285,6 +286,7 @@ object UserInputValidations {
             .andThen(s => validMintingSupply(mintingStatement.quantity, s).map(_ => s))
         ).andThen(res => fixedSeriesMatch(res._1.fixedSeries, res._2.seriesId)),
         positiveQuantity(mintingStatement.quantity, "quantity to mint"),
+        noUnknownType(txos.map(_.transactionOutput.value.value.typeIdentifier)),
         validFee(fee, txos.map(_.transactionOutput.value.value))
       ).fold.toEither
     } match {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/BoxValueSyntax.scala
@@ -8,6 +8,7 @@ import scala.language.implicitConversions
 
 trait BoxValueSyntax {
   implicit def lvlAsBoxVal(lvl:  LVL): Value = Value.Lvl(lvl)
+  implicit def toplAsBoxVal(tpl: TOPL): Value = Value.Topl(tpl)
   implicit def groupAsBoxVal(g:  Group): Value = Value.Group(g)
   implicit def seriesAsBoxVal(s: Series): Value = Value.Series(s)
   implicit def assetAsBoxVal(a:  Asset): Value = Value.Asset(a)
@@ -23,6 +24,7 @@ class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
 
   def quantity: Int128 = value match {
     case Value.Lvl(l)    => l.quantity
+    case Value.Topl(t)   => t.quantity
     case Value.Group(g)  => g.quantity
     case Value.Series(s) => s.quantity
     case Value.Asset(a)  => a.quantity
@@ -31,6 +33,7 @@ class ValueToQuantitySyntaxOps(val value: Value) extends AnyVal {
 
   def setQuantity(quantity: Int128): Value = value match {
     case Value.Lvl(l)    => l.withQuantity(quantity)
+    case Value.Topl(t)   => t.withQuantity(quantity)
     case Value.Group(g)  => g.withQuantity(quantity)
     case Value.Series(s) => s.withQuantity(quantity)
     case Value.Asset(a)  => a.withQuantity(quantity)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
@@ -2,6 +2,7 @@ package co.topl.brambl.syntax
 
 import co.topl.brambl.models.{GroupId, SeriesId}
 import co.topl.brambl.models.box.Value._
+import co.topl.consensus.models.StakingRegistration
 import com.google.protobuf.ByteString
 
 import scala.language.implicitConversions
@@ -16,6 +17,7 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
 
   def typeIdentifier: ValueTypeIdentifier = value match {
     case Value.Lvl(_)    => LvlType
+    case Value.Topl(t)   => ToplType(t.registration)
     case Value.Group(g)  => GroupType(g.groupId)
     case Value.Series(s) => SeriesType(s.seriesId)
     case Value.Asset(a) =>
@@ -35,7 +37,7 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
         case (None, _, _, Some(_)) =>
           throw new Exception("groupId must be provided when seriesAlloy is used in an asset")
       }
-    case _ => throw new Exception("Invalid value type")
+    case _ => UnknownType
   }
 }
 
@@ -48,6 +50,11 @@ trait ValueTypeIdentifier
  * A LVL value type
  */
 case object LvlType extends ValueTypeIdentifier
+
+/**
+ * A TOPL value type
+ */
+case class ToplType(registration: Option[StakingRegistration]) extends ValueTypeIdentifier
 
 /**
  * A Group Constructor Token value type, identified by a GroupId
@@ -74,3 +81,8 @@ case class SeriesType(seriesId: SeriesId) extends ValueTypeIdentifier
  * @param seriesIdOrAlloy The SeriesId or Series Alloy of the asset
  */
 case class AssetType(groupIdOrAlloy: ByteString, seriesIdOrAlloy: ByteString) extends ValueTypeIdentifier
+
+/**
+ * An unknown value type. This is useful for when new types are added to the ecosystem and the SDK is not updated yet.
+ */
+case object UnknownType extends ValueTypeIdentifier

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -171,6 +171,7 @@ trait MockHelpers {
   val mockSeriesPolicyAccumulator: SeriesPolicy = mockSeriesPolicy.copy(quantityDescriptor = ACCUMULATOR)
   val mockGroupPolicy: GroupPolicy = GroupPolicy("Mock Group Policy", dummyTxoAddress)
 
+  val toplValue: Value = Value.defaultInstance.withTopl(Value.TOPL(quantity, None))
   val seriesValue: Value = Value.defaultInstance.withSeries(Value.Series(mockSeriesPolicy.computeId, quantity, None))
   val groupValue: Value = Value.defaultInstance.withGroup(Value.Group(mockGroupPolicy.computeId, quantity))
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
@@ -6,7 +6,7 @@ import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
 import co.topl.brambl.models.{LockAddress, LockId}
 import co.topl.brambl.models.box.FungibilityType.{GROUP, SERIES}
 import co.topl.brambl.models.box.QuantityDescriptorType.{ACCUMULATOR, FRACTIONABLE, IMMUTABLE}
-import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.box.{AssetMintingStatement, Value}
 import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
 import co.topl.brambl.syntax.{
   assetAsBoxVal,
@@ -37,6 +37,13 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
         )
       )
     )
+  }
+
+  test("unsupported token type in txos") {
+    val testTx = buildMintAssetTransaction
+      .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
   test("a lock from the lock map not in the txos") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
@@ -14,6 +14,14 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
+  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+  }
+
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
@@ -8,18 +8,11 @@ import co.topl.brambl.syntax.{
   ioTransactionAsTransactionSyntaxOps,
   valueToQuantitySyntaxOps,
   valueToTypeIdentifierSyntaxOps,
-  LvlType
+  LvlType,
+  UnknownType
 }
 
 class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderInterpreterSpecBase {
-
-  test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)
-      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
-      .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
-  }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
@@ -2,6 +2,7 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.Datum
+import co.topl.brambl.models.box.Value
 import co.topl.brambl.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeIdentifierSyntaxOps, LvlType}
 
 class TransactionBuilderInterpreterGroupMintingSpec extends TransactionBuilderInterpreterSpecBase {
@@ -37,6 +38,13 @@ class TransactionBuilderInterpreterGroupMintingSpec extends TransactionBuilderIn
         )
       )
     )
+  }
+
+  test("unsupported token type in txos") {
+    val testTx = buildMintGroupTransaction
+      .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
   test("registrationUtxo does not contain lvls") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -14,16 +14,17 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("buildTransferAmountTransaction > unsupported token type (tokenIdentifier)") {
     val testTx = buildTransferAmountTransaction
-      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
+      .withTokenIdentifier(UnknownType)
       .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
-  test("buildTransferAmountTransaction > unsupported token type (tokenIdentifier)") {
+  test("buildTransferAmountTransaction > unsupported token type (txos)") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(UnknownType)
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -8,17 +8,24 @@ import co.topl.brambl.syntax.{
   ioTransactionAsTransactionSyntaxOps,
   valueToQuantitySyntaxOps,
   valueToTypeIdentifierSyntaxOps,
-  LvlType
+  LvlType,
+  UnknownType
 }
 
 class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
+  test("buildTransferAmountTransaction > unsupported token type (txos)") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(groupValue.value.typeIdentifier)
-      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+  }
+
+  test("buildTransferAmountTransaction > unsupported token type (tokenIdentifier)") {
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(UnknownType)
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -13,13 +13,6 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = buildTransferAmountTransaction
-      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
-      .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
-  }
-
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
       .withAmount(0)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -13,6 +13,13 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
+  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+    val testTx = buildTransferAmountTransaction
+      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+  }
+
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
       .withAmount(0)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
@@ -2,6 +2,7 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.Datum
+import co.topl.brambl.models.box.Value
 import co.topl.brambl.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeIdentifierSyntaxOps, LvlType}
 
 class TransactionBuilderInterpreterSeriesMintingSpec extends TransactionBuilderInterpreterSpecBase {
@@ -37,6 +38,13 @@ class TransactionBuilderInterpreterSeriesMintingSpec extends TransactionBuilderI
         )
       )
     )
+  }
+
+  test("unsupported token type in txos") {
+    val testTx = buildMintSeriesTransaction
+      .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
+      .run
+    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
   test("registrationUtxo does not contain lvls") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
@@ -13,14 +13,6 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > underlying error fails (unsupported token type)") {
-    val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
-      .withTxos(mockTxos :+ valToTxo(Value.defaultInstance.withTopl(Value.TOPL(quantity))))
-      .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"Invalid value type")))))
-  }
-
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(seriesValue.value.typeIdentifier)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
@@ -14,6 +14,18 @@ class TransactionBuilderInterpreterToplTransferSpec extends TransactionBuilderIn
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
+  test("buildTransferAmountTransaction > Topl with staking registration") {
+    val testTx = buildTransferAmountTransaction
+      .withTokenIdentifier(toplReg1.value.typeIdentifier)
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(Seq(UserInputError(s"If tokenIdentifier is a Topl type, staking registration must be None")))
+      )
+    )
+  }
+
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(toplValue.value.typeIdentifier)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
@@ -2,20 +2,13 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType
-}
+import co.topl.brambl.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeIdentifierSyntaxOps, LvlType}
 
-class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilderInterpreterSpecBase {
+class TransactionBuilderInterpreterToplTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
   test("buildTransferAmountTransaction > unsupported token type (txos)") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
@@ -23,7 +16,7 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withAmount(0)
       .run
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"quantity to transfer must be positive")))))
@@ -31,7 +24,7 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > a txo isnt tied to lockPredicateFrom") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(lvlValue, trivialLockAddress))
       .run
     assertEquals(
@@ -42,7 +35,7 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > non sufficient funds") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withAmount(4)
       .run
     assertEquals(
@@ -61,7 +54,7 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > fee not satisfied") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withFee(3)
       .run
     assertEquals(
@@ -76,21 +69,21 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
 
   test("buildTransferAmountTransaction > [complex] duplicate inputs are merged and split correctly") {
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos())
       .withOutputs(
         // to recipient
-        buildRecipientUtxos(List(seriesValue))
+        buildRecipientUtxos(List(toplValue))
         ++
         // change due to excess fee and transfer input
-        buildChangeUtxos(List(lvlValue, seriesValue))
+        buildChangeUtxos(List(lvlValue, toplValue))
         ++
         // change values unaffected by recipient transfer and fee
         buildChangeUtxos(
-          mockChange.filterNot(v => List(LvlType, seriesValue.value.typeIdentifier).contains(v.value.typeIdentifier))
+          mockChange.filterNot(v => List(LvlType, toplValue.value.typeIdentifier).contains(v.value.typeIdentifier))
         )
       )
     assertEquals(
@@ -100,16 +93,16 @@ class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilder
   }
 
   test("buildTransferAmountTransaction > [simplest case] no change, only 1 output") {
-    val txos = Seq(valToTxo(seriesValue))
+    val txos = Seq(valToTxo(toplValue))
     val testTx = buildTransferAmountTransaction
-      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withTxos(txos)
       .withFee(0)
       .run
     val expectedTx = IoTransaction.defaultInstance
       .withDatum(txDatum)
       .withInputs(buildStxos(txos))
-      .withOutputs(buildRecipientUtxos(List(seriesValue)))
+      .withOutputs(buildRecipientUtxos(List(toplValue)))
     assertEquals(testTx.toOption.get.computeId, expectedTx.computeId)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/BoxValueSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/BoxValueSyntaxSpec.scala
@@ -31,7 +31,8 @@ class BoxValueSyntaxSpec extends munit.FunSuite with MockHelpers {
     assertEquals(groupValue.value.quantity, quantity)
     assertEquals(seriesValue.value.quantity, quantity)
     assertEquals(assetGroupSeries.value.quantity, quantity)
-    intercept[Exception](BoxValue.Topl(Value.TOPL(mockNewQuantity)).quantity)
+    assertEquals(toplValue.value.quantity, quantity)
+    intercept[Exception](Value.defaultInstance.value.quantity)
   }
 
   test("setQuantity") {
@@ -39,6 +40,7 @@ class BoxValueSyntaxSpec extends munit.FunSuite with MockHelpers {
     assertEquals(groupValue.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
     assertEquals(seriesValue.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
     assertEquals(assetGroupSeries.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
-    intercept[Exception](BoxValue.Topl(Value.TOPL(mockNewQuantity)).setQuantity(mockNewQuantity))
+    assertEquals(toplValue.value.setQuantity(mockNewQuantity).quantity, mockNewQuantity)
+    intercept[Exception](Value.defaultInstance.value.setQuantity(mockNewQuantity))
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
@@ -29,6 +29,7 @@ class TokenTypeIdentifierSyntaxSpec extends munit.FunSuite with MockHelpers {
       assetSeries.copy(assetSeries.getAsset.copy(groupAlloy = mockAlloy.some)).value.typeIdentifier,
       AssetType(testAlloy, sIdSeries.value)
     )
-    intercept[Exception](BoxValue.Topl(Value.TOPL(quantity)).typeIdentifier)
+    assertEquals(toplValue.value.typeIdentifier, ToplType(None))
+    assertEquals(Value.defaultInstance.value.typeIdentifier, UnknownType)
   }
 }

--- a/documentation/docs/reference/transactions/transfer.mdx
+++ b/documentation/docs/reference/transactions/transfer.mdx
@@ -28,7 +28,9 @@ the <ScaladocLink path="co/topl/brambl/builders/TransactionBuilderApi.html#build
 function of a Transaction Builder API instance.
 
 :::note
-This function only supports transferring a specific amount of assets if their quantity descriptor type is `LIQUID`.
+Transferring a specific amount of tokens using this function is not supported for some token types:
+- Asset type if their quantity descriptor type is NOT `LIQUID`
+- TOPL type if their registration is NOT `None`
 :::
 
 ```scala
@@ -49,7 +51,8 @@ aggregated into a single output to reduce the number of UTXOs.
 
 The parameters are as follows:
 - `tokenIdentifier` - The Token Identifier denoting the type of token to transfer to the recipient. If this denotes an
-Asset Token, the quantity descriptor type of the asset must be `LIQUID`.
+Asset Token, the quantity descriptor type of the asset must be `LIQUID`. If this denotes a TOPL, the registration field
+must be `None`.
 - `txos` - A sequence of TXOs to be the inputs of the created transaction. All TXOs must be encumbered by the same lock
 predicate, given by `lockPredicateFrom`. You can obtain these TXOs from the [RPC queries](../rpc#querying-utxos).
 - `lockPredicateFrom` - The Predicate Lock that encumbers all the TXOs in `txos`.


### PR DESCRIPTION
## Purpose

Transfer functions in TransactionBuilder failed when TOPLs or UpdateProposals were passed in as parameters. The SDK was updated to support such parameters.

## Approach

- For UpdateProposals (and any new types that may be added to the ecosystem in the future), added ValueTypeIdentifier "UnknownType". If an "UnknownType" is provided as a parameter (either in TXOs or as tokenIdentifier) in TxBuilder functions, a validation error message will be returned.
- Support Transferring TOPLs; transferAll supports all TOPLs whereas transferAmount supports all TOPLs in the txos but only TOPLs without staking registration for tokenIdentifier (since as a default we won't aggregate/deaggregate for the user).
- Added tests

## Testing

- Added new tests for ValueTypeIdentifier, Aggreations, and TransactionBuilder
- Ensured all tests pass

## Tickets
* Closes TSDK-610