### PR TITLE
TSDK-637 Workflow dependencies

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -78,7 +78,12 @@ jobs:
         with:
           name: Test Results (Java ${{ matrix.java }})
           path: target/test-reports/*.xml
-      
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: success()
+        with:
+          files: |
+            target/test-reports/**/*.xml
       - name: Cleanup before cache
         shell: bash
         run: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,9 +1,6 @@
 name: Deploy to GitHub Pages
 
-on:
-  push:
-    branches: [main]
-
+on: [workflow_call]
 
 jobs:
   deploy:

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -24,7 +24,7 @@ jobs:
         name: Create GitHub deployment (release)
         id: deployment-release
         # Tag pushes are considered releases
-        if: github.ref_type == "tag"
+        if: github.ref_type == 'tag'
         with:
           token: '${{ github.token }}'
           initial-status: success
@@ -33,7 +33,7 @@ jobs:
         name: Create GitHub deployment (snapshot)
         id: deployment-snap
         # Branch pushes are considered snapshots
-        if: github.ref_type == "branch"
+        if: github.ref_type == 'branch'
         with:
           token: '${{ github.token }}'
           initial-status: success

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -11,10 +11,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-
       - uses: olafurpg/setup-scala@v14
       - uses: olafurpg/setup-gpg@v3
-
       - name: Publish artifacts to Maven Central
         run: sbt ci-release
         env:
@@ -22,3 +20,21 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      - uses: chrnorm/deployment-action@v2
+        name: Create GitHub deployment (release)
+        id: deployment-release
+        # Tag pushes are considered releases
+        if: github.ref_type == "tag"
+        with:
+          token: '${{ github.token }}'
+          initial-status: success
+          environment: release
+      - uses: chrnorm/deployment-action@v2
+        name: Create GitHub deployment (snapshot)
+        id: deployment-snap
+        # Branch pushes are considered snapshots
+        if: github.ref_type == "branch"
+        with:
+          token: '${{ github.token }}'
+          initial-status: success
+          environment: snapshot

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -1,8 +1,6 @@
 name: Maven Central Release
-on:
-  push:
-    branches: ["*"]
-    tags: ["*"]
+
+on: [workflow_call]
 
 jobs:
   maven_release:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,4 +21,4 @@ jobs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build
     # Only update Github Pages if this is a push to main
-    if: github.ref_type == branch && github.ref_name == main
+    if: github.ref_type == 'branch' && github.ref_name == 'main'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,7 @@ jobs:
   maven-release:
     uses: ./.github/workflows/maven_release.yml
     needs: sbt-build
+    secrets: inherits
   deploy-docs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,4 +21,4 @@ jobs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build
     # Only update Github Pages if this is a push to main
-    if: github.ref_type == "branch" && github.ref_name == "main"
+    if: github.ref_type == branch && github.ref_name == main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
   maven-release:
     uses: ./.github/workflows/maven_release.yml
     needs: sbt-build
-    secrets: inherits
+    secrets: inherit
   deploy-docs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,9 @@
-name: commonSc_PR
+name: Check and Deploy
 
 on:
-  pull_request:
-    branches: [main, release-*, rc-*]
+  push:
+    branches: ["*"]
+    tags: ["*"]
 
 jobs:
   sbt-build:
@@ -13,18 +14,11 @@ jobs:
       java-versions: >-
         ["11"]
       preserve-cache-between-runs: true
-
-#  sbt-integration-tests:
-#    uses: ./.github/workflows/_scala_integration_tests.yml
-#    needs: sbt-build
-#    with:
-#      target-os: >-
-#        ["ubuntu-latest"]
-#      java-versions: >-
-#        ["11"]
-#      preserve-cache-between-runs: true
-#
-#  publish-test-results:
-#    uses: ./.github/workflows/_publish_test_results.yml
-#    if: always()
-#    needs: [sbt-integration-tests]
+  maven-release:
+    uses: ./.github/workflows/maven_release.yml
+    needs: sbt-build
+  deploy-docs:
+    uses: ./.github/workflows/deploy_docs.yml
+    needs: sbt-build
+    # Only update Github Pages if this is a push to main
+    if: github.ref_type == "branch" && github.ref_name == "main"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,5 +21,5 @@ jobs:
   deploy-docs:
     uses: ./.github/workflows/deploy_docs.yml
     needs: sbt-build
-    # Only update Github Pages if this is a push to main
-    if: github.ref_type == 'branch' && github.ref_name == 'main'
+    # Only update Github Pages if this is a release tag
+    if: startsWith(github.ref, 'refs/tags/v')

--- a/build.sbt
+++ b/build.sbt
@@ -155,5 +155,5 @@ lazy val brambl = project
   )
 
 addCommandAlias("checkPR", s"; scalafixAll --check; scalafmtCheckAll; +test")
-addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; unidoc")
+addCommandAlias("preparePR", s"; scalafixAll; scalafmtAll; +test; unidoc")
 addCommandAlias("checkPRTestQuick", s"; scalafixAll --check; scalafmtCheckAll; testQuick")


### PR DESCRIPTION
## Purpose and Approach

- readded `+test` to `preparePR`. I verified that it works on my machine when using WSL
- updated GH Actions workflows such that maven release and GH Pages do not run unless build/test succeeds. Update to documentation portal will only occur if we are pushing to main
- Added Publish Test Results
- Added GH Deployments for releases (tag pushes) and snapshots (branch pushes)

## Testing

For push to any branch:
https://github.com/Topl/BramblSc/actions/runs/6893972552

For push to main; I will manually check that the workflow ran properly once merged. Should be similar to any branch

For tags; I will manually check that the workflow ran properly once a release is created. Should deploy pages and deploy to releases 

## Tickets
* closes TSDK-637