### PR TITLE
TSDK-638 Filter out UnknownType

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -31,6 +31,7 @@ import co.topl.brambl.syntax.{
   valueToQuantitySyntaxOps,
   valueToTypeIdentifierSyntaxOps,
   LvlType,
+  UnknownType,
   ValueTypeIdentifier
 }
 import com.google.protobuf.struct.Struct
@@ -167,8 +168,9 @@ trait TransactionBuilderApi[F[_]] {
    * recipient will be transferred to the change address.
    *
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain some token
-   *             matching tokenIdentifier (if it is provided) and at least the quantity of LVLs to satisfy the fee. All
-   *             TXOs must contain values of valid type. Else an error will be returned.
+   *             matching tokenIdentifier (if it is provided) and at least the quantity of LVLs to satisfy the fee. Else
+   *             an error will be returned. Any TXOs that contain values of an invalid type, such as UnknownType, will be
+   *             filtered out and won't be included in the inputs.
    * @param lockPredicateFrom The Lock Predicate encumbering the txos
    * @param recipientLockAddress The LockAddress of the recipient
    * @param changeLockAddress A LockAddress to send the tokens that are not going to the recipient
@@ -195,13 +197,13 @@ trait TransactionBuilderApi[F[_]] {
    *       descriptor type is LIQUID.
    * @note This function only support transferring a specific amount of TOPLs (via tokenIdentifier) if their staking
    *       registration is None.
-   *
    * @param tokenIdentifier The Token Identifier denoting the type of token to transfer to the recipient. If this denotes
    *                        an Asset Token, the referenced asset's quantity descriptor type must be LIQUID, else an error
    *                        will be returned. This must not be UnknownType.
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain at least the
    *             necessary quantity (given by amount) of the identified Token and at least the quantity of LVLs to
-   *             satisfy the fee. All TXOs must contain values of valid type. Else an error will be returned.
+   *             satisfy the fee. Else an error will be returned. Any TXOs that contain values of an invalid type, such
+   *             as UnknownType, will be filtered out and won't be included in the inputs.
    * @param lockPredicateFrom The Lock Predicate encumbering the txos
    * @param amount The amount of identified Token to transfer to the recipient
    * @param recipientLockAddress The LockAddress of the recipient
@@ -226,8 +228,9 @@ trait TransactionBuilderApi[F[_]] {
    * contain more tokens.
    *
    * @param txos All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain some LVLs (as
-   *             specified in the policy), to satisfy the registration fee. All TXOs must contain values of valid type.
-   *             Else an error will be returned.
+   *             specified in the policy), to satisfy the registration fee. Else an error will be returned. Any TXOs
+   *             that contain values of an invalid type, such as UnknownType, will be filtered out and won't be included
+   *             in the inputs.
    * @param lockPredicateFrom The Predicate Lock that encumbers the funds in the txos. This will be used in
    *                         the attestations of the inputs.
    * @param groupPolicy The group policy for which we are minting constructor tokens. This group policy specifies a
@@ -255,8 +258,9 @@ trait TransactionBuilderApi[F[_]] {
    * contain more tokens.
    *
    * @param txos              All the TXOs encumbered by the Lock given by lockPredicateFrom. These TXOs must contain
-   *                          some LVLs (as specified in the policy), to satisfy the registration fee. All TXOs must
-   *                          contain values of valid type. Else an error will be returned.
+   *                          some LVLs (as specified in the policy), to satisfy the registration fee. Else an error will
+   *                          be returned. Any TXOs that contain values of an invalid type, such as UnknownType, will be
+   *                          filtered out and won't be included in the inputs.
    * @param lockPredicateFrom The Predicate Lock that encumbers the funds in the txos. This will be used in
    *                          the attestations of the inputs.
    * @param seriesPolicy The series policy for which we are minting constructor tokens. This series policy specifies a
@@ -289,7 +293,8 @@ trait TransactionBuilderApi[F[_]] {
    * @param mintingStatement      The minting statement that specifies the asset to mint.
    * @param txos                  All the TXOs encumbered by the Locks given by locks. These TXOs must contain some
    *                              group and series constructors (as referenced in the AMS) to satisfy the minting
-   *                              requirements. All TXOs must contain values of valid type. Else an error will be returned.
+   *                              requirements. Else an error will be returned. Any TXOs that contain values of an invalid
+   *                              type, such as UnknownType, will be filtered out and won't be included in the inputs.
    * @param locks             A mapping of Predicate Locks that encumbers the funds in the txos. This will be used in the
    *                              attestations of the txos' inputs.
    * @param fee The transaction fee. The txos must contain enough LVLs to satisfy this fee
@@ -379,13 +384,14 @@ object TransactionBuilderApi {
       ): F[Either[BuilderError, IoTransaction]] = (
         for {
           fromLockAddr <- EitherT.right(lockAddress(Lock().withPredicate(lockPredicateFrom)))
+          filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
-            .fromEither[F](validateTransferAllParams(txos, fromLockAddr, fee, tokenIdentifier))
+            .fromEither[F](validateTransferAllParams(filteredTxos, fromLockAddr, fee, tokenIdentifier))
             .leftMap(errs => UserInputErrors(errs.toList))
           stxoAttestation <- EitherT.right(unprovenAttestation(lockPredicateFrom))
           datum           <- EitherT.right(datum())
-          stxos           <- buildStxos(txos, stxoAttestation)
-          utxos           <- buildUtxos(txos, tokenIdentifier, None, recipientLockAddr, changeLockAddr, fee)
+          stxos           <- buildStxos(filteredTxos, stxoAttestation)
+          utxos           <- buildUtxos(filteredTxos, tokenIdentifier, None, recipientLockAddr, changeLockAddr, fee)
         } yield IoTransaction(inputs = stxos, outputs = utxos, datum = datum)
       ).value
 
@@ -400,13 +406,21 @@ object TransactionBuilderApi {
       ): F[Either[BuilderError, IoTransaction]] = (
         for {
           fromLockAddr <- EitherT.right(lockAddress(Lock().withPredicate(lockPredicateFrom)))
+          filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
-            .fromEither[F](validateTransferAmountParams(txos, fromLockAddr, amount, transferType, fee))
+            .fromEither[F](validateTransferAmountParams(filteredTxos, fromLockAddr, amount, transferType, fee))
             .leftMap(errs => UserInputErrors(errs.toList))
           stxoAttestation <- EitherT.right(unprovenAttestation(lockPredicateFrom))
           datum           <- EitherT.right(datum())
-          stxos           <- buildStxos(txos, stxoAttestation)
-          utxos <- buildUtxos(txos, transferType.some, BigInt(amount).some, recipientLockAddr, changeLockAddr, fee)
+          stxos           <- buildStxos(filteredTxos, stxoAttestation)
+          utxos <- buildUtxos(
+            filteredTxos,
+            transferType.some,
+            BigInt(amount).some,
+            recipientLockAddr,
+            changeLockAddr,
+            fee
+          )
         } yield IoTransaction(inputs = stxos, outputs = utxos, datum = datum)
       ).value
 
@@ -478,10 +492,11 @@ object TransactionBuilderApi {
       ): F[Either[BuilderError, IoTransaction]] = (
         for {
           registrationLockAddr <- EitherT.right[BuilderError](lockAddress(Lock().withPredicate(lockPredicateFrom)))
+          filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
             .fromEither[F](
               validateConstructorMintingParams(
-                txos,
+                filteredTxos,
                 registrationLockAddr,
                 groupPolicy.registrationUtxo,
                 quantityToMint,
@@ -490,12 +505,12 @@ object TransactionBuilderApi {
             )
             .leftMap(errs => UserInputErrors(errs.toList))
           stxoAttestation <- EitherT.right[BuilderError](unprovenAttestation(lockPredicateFrom))
-          stxos           <- buildStxos(txos, stxoAttestation)
+          stxos           <- buildStxos(filteredTxos, stxoAttestation)
           datum           <- EitherT.right[BuilderError](datum())
           utxoMinted <- EitherT.right[BuilderError](
             groupOutput(mintedAddress, quantityToMint, groupPolicy.computeId, groupPolicy.fixedSeries)
           )
-          utxoChange <- buildUtxos(txos, None, None, changeAddress, changeAddress, fee)
+          utxoChange <- buildUtxos(filteredTxos, None, None, changeAddress, changeAddress, fee)
         } yield IoTransaction(
           inputs = stxos,
           outputs = utxoChange :+ utxoMinted,
@@ -515,10 +530,11 @@ object TransactionBuilderApi {
       ): F[Either[BuilderError, IoTransaction]] = (
         for {
           registrationLockAddr <- EitherT.right[BuilderError](lockAddress(Lock().withPredicate(lockPredicateFrom)))
+          filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
             .fromEither[F](
               validateConstructorMintingParams(
-                txos,
+                filteredTxos,
                 registrationLockAddr,
                 seriesPolicy.registrationUtxo,
                 quantityToMint,
@@ -527,7 +543,7 @@ object TransactionBuilderApi {
             )
             .leftMap(errs => UserInputErrors(errs.toList))
           stxoAttestation <- EitherT.right[BuilderError](unprovenAttestation(lockPredicateFrom))
-          stxos           <- buildStxos(txos, stxoAttestation)
+          stxos           <- buildStxos(filteredTxos, stxoAttestation)
           datum           <- EitherT.right[BuilderError](datum())
           utxoMinted <- EitherT.right[BuilderError](
             seriesOutput(
@@ -539,7 +555,7 @@ object TransactionBuilderApi {
               seriesPolicy.quantityDescriptor
             )
           )
-          utxoChange <- buildUtxos(txos, None, None, changeAddress, changeAddress, fee)
+          utxoChange <- buildUtxos(filteredTxos, None, None, changeAddress, changeAddress, fee)
         } yield IoTransaction(
           inputs = stxos,
           outputs = utxoChange :+ utxoMinted,
@@ -570,20 +586,21 @@ object TransactionBuilderApi {
         commitment:             Option[ByteString]
       ): F[Either[BuilderError, IoTransaction]] = (
         for {
+          datum <- EitherT.right[BuilderError](datum())
+          filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
-            .fromEither[F](validateAssetMintingParams(mintingStatement, txos, locks.keySet, fee))
+            .fromEither[F](validateAssetMintingParams(mintingStatement, filteredTxos, locks.keySet, fee))
             .leftMap(errs => UserInputErrors(errs.toList))
-          datum        <- EitherT.right[BuilderError](datum())
-          attestations <- toAttestationMap(txos, locks)
+          attestations <- toAttestationMap(filteredTxos, locks)
           stxos        <- attestations.map(el => buildStxos(el._1, el._2)).toSeq.sequence.map(_.flatten)
           // Per validation, there is exactly one series token in txos
-          (seriesTxo, nonSeriesTxo) = txos
+          (seriesTxo, nonSeriesTxo) = filteredTxos
             .partition(_.outputAddress == mintingStatement.seriesTokenUtxo)
             .leftMap(_.head)
           seriesUtxo = seriesTxo.transactionOutput
           seriesToken = seriesUtxo.value.getSeries
           // Per validation, there is exactly one group token in txos
-          groupToken = txos
+          groupToken = filteredTxos
             .filter(_.outputAddress == mintingStatement.groupTokenUtxo)
             .head
             .transactionOutput

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -193,7 +193,7 @@ object UserInputValidations {
           "lockPredicateFrom"
         ),
         validTransferSupplyAll(tokenIdentifier, allValues.map(_.typeIdentifier)),
-        noUnknownType(allValues.map(_.typeIdentifier) ++ tokenIdentifier.toSeq),
+        noUnknownType(tokenIdentifier.toSeq),
         validFee(fee, allValues)
       ).fold.toEither
     } match {
@@ -221,7 +221,7 @@ object UserInputValidations {
           "the txos",
           "lockPredicateFrom"
         ),
-        noUnknownType(allValues.map(_.typeIdentifier) :+ transferIdentifier).andThen(_ =>
+        noUnknownType(Seq(transferIdentifier)).andThen(_ =>
           validTransferSupplyAmount(amount, allValues, transferIdentifier)
         ),
         toplNoStakingReg(transferIdentifier, "tokenIdentifier"),
@@ -254,7 +254,6 @@ object UserInputValidations {
           "lockPredicateFrom"
         ),
         positiveQuantity(quantityToMint, "quantityToMint"),
-        noUnknownType(txos.map(_.transactionOutput.value.value.typeIdentifier)),
         validFee(fee, txos.map(_.transactionOutput.value.value))
       ).fold.toEither
     } match {
@@ -286,7 +285,6 @@ object UserInputValidations {
             .andThen(s => validMintingSupply(mintingStatement.quantity, s).map(_ => s))
         ).andThen(res => fixedSeriesMatch(res._1.fixedSeries, res._2.seriesId)),
         positiveQuantity(mintingStatement.quantity, "quantity to mint"),
-        noUnknownType(txos.map(_.transactionOutput.value.value.typeIdentifier)),
         validFee(fee, txos.map(_.transactionOutput.value.value))
       ).fold.toEither
     } match {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
@@ -39,11 +39,15 @@ class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderIn
     )
   }
 
-  test("unsupported token type in txos") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildMintAssetTransaction
       .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildMintAssetTransaction.run // The only difference is the unsupported txo is not present
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("a lock from the lock map not in the txos") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
@@ -14,12 +14,19 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTokenIdentifier(assetGroupSeries.value.typeIdentifier)
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupMintingSpec.scala
@@ -40,11 +40,15 @@ class TransactionBuilderInterpreterGroupMintingSpec extends TransactionBuilderIn
     )
   }
 
-  test("unsupported token type in txos") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildMintGroupTransaction
       .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildMintGroupTransaction.run // The only difference is the unsupported txo is not present
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("registrationUtxo does not contain lvls") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -21,12 +21,19 @@ class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderI
     assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
   }
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(groupValue.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTokenIdentifier(groupValue.value.typeIdentifier)
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -13,11 +13,17 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesMintingSpec.scala
@@ -40,11 +40,15 @@ class TransactionBuilderInterpreterSeriesMintingSpec extends TransactionBuilderI
     )
   }
 
-  test("unsupported token type in txos") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildMintSeriesTransaction
       .addTxo(valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildMintSeriesTransaction.run // The only difference is the unsupported txo is not present
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("registrationUtxo does not contain lvls") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
@@ -13,12 +13,19 @@ import co.topl.brambl.syntax.{
 
 class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(seriesValue.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTokenIdentifier(seriesValue.value.typeIdentifier)
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAmountTransaction > quantity to transfer is non positive") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterToplTransferSpec.scala
@@ -6,12 +6,19 @@ import co.topl.brambl.syntax.{ioTransactionAsTransactionSyntaxOps, valueToTypeId
 
 class TransactionBuilderInterpreterToplTransferSpec extends TransactionBuilderInterpreterSpecBase {
 
-  test("buildTransferAmountTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTokenIdentifier(toplValue.value.typeIdentifier)
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTokenIdentifier(toplValue.value.typeIdentifier)
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAmountTransaction > Topl with staking registration") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterTransferAllSpec.scala
@@ -33,11 +33,17 @@ class TransactionBuilderInterpreterTransferAllSpec extends TransactionBuilderInt
     )
   }
 
-  test("buildTransferAllTransaction > unsupported token type (txos)") {
+  test("unsupported token type in txos is filtered out/ignored") {
     val testTx = buildTransferAmountTransaction
       .withTxos(mockTxos :+ valToTxo(Value.defaultInstance)) // Value.empty
       .run
-    assertEquals(testTx, Left(UserInputErrors(Seq(UserInputError(s"UnknownType tokens are not supported.")))))
+    val expectedTx = buildTransferAmountTransaction
+      .withTxos(mockTxos) // The only difference is the unsupported txo is not present
+      .run
+    assert(
+      (testTx.isRight && expectedTx.isRight) &&
+      sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx.toOption.get).computeId
+    )
   }
 
   test("buildTransferAllTransaction > All locks don't match") {

--- a/documentation/docs/reference/prove.mdx
+++ b/documentation/docs/reference/prove.mdx
@@ -91,7 +91,6 @@ import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.codecs.AddressCodecs.decodeAddress
-import co.topl.brambl.syntax.{UnknownType, valueToTypeIdentifierSyntaxOps}
 import co.topl.brambl.dataApi.{GenusQueryAlgebra, RpcChannelResource}
 import co.topl.brambl.servicekit.WalletStateResource
 import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi}
@@ -112,7 +111,6 @@ val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, 
 val toAddr = decodeAddress("ptetP7jshHTuV9bmPmtVLm6PtUzBMZ8iYRvAxvbGTJ5VgiEPHqCCnZ8MLLdi").toOption.get
 
 val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
-val genusQuery = GenusQueryAlgebra.make[IO](channelResource)
 val walletApi = WalletApi.make[IO](WalletKeyApi.make())
 val walletStateApi = WalletStateApi.make[IO](walletConnection, walletApi)
 val credentialler = CredentiallerInterpreter.make[IO](walletApi, walletStateApi, mainKey)
@@ -123,8 +121,7 @@ val predicateTemplate: LockTemplate[IO] = PredicateTemplate[IO](Seq(HeightTempla
 val tx = for {
   fromLock <- predicateTemplate.build(List.empty).map(_.toOption.get)
   fromAddr <- transactionBuilderApi.lockAddress(fromLock)
-  txos <- genusQuery.queryUtxo(fromAddr)
-  fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
+  fromTxos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
   unprovenTx <- transactionBuilderApi.buildTransferAllTransaction(fromTxos, fromLock.getPredicate, toAddr, toAddr, 1L)
   // Proving begins here:
   provenTx <- credentialler.prove(unprovenTx.toOption.get)
@@ -185,7 +182,6 @@ import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.codecs.AddressCodecs.decodeAddress
-import co.topl.brambl.syntax.{UnknownType, valueToTypeIdentifierSyntaxOps}
 import co.topl.brambl.dataApi.{GenusQueryAlgebra, RpcChannelResource}
 import co.topl.brambl.models.{Datum, Event}
 import co.topl.brambl.servicekit.WalletStateResource
@@ -220,8 +216,7 @@ val invalidHeight = "header" -> Datum().withHeader(Datum.Header(Event.Header(0))
 val unprovenTx = for {
   fromLock <- predicateTemplate.build(List.empty).map(_.toOption.get)
   fromAddr <- transactionBuilderApi.lockAddress(fromLock)
-  txos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
-  fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
+  fromTxos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
   unprovenTxRes <- transactionBuilderApi.buildTransferAllTransaction(fromTxos, fromLock.getPredicate, toAddr, toAddr, 1L)
 } yield unprovenTxRes.toOption.get
 

--- a/documentation/docs/reference/rpc.mdx
+++ b/documentation/docs/reference/rpc.mdx
@@ -113,7 +113,6 @@ import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.codecs.AddressCodecs.decodeAddress
-import co.topl.brambl.syntax.{UnknownType, valueToTypeIdentifierSyntaxOps}
 import co.topl.brambl.dataApi.{BifrostQueryAlgebra, GenusQueryAlgebra, RpcChannelResource}
 import co.topl.brambl.servicekit.WalletStateResource
 import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi}
@@ -127,11 +126,13 @@ val walletConnection = WalletStateResource.walletResource("wallet.db")
 // Some mock key pair. Do not use. Replace with your Topl main key pair.
 val mainKey = (new ExtendedEd25519).deriveKeyPairFromSeed(Array.fill(96)(0: Byte))
 
+// Replace with the address and port of your node's gRPC endpoint
+val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
+
 // Mock address. Replace with recipient address.
 val toAddr = decodeAddress("ptetP7jshHTuV9bmPmtVLm6PtUzBMZ8iYRvAxvbGTJ5VgiEPHqCCnZ8MLLdi").toOption.get
 
 val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
-val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
 val predicateTemplate: LockTemplate[IO] = PredicateTemplate[IO](Seq(HeightTemplate("header", 1, Long.MaxValue)), 1)
 val walletApi = WalletApi.make[IO](WalletKeyApi.make())
 val walletStateApi = WalletStateApi.make[IO](walletConnection, walletApi)
@@ -141,8 +142,7 @@ val bifrostQuery = BifrostQueryAlgebra.make[IO](channelResource)
 val tx = for {
   fromLock <- predicateTemplate.build(List.empty).map(_.toOption.get)
   fromAddr <- transactionBuilderApi.lockAddress(fromLock)
-  txos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
-  fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
+  fromTxos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
   unprovenTx <- transactionBuilderApi.buildTransferAllTransaction(fromTxos, fromLock.getPredicate, toAddr, toAddr, 1L)
   provenTx <- credentialler.prove(unprovenTx.toOption.get)
   // Broadcast starts here:

--- a/documentation/docs/reference/transactions/transfer.mdx
+++ b/documentation/docs/reference/transactions/transfer.mdx
@@ -74,23 +74,23 @@ import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.codecs.AddressCodecs.decodeAddress
-import co.topl.brambl.syntax.{LvlType, UnknownType, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.LvlType
 import co.topl.brambl.dataApi.{GenusQueryAlgebra, RpcChannelResource}
 
 // Mock address. Replace with recipient address.
 val toAddr = decodeAddress("ptetP7jshHTuV9bmPmtVLm6PtUzBMZ8iYRvAxvbGTJ5VgiEPHqCCnZ8MLLdi").toOption.get
 
-val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+// Replace with the address and port of your node's gRPC endpoint
 val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
-val genusQuery = GenusQueryAlgebra.make[IO](channelResource)
+
+val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
 val predicateTemplate: LockTemplate[IO] = PredicateTemplate[IO](Seq(HeightTemplate("header", 1, Long.MaxValue)), 1)
 
 // Transaction building starts here:
 val tx = for {
   fromLock <- predicateTemplate.build(List.empty).map(_.toOption.get)
   fromAddr <- transactionBuilderApi.lockAddress(fromLock)
-  txos <- genusQuery.queryUtxo(fromAddr)
-  fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
+  fromTxos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
   res <- transactionBuilderApi.buildTransferAmountTransaction(LvlType, fromTxos, fromLock.getPredicate, 1L, toAddr, toAddr, 1L)
 } yield res
 
@@ -146,23 +146,22 @@ import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
 import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
 import co.topl.brambl.codecs.AddressCodecs.decodeAddress
-import co.topl.brambl.syntax.{UnknownType, valueToTypeIdentifierSyntaxOps}
 import co.topl.brambl.dataApi.{GenusQueryAlgebra, RpcChannelResource}
 
 // Mock address. Replace with recipient address.
 val toAddr = decodeAddress("ptetP7jshHTuV9bmPmtVLm6PtUzBMZ8iYRvAxvbGTJ5VgiEPHqCCnZ8MLLdi").toOption.get
 
-val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+// Replace with the address and port of your node's gRPC endpoint
 val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
-val genusQuery = GenusQueryAlgebra.make[IO](channelResource)
+
+val transactionBuilderApi = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
 val predicateTemplate: LockTemplate[IO] = PredicateTemplate[IO](Seq(HeightTemplate("header", 1, Long.MaxValue)), 1)
 
 // Transaction building starts here:
 val tx = for {
   fromLock <- predicateTemplate.build(List.empty).map(_.toOption.get)
   fromAddr <- transactionBuilderApi.lockAddress(fromLock)
-  txos <- genusQuery.queryUtxo(fromAddr)
-  fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
+  fromTxos <- GenusQueryAlgebra.make[IO](channelResource).queryUtxo(fromAddr)
   res <- transactionBuilderApi.buildTransferAllTransaction(fromTxos, fromLock.getPredicate, toAddr, toAddr, 1L)
 } yield res
 


### PR DESCRIPTION
## Purpose

If the input parameter `txos` (in TransactionBuilder functions) contain an UnknownType parameter, filter it out instead of sending an error.

The reason for this change is that when spending from Genesis, there will always be an UpdateProposal value, thus always erroring out (forcing users to manually filter them out before hand). This became apparent when writing examples in the Documentation portal; for example

```
txos <- genusQuery.queryUtxo(fromAddr)
fromTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType) // <-- this line
res <- transactionBuilderApi.buildTransferAllTransaction(fromTxos, fromLock.getPredicate, toAddr, toAddr, 1L)
```

## Approach

- Allowed UnknownType to be provided and filter it out within the function (instead of expecting the user to do it before hand)
- updated tests
- Updated documentation examples

## Testing

- Ensured all unit tests pass
- Ensured all the updated examples can successfully be run

## Tickets
* closes TSDK-638