### PR TITLE
TSDK-646 Document Additional Wallet Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added documentation for using a wallet (extract main key, derive child keys) 
-- Added documentation wallet functionality using persistence (createAndSave, importAndSave, loadAndExtractMainKey) 
+- Added documentation wallet functionality using persistence (createAndSaveNewWallet, importWalletAndSave, loadAndExtractMainKey) 
 
 ## [v2.0.0-alpha4-SNAPSHOT] - - TODO replace date after release 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added documentation for using a wallet (extract main key, derive child keys) 
+- Added documentation wallet functionality using persistence (createAndSave, importAndSave, loadAndExtractMainKey) 
 
 ## [v2.0.0-alpha4-SNAPSHOT] - - TODO replace date after release 
 

--- a/documentation/docs/reference/wallets/create.mdx
+++ b/documentation/docs/reference/wallets/create.mdx
@@ -98,6 +98,12 @@ using `name` and `mnemonicName` respectively. On failure, this function returns
 a <ScaladocLink path="co/topl/brambl/wallet/WalletApi$$WalletApiFailure.html"><code>WalletApiFailure</code></ScaladocLink>
 which specifies the reason for failure.
 
+:::caution
+If you lose your *password*, you can use your *passphrase* and the generated mnemonic to recover your wallet (using import).
+It is critical to store the used passphrase and the generated mnemonic in a safe place. If you lose either of these,
+you will not be able to recover your wallet.
+:::
+
 ### Example
 
 The following snippet is an example of creating and saving a new wallet instance using Cats Effect

--- a/documentation/docs/reference/wallets/create.mdx
+++ b/documentation/docs/reference/wallets/create.mdx
@@ -7,7 +7,11 @@ description: Create a new Wallet from scratch
 import ScaladocLink from '@site/src/components/ScaladocLink';
 
 Creating a wallet involves generating your Topl main key pair. This main key pair is used to derive all keys that a user would
-use to create and prove transactions. You can create a new wallet using
+use to create and prove transactions.
+
+## Create a Wallet
+
+You can create a new wallet using
 the <ScaladocLink path="co/topl/brambl/wallet/WalletApi.html#createNewWallet(Array[Byte],Option[String],MnemonicSize):F[Either[WalletApiFailure,NewWalletResult[F]]]"><code>createNewWallet</code></ScaladocLink>
 function of a Wallet API instance.
 
@@ -40,15 +44,83 @@ It is critical to store the used passphrase and the generated mnemonic in a safe
 you will not be able to recover your wallet.
 :::
 
-## Example
+### Example
 
 The following example shows how to create a new wallet using the default of no passphrase and a mnemonic length of 12 words.
 
 ```scala
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import co.topl.brambl.wallet.WalletApi
 import co.topl.brambl.servicekit.WalletKeyApi
 
 val walletApi = WalletApi.make[IO](WalletKeyApi.make())
 val newWalletResult = walletApi.createNewWallet("password".getBytes)
+newWalletResult.unsafeRunSync()
+```
+
+## Create and Save a Wallet
+
+You can create a new wallet and save it to a specified Wallet Key persistence layer using
+the <ScaladocLink path="co/topl/brambl/wallet/WalletApi.html#createAndSaveNewWallet[G[_]](Array[Byte],Option[String],MnemonicSize,String,String)(Monad[G],ToMonad[G]):G[Either[WalletApiFailure,NewWalletResult[F]]]"><code>createAndSaveNewWallet</code></ScaladocLink>
+function of a Wallet API instance.
+
+```scala
+def createAndSaveNewWallet[G[_]: Monad: FunctionK[F, G]](
+  password:     Array[Byte],
+  passphrase:   Option[String] = None,
+  mLen:         MnemonicSize = MnemonicSizes.words12,
+  name:         String = "default",
+  mnemonicName: String = "mnemonic"
+): G[Either[WalletApi.WalletApiFailure, WalletApi.NewWalletResult[F]]]
+```
+
+This function generates a Topl main key pair, encrypts it with the provided password, and stores it in
+the `WalletKeyApiAlgebra` used to initialize the Wallet API instance.
+
+The parameters are as follows:
+- `password`: The password to encrypt the main key pair with
+- `passphrase`: An optional passphrase used to generate the main key pair. The default is no passphrase.
+- `mLen`: The length of the mnemonic to generate. The default is 12 words.
+- `name`: The name of the wallet to save. The default is "default". Most commonly, only one wallet identity will be used.
+- `mnemonicName`: The name of the mnemonic to save. The default is "mnemonic". Most commonly, only one mnemonic will be used.
+
+Type parameters:
+- `G`: The context, bound to a context parameter of type `Monad[G]` and transformable to `F` (using Cats `FunctionK`),
+where `F` is the type parameter used in the WalletApi instance. Most commonly, `G` will be the same as `F` and will be transformed
+using `FunctionK.id[F]`.
+
+On success, this function returns
+a <ScaladocLink path="co/topl/brambl/wallet/WalletApi$$NewWalletResult.html"><code>NewWalletResult</code></ScaladocLink>
+which contains the Topl main key pair encrypted into a `VaultStore` instance, as well as the mnemonic which can be used
+to later import the derived Topl main key pair. Both this `VaultStore` instance and mnemonic are persisted, and can be accessed
+using `name` and `mnemonicName` respectively. On failure, this function returns
+a <ScaladocLink path="co/topl/brambl/wallet/WalletApi$$WalletApiFailure.html"><code>WalletApiFailure</code></ScaladocLink>
+which specifies the reason for failure.
+
+### Example
+
+The following snippet is an example of creating and saving a new wallet instance using Cats Effect
+`IO` and the default implementation of the `WalletKeyApi` provided by
+the <ScaladocLink path="co/topl/brambl/servicekit/index.html"><code>ServiceKit</code></ScaladocLink>. This default implementation
+of the `WalletKeyApi` uses the local filesystem to persist the wallet and mnemonic.
+
+```scala
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.wallet.WalletApi
+import co.topl.brambl.servicekit.WalletKeyApi
+
+import java.io.File
+
+val walletApi = WalletApi.make[IO](WalletKeyApi.make())
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+val homeDir = System.getProperty("user.home")
+// Replace with the desired location for your key file
+val keyFile = new File(homeDir, "mainkey.json").getCanonicalPath
+// Replace with the desired location of for your mnemonic file
+val mnemonicFile = new File(homeDir, "mnemonic.txt").getCanonicalPath
+val newWalletResult = walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
+newWalletResult.unsafeRunSync()
 ```

--- a/documentation/docs/reference/wallets/import.mdx
+++ b/documentation/docs/reference/wallets/import.mdx
@@ -9,7 +9,11 @@ import ScaladocLink from '@site/src/components/ScaladocLink';
 
 Importing a wallet involves generating your existing Topl main key pair using your passphrase and your previously-derived mnemonic.
 This is also referred to as "Recovering a Wallet". If you do not have an existing wallet to import (or recover), see
-[Create a Wallet](./create). You can import your wallet using
+[Create a Wallet](./create).
+
+## Import a Wallet
+
+You can import your wallet using
 the <ScaladocLink path="co/topl/brambl/wallet/WalletApi.html#importWallet(IndexedSeq[String],Array[Byte],Option[String]):F[Either[WalletApiFailure,VaultStore[F]]]"><code>importWallet</code></ScaladocLink>
 function of a Wallet API instance.
 
@@ -38,13 +42,14 @@ The provided mnemonic and passphrase **must** be the same as the mnemonic and pa
 The password could be different.
 :::
 
-## Example
+### Example
 
 The following example shows how to import an existing wallet using a mnemonic. This example assumes that no passphrase
 was used in the initial creation of the existing wallet.
 
 ```scala
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import co.topl.brambl.wallet.WalletApi
 import co.topl.brambl.servicekit.WalletKeyApi
 
@@ -54,4 +59,73 @@ val walletApi = WalletApi.make[IO](WalletKeyApi.make())
 val someMnemonic = "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic"
 
 val recoverWalletResult = walletApi.importWallet(someMnemonic.split(" "), "password".getBytes)
+recoverWalletResult.unsafeRunSync()
+```
+
+## Import and Save a Wallet
+
+You can import an existing wallet and save it to a specified Wallet Key persistence layer using
+the <ScaladocLink path="co/topl/brambl/wallet/WalletApi.html#importWalletAndSave[G[_]](IndexedSeq[String],Array[Byte],Option[String],String)(Monad[G],ToMonad[G]):G[Either[WalletApiFailure,VaultStore[F]]]"><code>importWalletAndSave</code></ScaladocLink>
+function of a Wallet API instance.
+
+```scala
+def importWalletAndSave[G[_]: Monad: FunctionK[F, G]](
+  mnemonic:   IndexedSeq[String],
+  password:   Array[Byte],
+  passphrase: Option[String] = None,
+  name:       String = "default"
+): G[Either[WalletApi.WalletApiFailure, VaultStore[F]]]
+```
+
+This function generates the Topl main key pair associated to the mnemonic and passphrase, encrypts it with the provided
+password, and stores it in the `WalletKeyApiAlgebra` used to initialize the Wallet API instance.
+
+The parameters are as follows:
+- `mnemonic`: The mnemonic used to regenerate the existing Topl main key pair
+- `password`: The password to encrypt the generated Topl main key pair with
+- `passphrase`: An optional passphrase used to regenerate the existing Topl main key pair. The default is no passphrase.
+- `name`: The name of the wallet to save. The default is "default". Most commonly, only one wallet identity will be used.
+
+Type parameters:
+- `G`: The context, bound to a context parameter of type `Monad[G]` and transformable to `F` (using Cats `FunctionK`),
+where `F` is the type parameter used in the WalletApi instance. Most commonly, `G` will be the same as `F` and will be transformed
+using `FunctionK.id[F]`.
+
+On success, this function returns the regenerated Topl main key pair encrypted into a `VaultStore` instance. This
+`VaultStore` instance is persisted and can be later accessed using the specified `name`. On failure, this function returns
+a <ScaladocLink path="co/topl/brambl/wallet/WalletApi$$WalletApiFailure.html"><code>WalletApiFailure</code></ScaladocLink>
+which specifies the reason for failure.
+
+:::note
+The provided mnemonic and passphrase **must** be the same as the mnemonic and passphrase used to generate the original Topl main key pair.
+The password could be different.
+:::
+
+### Example
+
+The following snippet is an example of importing and saving an existing wallet (given by a mnemonic) using Cats Effect
+`IO` and the default implementation of the `WalletKeyApi` provided by
+the <ScaladocLink path="co/topl/brambl/servicekit/index.html"><code>ServiceKit</code></ScaladocLink>. This default implementation
+of the `WalletKeyApi` uses the local filesystem to persist the wallet and mnemonic.
+
+```scala
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.wallet.WalletApi
+import co.topl.brambl.servicekit.WalletKeyApi
+
+import java.io.File
+
+val walletApi = WalletApi.make[IO](WalletKeyApi.make())
+
+// Some mock mnemonic. Replace with your own.
+val someMnemonic = "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic"
+
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+val homeDir = System.getProperty("user.home")
+// Replace with the desired location for your key file
+val keyFile = new File(homeDir, "mainkey.json").getCanonicalPath
+val newWalletResult = walletApi.importWalletAndSave[IO](someMnemonic.split(" "), "password".getBytes, name = keyFile)
+newWalletResult.unsafeRunSync()
 ```

--- a/documentation/docs/reference/wallets/usage.mdx
+++ b/documentation/docs/reference/wallets/usage.mdx
@@ -8,7 +8,7 @@ import ScaladocLink from '@site/src/components/ScaladocLink';
 
 With a wallet, you can generate key pairs for use in the Topl network. Topl uses ExtendedEd25519 for our implementation
 of a hierarchical deterministic (HD) wallet. Using an HD wallet, you can derive many keys for a given "main" key.
-This page will walk you through the process of generating a Topl main key pair as well as deriving child key pairs for a
+This page will walk you through the process of accessing your Topl main key pair as well as deriving child key pairs for a
 3-layer path (x/y/z).
 
 ## Prerequisites
@@ -28,7 +28,7 @@ val walletApi = WalletApi.make[IO](WalletKeyApi.make())
 val newWalletResult = walletApi.createNewWallet(password)
 ```
 
-## Generate a Topl Main Key Pair
+## Decrypt a Topl Main Key Pair
 
 During wallet initialization, a Topl main key pair is generated and encrypted in a `VaultStore`. To use this key pair
 you must first decrypt it by extracting it from the `VaultStore`. This can be achieved by using
@@ -76,6 +76,79 @@ val mainKey = for {
   decryptedKey <- walletApi.extractMainKey(newWallet.toOption.get.mainKeyVaultStore, password)
 } yield decryptedKey.toOption.get
 
+mainKey.unsafeRunSync()
+```
+
+## Load and Decrypt a Topl Main Key Pair
+
+If your wallet was saved to the Wallet Key persistence layer during wallet initialization (for example, by
+using [Create and Save a Wallet](./create#create-and-save-a-wallet) or [Import and Save a Wallet](./import#import-and-save-a-wallet)),
+your Topl main key pair can be loaded and decrypted in a single step. This can be achieved by using
+the <ScaladocLink path="co/topl/brambl/wallet/WalletApi.html#loadAndExtractMainKey[G[_]](Array[Byte],String)(Monad[G],ToMonad[G]):G[Either[WalletApiFailure,KeyPair]]"><code>loadAndExtractMainKey</code></ScaladocLink>
+function of a Wallet API instance.
+
+```scala
+def loadAndExtractMainKey[G[_]: Monad: FunctionK[F, G]](
+  password: Array[Byte],
+  name:     String = "default"
+): G[Either[WalletApi.WalletApiFailure, KeyPair]]
+```
+
+This function loads an encrypted wallet (specified by `name`) from the `WalletKeyApiAlgebra` used to initialize the
+Wallet API, and then extracts and decrypts the Topl main key pair contained within it using the given password.
+
+The parameters are as follows:
+- `password`: The password used to encrypt the `VaultStore`.
+- `name`: The name of the wallet to load. Defaults to "default".
+
+Type parameters:
+- `G`: The context, bound to a context parameter of type `Monad[G]` and transformable to `F` (using Cats `FunctionK`),
+where `F` is the type parameter used in the WalletApi instance. Most commonly, `G` will be the same as `F` and will be transformed
+using `FunctionK.id[F]`.
+
+On success, the function returns the decrypted Topl
+main [key pair](https://github.com/Topl/protobuf-specs/blob/main/proto/quivr/models/shared.proto#L78). On failure, the function returns
+a <ScaladocLink path="co/topl/brambl/wallet/WalletApi$$WalletApiFailure.html"><code>WalletApiFailure</code></ScaladocLink>
+which specifies the reason for failure.
+
+:::caution
+For maximum security, the Topl main key pair should never be used to create and prove transactions. Instead, use a
+child key pair derived from the Topl main key pair.
+:::
+
+### Example
+
+The following example shows how to load a wallet and extract its Topl main key pair after previously persisting it using
+the default implementation of the `WalletKeyApi` provided by
+the <ScaladocLink path="co/topl/brambl/servicekit/index.html"><code>ServiceKit</code></ScaladocLink>. This default implementation
+of the `WalletKeyApi` uses the local filesystem to persist the wallet and mnemonic..
+
+```scala
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.wallet.WalletApi
+import co.topl.brambl.servicekit.WalletKeyApi
+
+import java.io.File
+
+val walletApi = WalletApi.make[IO](WalletKeyApi.make())
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+
+val homeDir = System.getProperty("user.home")
+// Replace with the desired location for your key file
+val keyFile = new File(homeDir, "mainkey.json").getCanonicalPath
+// Replace with the desired location of for your mnemonic file
+val mnemonicFile = new File(homeDir, "mnemonic.txt").getCanonicalPath
+
+val password = "password".getBytes
+
+walletApi.createAndSaveNewWallet[IO](password, name = keyFile, mnemonicName = mnemonicFile).unsafeRunSync()
+
+// Load and extract begins here:
+val mainKey = for {
+  decryptedKey <- walletApi.loadAndExtractMainKey[IO](password, keyFile)
+} yield decryptedKey.toOption.get
 mainKey.unsafeRunSync()
 ```
 


### PR DESCRIPTION
## Purpose

To document the wallet functionality that use persistence (WalletKeyApi). These include persisting a created wallet: `createAndSaveNewWallet`, `importWalletAndSave`, as well as using a persisted wallet: `loadAndExtractMainKey`

## Approach

Documented the 3 functions as 3 use cases under "Wallet Keys" in the documentation portal

## Testing

No code changes, but ensured all examples run successfully 

## Tickets
* closes TSDK-646
