### PR TITLE
TSDK-641 Usability Improvements for CLI (get block by depth)

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
@@ -8,6 +8,7 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.consensus.models.BlockId
 import co.topl.node.models.BlockBody
 import io.grpc.ManagedChannel
+import co.topl.consensus.models.BlockHeader
 
 /**
  * Defines a Bifrost Query API for interacting with a Bifrost node.
@@ -17,21 +18,30 @@ trait BifrostQueryAlgebra[F[_]] {
   /**
    * Fetches a block by its height.
    * @param height The height of the block to fetch.
-   * @return The BlockId, BlockBody, and contained transactions of the fetched block, if it exists.
+   * @return The BlockId, BlockHeader, BlockBody, and contained transactions of the fetched block, if it exists.
    */
   def blockByHeight(
     height: Long
-  ): F[Option[(BlockId, BlockBody, Seq[IoTransaction])]]
+  ): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]]
+
+  /**
+   * Fetches a block by its depth.
+   * @param height The depth of the block to fetch. The depth 1 is the tip of the chain.
+   * @return The BlockId, BlockHeader, BlockBody, and contained transactions of the fetched block, if it exists.
+   */
+  def blockByDepth(
+    depth: Long
+  ): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]]
 
   /**
    * Fetches a block by its Id.
    *
    * @param blockId The Id of the block to fetch.
-   * @return The BlockId, BlockBody, and contained transactions of the fetched block, if it exists.
+   * @return The BlockId, BlockHeader, BlockBody, and contained transactions of the fetched block, if it exists.
    */
   def blockById(
     blockId: BlockId
-  ): F[Option[(BlockId, BlockBody, Seq[IoTransaction])]]
+  ): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]]
 
   /**
    * Fetches a transaction by its Id.
@@ -57,9 +67,14 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
 
   case class FetchBlockBody(blockId: BlockId) extends BifrostQueryADT[Option[BlockBody]]
 
+  case class FetchBlockHeader(blockId: BlockId) extends BifrostQueryADT[Option[BlockHeader]]
+
   case class FetchTransaction(txId: TransactionId) extends BifrostQueryADT[Option[IoTransaction]]
 
   case class BlockByHeight(height: Long) extends BifrostQueryADT[Option[BlockId]]
+
+  case class BlockByDepth(depth: Long) extends BifrostQueryADT[Option[BlockId]]
+
   case class BroadcastTransaction(tx: IoTransaction) extends BifrostQueryADT[TransactionId]
 
   type BifrostQueryADTMonad[A] = Free[BifrostQueryADT, A]
@@ -69,6 +84,11 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
   ): BifrostQueryADTMonad[Option[BlockBody]] =
     Free.liftF(FetchBlockBody(blockId))
 
+  def fetchBlockHeaderF(
+    blockId: BlockId
+  ): BifrostQueryADTMonad[Option[BlockHeader]] =
+    Free.liftF(FetchBlockHeader(blockId))
+
   def fetchTransactionF(
     txId: TransactionId
   ): BifrostQueryADTMonad[Option[IoTransaction]] =
@@ -77,24 +97,43 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
   def blockByHeightF(height: Long): BifrostQueryADTMonad[Option[BlockId]] =
     Free.liftF(BlockByHeight(height))
 
+  def blockByDepthF(depth: Long): BifrostQueryADTMonad[Option[BlockId]] =
+    Free.liftF(BlockByDepth(depth))
+
   def broadcastTransactionF(tx: IoTransaction): BifrostQueryADTMonad[TransactionId] =
     Free.liftF(BroadcastTransaction(tx))
 
   def make[F[_]: Sync](channelResource: Resource[F, ManagedChannel]): BifrostQueryAlgebra[F] =
     new BifrostQueryAlgebra[F] {
 
-      override def blockById(
-        blockId: BlockId
-      ): F[Option[(BlockId, BlockBody, Seq[IoTransaction])]] = {
+      override def blockByDepth(depth: Long): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = {
         import cats.implicits._
         interpretADT(
           channelResource,
           (for {
-            blockBody <- OptionT(fetchBlockBodyF(blockId))
+            blockId     <- OptionT(blockByDepthF(depth))
+            blockHeader <- OptionT(fetchBlockHeaderF(blockId))
+            blockBody   <- OptionT(fetchBlockBodyF(blockId))
             transactions <- blockBody.transactionIds
               .map(txId => OptionT(fetchTransactionF(txId)))
               .sequence
-          } yield (blockId, blockBody, transactions)).value
+          } yield (blockId, blockHeader, blockBody, transactions)).value
+        )
+      }
+
+      override def blockById(
+        blockId: BlockId
+      ): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = {
+        import cats.implicits._
+        interpretADT(
+          channelResource,
+          (for {
+            blockBody   <- OptionT(fetchBlockBodyF(blockId))
+            blockHeader <- OptionT(fetchBlockHeaderF(blockId))
+            transactions <- blockBody.transactionIds
+              .map(txId => OptionT(fetchTransactionF(txId)))
+              .sequence
+          } yield (blockId, blockHeader, blockBody, transactions)).value
         )
       }
 
@@ -103,17 +142,18 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
       ): F[Option[IoTransaction]] =
         interpretADT(channelResource, fetchTransactionF(txId))
 
-      def blockByHeight(height: Long): F[Option[(BlockId, BlockBody, Seq[IoTransaction])]] = {
+      def blockByHeight(height: Long): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = {
         import cats.implicits._
         interpretADT(
           channelResource,
           (for {
-            blockId   <- OptionT(blockByHeightF(height))
-            blockBody <- OptionT(fetchBlockBodyF(blockId))
+            blockId     <- OptionT(blockByHeightF(height))
+            blockHeader <- OptionT(fetchBlockHeaderF(blockId))
+            blockBody   <- OptionT(fetchBlockBodyF(blockId))
             transactions <- blockBody.transactionIds
               .map(txId => OptionT(fetchTransactionF(txId)))
               .sequence
-          } yield (blockId, blockBody, transactions)).value
+          } yield (blockId, blockHeader, blockBody, transactions)).value
         )
       }
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
@@ -12,6 +12,8 @@ import co.topl.node.services.{
   NodeRpcGrpc
 }
 import io.grpc.ManagedChannel
+import co.topl.node.services.FetchBlockIdAtDepthReq
+import co.topl.node.services.FetchBlockHeaderReq
 
 /**
  * Defines an interpreter for Bifrost Query API.
@@ -32,6 +34,28 @@ trait BifrostQueryInterpreter {
         ): ChannelContextKlesli[A] = {
           import cats.implicits._
           fa match {
+            case BifrostQueryAlgebra.BlockByDepth(depth) =>
+              Kleisli(blockingStub =>
+                Sync[F]
+                  .blocking(
+                    blockingStub
+                      .fetchBlockIdAtDepth(
+                        FetchBlockIdAtDepthReq(depth)
+                      )
+                  )
+                  .map(_.blockId.asInstanceOf[A])
+              )
+            case BifrostQueryAlgebra.FetchBlockHeader(blockId) =>
+              Kleisli(blockingStub =>
+                Sync[F]
+                  .blocking(
+                    blockingStub
+                      .fetchBlockHeader(
+                        FetchBlockHeaderReq(blockId)
+                      )
+                  )
+                  .map(_.header.asInstanceOf[A])
+              )
             case BifrostQueryAlgebra.FetchBlockBody(blockId) =>
               Kleisli(blockingStub =>
                 Sync[F]

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -305,8 +305,8 @@ object WalletStateApi {
               query
             )
           )
-          address <- Sync[F].delay(rs.getString("address"))
-        } yield if (rs.next()) Some(address) else None
+          address <- Sync[F].delay(Option(rs.getString("address")))
+        } yield address
       }
 
       override def getCurrentIndicesForFunds(


### PR DESCRIPTION
## Purpose

As part of improving the usability of the CLI, we implemented full validation at broadcast time. This  validation requires to know the current height of the block and the current tick. Although this functionality is implemented in the node, the brambl-sdk did not support it. We implemented it in order to add the validation to the CLI.

## Approach

We implemented it by following the same pattern as before.

## Testing

All tests continue to pass.

## Tickets
* TSDK-641
