### PR TITLE
TSDK-647 Load Wallet Tutorial & Transfer to another Wallet Tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added documentation for using a wallet (extract main key, derive child keys) 
 - Added documentation wallet functionality using persistence (createAndSaveNewWallet, importWalletAndSave, loadAndExtractMainKey) 
+- Added documentation for updating a wallet state
+- Added tutorials: Load new wallet with Genesis funds, Transfer funds from one wallet to another
 
 ## [v2.0.0-alpha4-SNAPSHOT] - - TODO replace date after release 
 

--- a/documentation/docs/reference/getting-started.mdx
+++ b/documentation/docs/reference/getting-started.mdx
@@ -19,6 +19,8 @@ val bramblVersion = "2.0.0" // replace with the latest version
 libraryDependencies += "co.topl" %% "brambl-sdk" % bramblVersion
 ```
 
+The list of versions can be found [here](https://central.sonatype.com/artifact/co.topl/brambl-sdk_2.13/versions).
+
 ### Service Kit
 
 Wallet functionality in the Brambl SDK requires an implementation of a `ServiceKit` which is responsible for implementing

--- a/documentation/docs/tutorials/tutorials/_category_.json
+++ b/documentation/docs/tutorials/tutorials/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Tutorials (TBD)",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "Learn how to do common tasks with the SDK."
-  }
-}

--- a/documentation/docs/tutorials/tutorials/obtain-funds.md
+++ b/documentation/docs/tutorials/tutorials/obtain-funds.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 1
+title: Load Wallet with Funds
+description: Populate a wallet with LVL tokens from your Local Node
+---
+
+## Use Case
+
+Coming Soon
+
+Most of these tutorials require initial funds to be present in a wallet. This tutorial will show you how to load a wallet with LVL tokens from your Local Node.
+The funds come from the Genesis block in you Local Node.
+
+## Set-Up
+
+Run the following command to start your Local Node:
+
+```bash
+TBD
+```
+
+## Step X: Create and Initialize a Wallet
+
+TBD
+
+## Step X: Create Height Lock
+
+TBD
+
+## Step X: Query Genesis Funds
+
+TBD
+
+## Step X: Generate a New Lock Address to Receive Tokens
+
+TBD
+
+## Step X: Update Wallet State
+
+TBD
+
+## Step X: Create Transaction
+
+TBD
+
+## Step X: Prove Transaction
+
+TBD
+
+## Step X: Broadcast Transaction
+
+TBD
+
+## Optional Step: Check Balance
+
+TBD

--- a/documentation/docs/tutorials/tutorials/obtain-funds.md
+++ b/documentation/docs/tutorials/tutorials/obtain-funds.md
@@ -88,16 +88,26 @@ import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResou
 import co.topl.brambl.wallet.WalletApi
 
 import java.io.File
+import java.nio.file.Paths
 
 implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
 
-val tutorialDir = new File(System.getProperty("user.home"), "tutorial")
+// Replace with the desired location for your tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+   val filePath = Paths.get(tutorialDir, fileName).toString
+   new File(filePath).delete() // Clear the file if it already exists
+   filePath
+}
+
 // Replace with the desired location for your key file
-val keyFile = new File(tutorialDir, "keyfile.json").getCanonicalPath
+val keyFile = initFilePath("keyfile.json")
 // Replace with the desired location of for your mnemonic file
-val mnemonicFile = new File(tutorialDir, "mnemonic.txt").getCanonicalPath
+val mnemonicFile = initFilePath("mnemonic.txt")
 // Replace with the desired location of for your wallet state DB file
-val walletDb = new File(tutorialDir, "wallet.db").getCanonicalPath
+val walletDb = initFilePath("wallet.db")
 
 val walletKeyApi = WalletKeyApi.make[IO]()
 val walletApi = WalletApi.make(walletKeyApi)
@@ -192,16 +202,26 @@ import co.topl.brambl.syntax.LvlType
 import co.topl.brambl.wallet.WalletApi
 
 import java.io.File
+import java.nio.file.Paths
 
 implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
 
-val tutorialDir = new File(System.getProperty("user.home"), "tutorial")
+// Replace with the desired location for your tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+   val filePath = Paths.get(tutorialDir, fileName).toString
+   new File(filePath).delete() // Clear the file if it already exists
+   filePath
+}
+
 // Replace with the desired location for your key file
-val keyFile = new File(tutorialDir, "keyfile.json").getCanonicalPath
+val keyFile = initFilePath("keyfile.json")
 // Replace with the desired location of for your mnemonic file
-val mnemonicFile = new File(tutorialDir, "mnemonic.txt").getCanonicalPath
+val mnemonicFile = initFilePath("mnemonic.txt")
 // Replace with the desired location of for your wallet state DB file
-val walletDb = new File(tutorialDir, "wallet.db").getCanonicalPath
+val walletDb = initFilePath("wallet.db")
 
 val walletKeyApi = WalletKeyApi.make[IO]()
 val walletApi = WalletApi.make(walletKeyApi)
@@ -281,16 +301,26 @@ import co.topl.brambl.syntax.LvlType
 import co.topl.brambl.wallet.{CredentiallerInterpreter, WalletApi}
 
 import java.io.File
+import java.nio.file.Paths
 
 implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
 
-val tutorialDir = new File(System.getProperty("user.home"), "tutorial")
+// Replace with the desired location for your tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+   val filePath = Paths.get(tutorialDir, fileName).toString
+   new File(filePath).delete() // Clear the file if it already exists
+   filePath
+}
+
 // Replace with the desired location for your key file
-val keyFile = new File(tutorialDir, "keyfile.json").getCanonicalPath
+val keyFile = initFilePath("keyfile.json")
 // Replace with the desired location of for your mnemonic file
-val mnemonicFile = new File(tutorialDir, "mnemonic.txt").getCanonicalPath
+val mnemonicFile = initFilePath("mnemonic.txt")
 // Replace with the desired location of for your wallet state DB file
-val walletDb = new File(tutorialDir, "wallet.db").getCanonicalPath
+val walletDb = initFilePath("wallet.db")
 
 val walletKeyApi = WalletKeyApi.make[IO]()
 val walletApi = WalletApi.make(walletKeyApi)
@@ -377,16 +407,26 @@ import co.topl.brambl.syntax.{LvlType, valueToQuantitySyntaxOps, valueToTypeIden
 import co.topl.brambl.wallet.{CredentiallerInterpreter, WalletApi}
 
 import java.io.File
+import java.nio.file.Paths
 
 implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
 
-val tutorialDir = new File(System.getProperty("user.home"), "tutorial")
+// Replace with the desired location for your tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+   val filePath = Paths.get(tutorialDir, fileName).toString
+   new File(filePath).delete() // Clear the file if it already exists
+   filePath
+}
+
 // Replace with the desired location for your key file
-val keyFile = new File(tutorialDir, "keyfile.json").getCanonicalPath
+val keyFile = initFilePath("keyfile.json")
 // Replace with the desired location of for your mnemonic file
-val mnemonicFile = new File(tutorialDir, "mnemonic.txt").getCanonicalPath
+val mnemonicFile = initFilePath("mnemonic.txt")
 // Replace with the desired location of for your wallet state DB file
-val walletDb = new File(tutorialDir, "wallet.db").getCanonicalPath
+val walletDb = initFilePath("wallet.db")
 
 val walletKeyApi = WalletKeyApi.make[IO]()
 val walletApi = WalletApi.make(walletKeyApi)

--- a/documentation/docs/tutorials/tutorials/obtain-funds.md
+++ b/documentation/docs/tutorials/tutorials/obtain-funds.md
@@ -13,33 +13,143 @@ The funds come from the Genesis block in you Local Node.
 
 ## Set-Up
 
-Run the following command to start your Local Node:
+Get started with launching a Local Node:
 
-```bash
-TBD
-```
+1. [Get Docker](https://docs.docker.com/get-docker/)
+2. Pull latest node image
+   ```bash
+    docker pull docker.io/toplprotocol/bifrost-node:2.0.0-alpha10
+   ``` 
+3. Run a node
+   ```bash
+    docker run --rm -p 9085:9085 -p 9084:9084 -p 9091:9091 docker.io/toplprotocol/bifrost-node:2.0.0-alpha10
+   ```
 
 ## Step X: Create and Initialize a Wallet
 
-TBD
+Before we can load a wallet with funds, we need to create the wallet. There are 2 steps to this process: creating the wallet's 
+Topl main key and initializing the wallet state.
 
-## Step X: Create Height Lock
+### Create the Wallet's Topl Main Key
 
-TBD
+> See [Create a Wallet](../../reference/wallets/create)
 
-## Step X: Query Genesis Funds
+We will generate a new Topl Main Key for the wallet using `createAndSaveNewWallet`. This will also save the keyfile and 
+mnemonic to the local file system.
 
-TBD
+1. Initialize a Wallet Key API to persist the keyfile and mnemonic. Here we are using the provided default implementation
+provided by the Service Kit to persist to the local file system.
+   ```scala
+   val walletKeyApi = WalletKeyApi.make[IO]()
+   ```
+2. Using the `walletKeyApi` created above, initialize a Wallet Api
+   ```scala
+   val walletApi = WalletApi.make(walletKeyApi)
+   ```
+3. Using the `walletApi` created above, create and persist a new wallet using `createAndSaveNewWallet`
+   ```scala
+   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = "keyfile.json", mnemonicName = "mnemonic.txt")
+   ```
 
-## Step X: Generate a New Lock Address to Receive Tokens
+### Initialize the Wallet State
 
-TBD
+> See [Initialize Wallet State](../../reference/wallet-state#initialize-wallet-state)
 
-## Step X: Update Wallet State
 
-TBD
+We will initialize the wallet state using `initWalletState`. Here we are using the provided default implementation 
+provided by the Service Kit to persist to a SQLite database file.
+
+1. With the `walletApi` created in the previous section, initialize a Wallet State API
+   ```scala
+   val walletStateApi = WalletStateApi.make[IO](WalletStateResource.walletResource("wallet.db"), walletApi)
+   ```
+2. Using the `walletResult` created above, extract the Topl main key.
+   ```scala
+   mainKeyPair <- walletApi.extractMainKey(walletResult.mainKeyVaultStore, "password".getBytes())
+   ```
+3. Using the `mainKeyPair` created above, derive a child key at (1, 1).
+   ```scala
+   childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair, 1, 1)
+   ```
+4. Using the `childKeyPair` and `walletStateApi` created above, initialize the wallet state using `initWalletState`
+   ```scala
+   walletStateApi.initWalletState(MAIN_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+   ```
+
+### Breakpoint Check
+
+At this point, your code should look something like this:
+
+```scala
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.constants.NetworkConstants
+import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResource}
+import co.topl.brambl.wallet.WalletApi
+
+import java.io.File
+
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+
+val homeDir = System.getProperty("user.home")
+// Replace with the desired location for your key file
+val keyFile = new File(homeDir, "keyfile.json").getCanonicalPath
+// Replace with the desired location of for your mnemonic file
+val mnemonicFile = new File(homeDir, "mnemonic.txt").getCanonicalPath
+// Replace with the desired location of for your wallet state DB file
+val walletDb = new File(homeDir, "wallet.db").getCanonicalPath
+
+val walletKeyApi = WalletKeyApi.make[IO]()
+val walletApi = WalletApi.make(walletKeyApi)
+val walletStateApi = WalletStateApi.make[IO](WalletStateResource.walletResource(walletDb), walletApi)
+
+val initializeWallet = for {
+   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
+   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
+   childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
+   _ <- walletStateApi.initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_LEDGER_ID, childKeyPair.vk)
+} yield ()
+
+initializeWallet.unsafeRunSync()
+```
+
+Running this code would create 3 files in your home directory: `keyfile.json`, `mnemonic.txt`, and `wallet.db`.
 
 ## Step X: Create Transaction
+
+After you have a wallet initialized, the next step is to build a transaction that will populate your wallet with some funds. 
+This transaction should transfer funds from the Genesis block to your wallet.
+
+### Query Genesis Funds
+The Genesis block encumbers tokens with a height lock. To retrieve these tokens, we need to create the LockAddress for this Height Lock.
+This LockAddress will also be used as the change address for the transaction (any excess funds will go back to this Address).
+
+1. Retrieve HeightLock from the Wallet State API. Since we are using the provided default implementation of the Wallet State API,
+we can retrieve the HeightLock using the following code:
+   ```scala
+   heightLock <- walletStateApi.getLock("nofellowship", "genesis", 0)
+   ```
+2. Create a LockAddress from the HeightLock retrieved in the previous step. See [Initialize Wallet State](../../reference/locks/create-lock-addr)
+   ```scala
+   lockAddress <- TransactionBuilderApi.make[IO](MAIN_NETWORK_ID, MAIN_LEDGER_ID).lockAddress(heightLock)
+   ```
+3. With the LockAddress created in the previous step, we can query the Genesis block for funds. This will return a list of UTXOs
+which will be the inputs for the transaction.
+
+### Generate a New Lock Address to Receive Tokens
+
+The output of the transaction should be a new LockAddress that our wallet can prove ownership of. To create this LockAddress
+
+### Step X: Update Wallet State
+
+TBD
+
+### Build the Transaction
+
+TBD
+
+### Breakpoint Check
 
 TBD
 
@@ -54,3 +164,5 @@ TBD
 ## Optional Step: Check Balance
 
 TBD
+
+## Putting It All Together

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -1,21 +1,26 @@
 ---
 sidebar_position: 2
 title: Transfer Tokens
-description: How to transfer tokens from one wallet to another
+description: Transfer tokens from one wallet to another
 ---
 
 ## Use Case
 
-Coming Soon (send 10 LVLs from one wallet to another). 
+To send 10 LVLs from an existing wallet to a new wallet.
 
-In this tutorial, we have 2 users, each with their own wallet. The first is the Sender, the second is the recipient.
-
-For the purposes of this tutorial, we will assume that the Sender already has an initialized wallet with 100 LVLs.
-The sender wants to send 10 LVLs to the recipient.
-
-To illustrate setting up a wallet, the Recipient will create and initialize a new wallet.
+**Objectives:**
+- Create a new wallet and lock address (the recipient's wallet)
+- Share a LockAddress with another wallet by Encoding it as a Base58 string
+- Use the keys and state from an existing wallet (the sender's wallet)
+- Create a transaction to 
+  - transfer an amount of funds from one wallet to another
+  - transfer the remaining funds back to the original wallet in a new LockAddress
+- Check the balance of a LockAddress
 
 ## Set-Up
+
+In this tutorial, we have 2 users, each with their own wallet. The first is the Sender, the second is the Recipient.
+
 Throughout this tutorial, we will be alternating between the Sender and the Recipient's Point-of-View. To distinguish 
 between the two, each section will be marked with either "Sender" or "Recipient". We will also keep all the 
 generated files (key file, wallet file, etc.) in separate folders for each user.

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 2
+title: Transfer Tokens
+description: How to transfer tokens from one wallet to another
+---
+
+## Use Case
+
+Coming Soon (send 10 LVLs from one wallet to another). 
+
+In this tutorial, we have 2 users, each with their own wallet. The first is the Sender, the second is the recipient.
+
+For the purposes of this tutorial, we will assume that the Sender already has an initialized wallet with 100 LVLs.
+The sender wants to send 10 LVLs to the recipient.
+
+To illustrate setting up a wallet, the Recipient will create and initialize a new wallet.
+
+## Set-Up
+
+To follow along with this tutorial, you will need to initialize and fund the Sender's wallet with 100 LVLs.
+
+Following the instructions in the [Load Wallet with Funds](./obtain-funds) tutorial, you can initialize and fund the Sender's wallet.
+
+## Step X: Recipient > Creates and Initializes a Wallet
+
+TBD
+
+## Step X: Recipient > Generates a New Lock Address to Receive Tokens
+
+TBD
+
+## Step X: Recipient > Update Wallet State
+
+TBD
+
+## Step X: Recipient > Shares Lock Address with Sender
+
+TBD
+
+## Step X: Sender > Decode Lock Address
+
+TBD
+
+## Step X: Sender > Get Lock and Lock Address of 100 LVLs Funds
+
+TBD
+
+## Step X: Sender > Query Genesis Funds
+
+TBD
+
+## Step X: Sender > Create new Lock and Lock Address for Change
+
+TBD
+
+## Step X: Sender > Update Wallet State
+
+TBD
+
+## Step X: Sender > Create Transaction
+
+TBD
+
+## Step X: Sender > Prove Transaction
+
+TBD
+
+## Step X: Sender > Broadcast Transaction
+
+TBD
+
+## Optional Step: Recipient > Check Balance

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -16,10 +16,27 @@ The sender wants to send 10 LVLs to the recipient.
 To illustrate setting up a wallet, the Recipient will create and initialize a new wallet.
 
 ## Set-Up
+Throughout this tutorial, we will be alternating between the Sender and the Recipient's Point-of-View. To distinguish 
+between the two, each section will be prefixed with either "Sender >" or "Recipient >". We will also keep all the 
+generated files (key file, wallet file, etc.) in separate folders for each user. These folders should be created and be empty
+in advance.
 
-To follow along with this tutorial, you will need to initialize and fund the Sender's wallet with 100 LVLs.
+To follow along with this tutorial, you will need to initialize and fund the Sender's wallet with 100 LVLs. 
 
-Following the instructions in the [Load Wallet with Funds](./obtain-funds) tutorial, you can initialize and fund the Sender's wallet.
+If you were following the instructions in the [Load Wallet with Funds](./obtain-funds) tutorial, the code to set up the 
+Senders wallet should look something like:
+
+```scala title="Initializing the Sender's Wallet and Funding it with 100 LVLs"
+
+```
+
+After running that file, you should see that the Sender's wallet has been initialized with 100 LVLs:
+
+```bash title="output"
+
+```
+
+Keep the same local node instance running. We will be using it for the rest of this tutorial.
 
 ## Step X: Recipient > Creates and Initializes a Wallet
 

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -18,8 +18,7 @@ To illustrate setting up a wallet, the Recipient will create and initialize a ne
 ## Set-Up
 Throughout this tutorial, we will be alternating between the Sender and the Recipient's Point-of-View. To distinguish 
 between the two, each section will be prefixed with either "Sender >" or "Recipient >". We will also keep all the 
-generated files (key file, wallet file, etc.) in separate folders for each user. These folders should be created and be empty
-in advance.
+generated files (key file, wallet file, etc.) in separate folders for each user.
 
 To follow along with this tutorial, you will need to initialize and fund the Sender's wallet with 100 LVLs. 
 
@@ -27,63 +26,159 @@ If you were following the instructions in the [Load Wallet with Funds](./obtain-
 Senders wallet should look something like:
 
 ```scala title="Initializing the Sender's Wallet and Funding it with 100 LVLs"
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.Context
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.constants.NetworkConstants.{MAIN_LEDGER_ID, PRIVATE_NETWORK_ID}
+import co.topl.brambl.dataApi.{BifrostQueryAlgebra, GenusQueryAlgebra, RpcChannelResource}
+import co.topl.brambl.models.{Datum, Event}
+import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResource}
+import co.topl.brambl.syntax.{LvlType, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps, int128AsBigInt}
+import co.topl.brambl.wallet.{CredentiallerInterpreter, WalletApi}
 
+import java.io.File
+import java.nio.file.Paths
+
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+
+// Replace with the desired location for your *Sender* tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial", "sender").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+  val filePath = Paths.get(tutorialDir, fileName).toString
+  new File(filePath).delete() // Clear the file if it already exists
+  filePath
+}
+
+// Replace with the desired location for your key file
+val keyFile = initFilePath("keyfile.json")
+// Replace with the desired location of for your mnemonic file
+val mnemonicFile = initFilePath("mnemonic.txt")
+// Replace with the desired location of for your wallet state DB file
+val walletDb = initFilePath("wallet.db")
+
+val walletKeyApi = WalletKeyApi.make[IO]()
+val walletApi = WalletApi.make(walletKeyApi)
+val conn = WalletStateResource.walletResource(walletDb)
+val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
+
+val initializeWallet = for {
+  walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
+  mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
+  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+} yield mainKeyPair
+
+// Replace with the address and port of your node's gRPC endpoint
+val channelResource = RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
+val genusQueryApi = GenusQueryAlgebra.make[IO](channelResource)
+val txBuilder = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+
+val unprovenTransaction = for {
+  _ <- initializeWallet
+  heightLock <- walletStateApi.getLock("nofellowship", "genesis", 1)
+  heightAddress <- txBuilder.lockAddress(heightLock.get)
+  txos <- genusQueryApi.queryUtxo(heightAddress)
+  sigLock <- walletStateApi.getLock("self", "default", 1)
+  sigAddress <- txBuilder.lockAddress(sigLock.get)
+  tx <- txBuilder.buildTransferAmountTransaction(
+    LvlType,
+    txos,
+    heightLock.get.getPredicate,
+    100L,
+    sigAddress,
+    heightAddress,
+    1L
+  )
+} yield tx.toOption.get
+
+val proveAndValidateResult = for {
+  tx <- unprovenTransaction
+  mainKey <- walletApi.loadAndExtractMainKey[IO]("password".getBytes, keyFile)
+  credentialler = CredentiallerInterpreter.make[IO](walletApi, walletStateApi, mainKey.toOption.get)
+  ctx = Context[IO](tx, 50, Map("header" -> Datum().withHeader(Datum.Header(Event.Header(50)))).lift)
+  res <- credentialler.proveAndValidate(tx, ctx)
+} yield res
+
+val bifrostQuery = BifrostQueryAlgebra.make[IO](channelResource)
+
+val broadcastTransaction = for {
+  provenTx <- proveAndValidateResult
+  txId <- bifrostQuery.broadcastTransaction(provenTx.toOption.get)
+} yield txId
+
+broadcastTransaction.unsafeRunSync()
+
+// Allow some time to pass before querying the transaction
+Thread.sleep(15000)
+
+// optionally view your funds
+val queryFunds = for {
+  sigLock <- walletStateApi.getLock("self", "default", 1)
+  sigAddress <- txBuilder.lockAddress(sigLock.get)
+  txos <- genusQueryApi.queryUtxo(sigAddress)
+} yield txos.map(_.transactionOutput.value.value).map(value => s"${value.typeIdentifier}: ${value.quantity.intValue}")
+
+queryFunds.unsafeRunSync().foreach(println)
 ```
 
 After running that file, you should see that the Sender's wallet has been initialized with 100 LVLs:
 
 ```bash title="output"
-
+LvlType: 100
 ```
 
 Keep the same local node instance running. We will be using it for the rest of this tutorial.
 
-## Step X: Recipient > Creates and Initializes a Wallet
+## Step X: Recipient 
 
 TBD
 
-## Step X: Recipient > Generates a New Lock Address to Receive Tokens
+### Creates and Initializes a Wallet
+
+- Create Recipients Topl main key
+- Initialize the Wallet State
+
+### Generates a New Lock Address to Receive Tokens
+
+- generate lock
+- generate lock address
+- encode lock address
+
+### Putting it all together
 
 TBD
 
-## Step X: Recipient > Update Wallet State
+## Step X: Sender
 
 TBD
 
-## Step X: Recipient > Shares Lock Address with Sender
+### Create Transaction
 
-TBD
+- Decode Recipients lock address
+- Query sender's UTXOs
+- Generate new lock address for sender's change
+- Save new lock address to wallet state
+- Build transaction
 
-## Step X: Sender > Decode Lock Address
+### Prove Transaction
 
-TBD
+- Load sender's main key
+- initialize credentialler
+- Create context (tick and height are trivial since there is no Height Lock)
+- Prove and validate transaction
 
-## Step X: Sender > Get Lock and Lock Address of 100 LVLs Funds
+### Broadcast Transaction
 
-TBD
+Link to other page "identical"
 
-## Step X: Sender > Query Genesis Funds
-
-TBD
-
-## Step X: Sender > Create new Lock and Lock Address for Change
-
-TBD
-
-## Step X: Sender > Update Wallet State
-
-TBD
-
-## Step X: Sender > Create Transaction
-
-TBD
-
-## Step X: Sender > Prove Transaction
-
-TBD
-
-## Step X: Sender > Broadcast Transaction
+### Putting it all together
 
 TBD
 
 ## Optional Step: Recipient > Check Balance
+
+// insert runnable code

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -133,26 +133,97 @@ LvlType: 100
 
 Keep the same local node instance running. We will be using it for the rest of this tutorial.
 
-## Step X: Recipient 
+## Step 1: Recipient 
 
-TBD
+Before we can send tokens to the recipient, the recipient needs to have a wallet and a LockAddress that they have ownership of. 
 
-### Creates and Initializes a Wallet
+### Create and Initialize the Recipient's Wallet
 
-- Create Recipients Topl main key
-- Initialize the Wallet State
+Initializing the recipient's wallet is similar to initializing the sender's wallet. For more details you can read
+[Create and Initialize a Wallet](./obtain-funds#step-1-create-and-initialize-a-wallet) in the Load Wallet with Funds tutorial.
+
+1. Create the Topl main key for the Recipient's wallet. For more details see the 
+[Create the Wallet's Topl Main Key](./obtain-funds#create-the-wallets-topl-main-key)'s section in a previous tutorial.
+2. Using the main key from the previous step, initialize the Recipient's Wallet State. For more details see the
+[Initialize the Wallet State](./obtain-funds#initialize-the-wallet-state) section in a previous tutorial.
 
 ### Generates a New Lock Address to Receive Tokens
 
-- generate lock
-- generate lock address
-- encode lock address
+After the recipient's wallet has been initialized, we can generate the LockAddress for the recipient to receive the 10 LVLs.
+For this tutorial, we will generate a LockAddress for a 1-of-1 Digital Signature Lock.
+
+1. Generate the 1-of-1 Signature lock and LockAddress for the recipient. For more details see the 
+[Generate a New Lock Address to Receive Tokens](./obtain-funds#generate-a-new-lock-address-to-receive-tokens) section in
+a previous tutorial.
+2. This LockAddress must be shared to the Sender. To support this, the Recipient will encode their LockAddress into a Base58 format.
+See [Share a LockAddress](../../reference/locks/share-lock-addr). 
+ ```scala
+val base58Addr = encodeAddress(lockAddress)
+ ```
 
 ### Putting it all together
 
-TBD
+At this point, you should have code to create a new wallet and lock address for the recipient. The code should look similar to this:
 
-## Step X: Sender
+```scala title="Initializing the Recipient's Wallet and Generating a LockAddress"
+import cats.arrow.FunctionK
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.codecs.AddressCodecs.encodeAddress
+import co.topl.brambl.constants.NetworkConstants.{MAIN_LEDGER_ID, PRIVATE_NETWORK_ID}
+import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResource}
+import co.topl.brambl.wallet.WalletApi
+
+import java.io.File
+import java.nio.file.Paths
+
+implicit val transformType: FunctionK[IO, IO] = FunctionK.id[IO]
+
+// Replace with the desired location for your *Recipient* tutorial directory
+val tutorialDir = Paths.get(System.getProperty("user.home"), "tutorial", "recipient").toString
+new File(tutorialDir).mkdirs() // Create the directory if it doesn't exist
+
+def initFilePath(fileName: String): String = {
+  val filePath = Paths.get(tutorialDir, fileName).toString
+  new File(filePath).delete() // Clear the file if it already exists
+  filePath
+}
+
+// Replace with the desired location for your key file
+val keyFile = initFilePath("keyfile.json")
+// Replace with the desired location of for your mnemonic file
+val mnemonicFile = initFilePath("mnemonic.txt")
+// Replace with the desired location of for your wallet state DB file
+val walletDb = initFilePath("wallet.db")
+
+val walletKeyApi = WalletKeyApi.make[IO]()
+val walletApi = WalletApi.make(walletKeyApi)
+val conn = WalletStateResource.walletResource(walletDb)
+val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
+
+val initializeWallet = for {
+  walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
+  mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
+  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  sigLock <- walletStateApi.getLock("self", "default", 1)
+  lockAddress <- TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID).lockAddress(sigLock.get)
+} yield encodeAddress(lockAddress)
+
+initializeWallet.unsafeRunSync()
+```
+
+After running that file, you should see the Recipient's LockAddress:
+
+```bash title="output"
+val res1: String = ptetP7jshHVVBsmyLd5ugb9mVSehmtFdZHYQZqG3zaFtWSfiX79kYt9obJea
+```
+
+It is important to note that your LockAddress will be different than the one shown above. Everytime the code is run, a new
+Topl main key is generated, thus resulting in a new LockAddress. 
+
+## Step 2: Sender
 
 TBD
 

--- a/documentation/docs/tutorials/tutorials/tutorial1.md
+++ b/documentation/docs/tutorials/tutorials/tutorial1.md
@@ -1,3 +1,0 @@
-# Tutorial 1
-
-Learn how to do something

--- a/documentation/docs/tutorials/tutorials/tutorial2.md
+++ b/documentation/docs/tutorials/tutorials/tutorial2.md
@@ -1,3 +1,0 @@
-# Tutorial 2
-
-Learn how to do something

--- a/documentation/docs/tutorials/tutorials/tutorial3.md
+++ b/documentation/docs/tutorials/tutorials/tutorial3.md
@@ -1,3 +1,0 @@
-# Tutorial 3
-
-Learn how to do something

--- a/documentation/docs/tutorials/tutorials/tutorials.mdx
+++ b/documentation/docs/tutorials/tutorials/tutorials.mdx
@@ -1,0 +1,10 @@
+---
+sidebar_position: 1
+title: Tutorials
+description: Learn how to do common tasks with the SDK.
+---
+import DocCardList from '@theme/DocCardList';
+
+Coming soon: Introduction to tutorials
+
+<DocCardList/>

--- a/documentation/docs/tutorials/tutorials/tutorials.mdx
+++ b/documentation/docs/tutorials/tutorials/tutorials.mdx
@@ -5,6 +5,8 @@ description: Learn how to do common tasks with the SDK.
 ---
 import DocCardList from '@theme/DocCardList';
 
-Coming soon: Introduction to tutorials
+Get started with our immersive tutorials, designed to guide you through essential tasks using our SDK. Each tutorial
+offers a seamless, step-by-step walkthrough, empowering you to effortlessly implement common use-cases and master the
+intricacies of our technology.
 
 <DocCardList/>

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -71,11 +71,11 @@ const config = {
             sidebarId: 'serviceKitSidebar',
             label: 'Service Kit',
           },
-//          {
-//            type: 'docSidebar',
-//            sidebarId: 'tutorialsSidebar',
-//            label: 'Tutorials',
-//          },
+          {
+            type: 'docSidebar',
+            sidebarId: 'tutorialsSidebar',
+            label: 'Tutorials',
+          },
 //          {
 //            type: 'docSidebar',
 //            sidebarId: 'conceptsSidebar',

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateResource.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateResource.scala
@@ -18,11 +18,15 @@ trait WalletStateResource {
    */
   def walletResource(name: String): Resource[IO, Connection] = Resource
     .make(
-      IO.delay(
-        DriverManager.getConnection(
-          s"jdbc:sqlite:${name}"
+      {
+        // Without this line, repeated runs fail with "No suitable driver found for jdbc:sqlite:..."
+        Class.forName("org.sqlite.JDBC")
+        IO.delay(
+          DriverManager.getConnection(
+            s"jdbc:sqlite:${name}"
+          )
         )
-      )
+      }
     )(conn => IO.delay(conn.close()))
 }
 


### PR DESCRIPTION
## Purpose

To begin documenting tutorials

## Approach

- Displayed the "Tutorials" section on the portal
- Added 2 tutorials: Load New Wallet with funds from Genesis, Transfer from one wallet to another
- Minor code change to `WalletStateResource`. This is since, without this change, I was unable to re-run code examples multiple times on my machine (the driver appears to get de-registered) and I had to keep restarting my machine. 

## Testing

- Ensured all existing unit tests pass
- Ensured all added standalone examples (i.e., "Breakpoint Check" and "Putting it all together" sections) work locally
- Ensured `npm run build` and `npm run serve` are succesul (i.e, no broken links)

## Tickets
* Closes TSDK-647