### PR TITLE
TSDK-665 Added support for proving digests propositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added documentation wallet functionality using persistence (createAndSaveNewWallet, importWalletAndSave, loadAndExtractMainKey) 
 - Added documentation for updating a wallet state
 - Added tutorials: Load new wallet with Genesis funds, Transfer funds from one wallet to another
+- Support saving and retrieving the preimage for Digest Propositions
 
 ## [v2.0.0-alpha4-SNAPSHOT] - - TODO replace date after release 
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
@@ -37,6 +37,14 @@ trait WalletStateAlgebra[F[_]] {
   def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]]
 
   /**
+   * Add a preimage secret associated to a digest proposition.
+   *
+   * @param preimage The preimage secret to add
+   * @param digest The digest proposition for which the preimage is derived from.
+   */
+  def addPreimage(preimage: Preimage, digest: Proposition.Digest): F[Unit]
+
+  /**
    * Get the current address for the wallet interaction
    *
    * @return The current address of the wallet interaction as a string in base58 encoding

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -23,7 +23,7 @@ object MockWalletStateApi extends WalletStateAlgebra[IO] with MockHelpers {
     MockSignatureProposition.value.digitalSignature.get.sizedEvidence -> MockIndices
   )
 
-  val propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
+  var propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
     MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
   )
 
@@ -32,6 +32,9 @@ object MockWalletStateApi extends WalletStateAlgebra[IO] with MockHelpers {
 
   override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] =
     IO.pure(propEvidenceToPreimage.get(digestProposition.sizedEvidence))
+
+  override def addPreimage(preimage: Preimage, digest: Proposition.Digest): IO[Unit] =
+    IO.pure(propEvidenceToPreimage += digest.sizedEvidence -> preimage)
 
   // The following are not implemented since they are not used in the tests
   override def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -710,8 +710,9 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
           Map(p.value.digitalSignature.get.sizedEvidence -> bobIndices).get(signatureProposition.sizedEvidence)
         )
 
-      override def initWalletState(networkId:     Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???
+      override def initWalletState(networkId:     Int, ledgerId:    Int, vk: VerificationKey): F[Unit] = ???
       override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] = ???
+      override def addPreimage(preimage:          Preimage, digest: Proposition.Digest): IO[Unit] = ???
       override def getCurrentAddress: F[String] = ???
       override def updateWalletState(
         lockPredicate: String,

--- a/documentation/docs/reference/locks/create-template.mdx
+++ b/documentation/docs/reference/locks/create-template.mdx
@@ -130,6 +130,11 @@ case class DigestTemplate[F[_]: Monad](
 
 The parameters are the same as a Digest proposition.
 
+:::note
+When creating a Digest Template or Proposition, the preimage of the digest should be added to the Wallet State. The preimage
+will allow the digest to be proven when used in a transaction. See [Add Digest Preimage](../wallet-state#add-digest-preimage) for more information.
+:::
+
 ### SignatureTemplate
 
 Once built, a SignatureTemplate refers to

--- a/documentation/docs/reference/wallet-state.mdx
+++ b/documentation/docs/reference/wallet-state.mdx
@@ -178,3 +178,58 @@ val updateWallet = for {
 
 updateWallet.unsafeRunSync()
 ```
+
+## Add Digest Preimage
+
+In order to prove any lock that contains a Digest Proposition, the user must provide the preimage of the digest. This
+can be done by calling the
+function <ScaladocLink path="co/topl/brambl/dataApi/WalletStateAlgebra.html#addPreimage(Preimage,Digest):F[Unit]"><code>addPreimage</code></ScaladocLink>
+in a Wallet State instance.
+
+```scala
+def addPreimage(preimage: Preimage, digest: Proposition.Digest): F[Unit]
+```
+
+This function adds a preimage to the wallet state. The preimage is associated with the given digest proposition. This preimage can
+then be used to prove any lock that contains the given digest proposition.
+
+### Example
+
+The following snippet is an example of adding and retrieving a preimage to the wallet state using Cats Effect `IO` and the default
+implementation of the `WalletKeyApi` and `WalletStateApi` provided by the
+the <ScaladocLink path="co/topl/brambl/servicekit/index.html"><code>ServiceKit</code></ScaladocLink>. In this example, we
+assume that the wallet state has already been initialized to `wallet.db`.
+
+```scala
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import co.topl.brambl.servicekit.{WalletKeyApi, WalletStateApi, WalletStateResource}
+import co.topl.brambl.wallet.WalletApi
+import co.topl.crypto.hash.Blake2b256
+import com.google.protobuf.ByteString
+import quivr.models.{Digest, Preimage, Proposition}
+
+import java.io.File
+
+// Replace with the location of your existing wallet database file
+val walletDbFile = new File(System.getProperty("user.home"), "wallet.db").getCanonicalPath
+
+val walletApi = WalletApi.make(WalletKeyApi.make[IO]())
+val walletDbConnection = WalletStateResource.walletResource(walletDbFile)
+val walletStateApi = WalletStateApi.make[IO](walletDbConnection, walletApi)
+
+val preimageInput = "Some message".getBytes
+val salt = "Some salt".getBytes
+val digestValue = ByteString.copyFrom((new Blake2b256).hash(preimageInput ++ salt))
+// Preimage
+val preimage = Preimage(ByteString.copyFrom(preimageInput), ByteString.copyFrom(salt))
+// Digest proposition
+val digest = Proposition.Digest("Blake2b256", Digest(digestValue))
+
+val addAndGetPreimage = for {
+  _ <- walletStateApi.addPreimage(preimage, digest)
+  fetchedPreimage <- walletStateApi.getPreimage(digest)
+} yield fetchedPreimage.get
+
+addAndGetPreimage.unsafeRunSync() == preimage
+```


### PR DESCRIPTION
## Purpose

To add the ability to use and prove Digest propositions.

## Approach

- Added `addPreimage` for a digest proposition in the Service Kit
- Implemented `getPreimage`
- The above 2 points involved adding a new table
- Updated documentation

## Testing

- Added a unit test for `addPreimage` which tests adding and retrieving
- ensured all other unit tests pass
- Used the changes in brambl-cli; ensured all unit tests and integration tests pass

## Tickets
* closes TSDK-665
