### PR TITLE
TSDK-666 initWalletState parameter improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a tutorial for creating a new custom asset
 
+### Changed
+
+- Service Kit's initWalletState now expects a Topl main key pair instead of a (1,1) partial derivative verification key
+
 ## [v2.0.0-beta1] - 2023-12-05
 
 ### Added

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
@@ -12,7 +12,7 @@ import quivr.models.{KeyPair, Preimage, Proposition}
 trait WalletStateAlgebra[F[_]] {
 
   /**
-   * Initialize the wallet interaction with the given verification key
+   * Initialize the wallet interaction with the given key pair
    *
    * @param networkId The network id to initialize the wallet interaction with
    * @param ledgerId The ledger id to initialize the wallet interaction with

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/WalletStateAlgebra.scala
@@ -4,7 +4,7 @@ import cats.data.ValidatedNel
 import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.models.Indices
 import co.topl.brambl.models.box.Lock
-import quivr.models.{Preimage, Proposition, VerificationKey}
+import quivr.models.{KeyPair, Preimage, Proposition}
 
 /**
  * Defines a data API for storing and retrieving wallet interaction.
@@ -16,9 +16,9 @@ trait WalletStateAlgebra[F[_]] {
    *
    * @param networkId The network id to initialize the wallet interaction with
    * @param ledgerId The ledger id to initialize the wallet interaction with
-   * @param vk The verification key to initialize the wallet interaction with
+   * @param mainKey The Topl Main verification key to initialize the wallet interaction with
    */
-  def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit]
+  def initWalletState(networkId: Int, ledgerId: Int, mainKey: KeyPair): F[Unit]
 
   /**
    * Get the indices associated to a signature proposition

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -37,7 +37,7 @@ object MockWalletStateApi extends WalletStateAlgebra[IO] with MockHelpers {
     IO.pure(propEvidenceToPreimage += digest.sizedEvidence -> preimage)
 
   // The following are not implemented since they are not used in the tests
-  override def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit] = ???
+  override def initWalletState(networkId: Int, ledgerId: Int, mainKey: KeyPair): F[Unit] = ???
 
   override def getCurrentAddress: F[String] = ???
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -3,42 +3,26 @@ package co.topl.brambl.wallet
 import cats.data.ValidatedNel
 import cats.effect.IO
 import cats.implicits._
-import co.topl.brambl.Context
-import co.topl.brambl.MockHelpers
-import co.topl.brambl.MockWalletKeyApi
-import co.topl.brambl.MockWalletStateApi
+import co.topl.brambl.{Context, MockHelpers, MockWalletKeyApi, MockWalletStateApi}
 import co.topl.brambl.builders.locks.LockTemplate
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
 import co.topl.brambl.dataApi.WalletStateAlgebra
-import co.topl.brambl.models.Datum
-import co.topl.brambl.models.Event
-import co.topl.brambl.models.Indices
-import co.topl.brambl.models.box.AssetMintingStatement
-import co.topl.brambl.models.box.Attestation
-import co.topl.brambl.models.box.Challenge
-import co.topl.brambl.models.box.Lock
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.{Datum, Event, Indices}
+import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.cryptoToPbKeyPair
-import co.topl.brambl.syntax.pbKeyPairToCryptoKeyPair
+import co.topl.brambl.syntax.{cryptoToPbKeyPair, pbKeyPairToCryptoKeyPair}
 import co.topl.brambl.validation.TransactionAuthorizationError.AuthorizationFailed
 import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
 import co.topl.quivr.api.Proposer
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.EvaluationAuthorizationFailed
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.LockedPropositionIsUnsatisfiable
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
 import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
-import quivr.models.Int128
-import quivr.models.KeyPair
-import quivr.models.Preimage
-import quivr.models.Proof
-import quivr.models.Proposition
-import quivr.models.VerificationKey
+import quivr.models._
 
 import scala.util.Random
 
@@ -710,7 +694,7 @@ class CredentiallerInterpreterSpec extends CatsEffectSuite with MockHelpers {
           Map(p.value.digitalSignature.get.sizedEvidence -> bobIndices).get(signatureProposition.sizedEvidence)
         )
 
-      override def initWalletState(networkId:     Int, ledgerId:    Int, vk: VerificationKey): F[Unit] = ???
+      override def initWalletState(networkId:     Int, ledgerId:    Int, mainKey: KeyPair): F[Unit] = ???
       override def getPreimage(digestProposition: Proposition.Digest): F[Option[Preimage]] = ???
       override def addPreimage(preimage:          Preimage, digest: Proposition.Digest): IO[Unit] = ???
       override def getCurrentAddress: F[String] = ???

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/CredentiallerInterpreterSpec.scala
@@ -19,7 +19,10 @@ import co.topl.brambl.validation.TransactionSyntaxError
 import co.topl.crypto.generation.Bip32Indexes
 import co.topl.crypto.signing.ExtendedEd25519
 import co.topl.quivr.api.Proposer
-import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{EvaluationAuthorizationFailed, LockedPropositionIsUnsatisfiable}
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
+  EvaluationAuthorizationFailed,
+  LockedPropositionIsUnsatisfiable
+}
 import com.google.protobuf.ByteString
 import munit.CatsEffectSuite
 import quivr.models._

--- a/documentation/docs/reference/wallet-state.mdx
+++ b/documentation/docs/reference/wallet-state.mdx
@@ -40,11 +40,11 @@ have a wallet state, the file path should point to the existing file.
 ## Initialize Wallet State
 
 When creating a wallet for the first time, you must initialize its state. This can be done by calling the
-function <ScaladocLink path="co/topl/brambl/dataApi/WalletStateAlgebra.html#initWalletState(Int,Int,VerificationKey):F[Unit]"><code>initWalletState</code></ScaladocLink>
+function <ScaladocLink path="co/topl/brambl/dataApi/WalletStateAlgebra.html#initWalletState(Int,Int,KeyPair):F[Unit]"><code>initWalletState</code></ScaladocLink>
 in a Wallet State instance. Read more about state initialization in [Creating a Vault and a Wallet Database](../service-kit/usage#creating-a-vault-and-a-wallet-database).
 
 ```scala
-def initWalletState(networkId: Int, ledgerId: Int, vk: VerificationKey): F[Unit]
+def initWalletState(networkId: Int, ledgerId: Int, mainKey: KeyPair): F[Unit]
 ```
 
 This function initializes the original state of a newly created wallet. In the provided default implementation, this
@@ -57,9 +57,8 @@ the <ScaladocLink path="co/topl/brambl/constants/NetworkConstants$.html"><code>N
 - `ledgerId`: The ID of the ledger that the wallet is being initialized for. This ID is used to generate the initial lock
 addresses. The only possible value is `MAIN_LEDGER_ID` which can be found in the
 the <ScaladocLink path="co/topl/brambl/constants/NetworkConstants$.html"><code>NetworkConstants</code></ScaladocLink> object.
-- `vk`: The parent verification key (x, y) associated to the "self" fellowship and "default" template. Most commonly, this
-will be the verification key derived from the (x=1, y=1) path of the wallet's Main Key Pair. This verification key is used
-to initialize the first fellowships, templates, and child key pair in the wallet state.
+- `mainKey`: The Topl Main Key to initialize the wallet state with. This key pair is used to initialize the first
+fellowships, templates, and child key pair in the wallet state.
 
 
 ### Example
@@ -89,9 +88,7 @@ val walletStateApi = WalletStateApi.make[IO](walletDbConnection, walletApi)
 val initializeWallet = for {
   wallet <- walletApi.createNewWallet(password).map(_.fold(throw _, identity))
   mainKey <- walletApi.extractMainKey(wallet.mainKeyVaultStore, password).map(_.fold(throw _, identity))
-  xyKey <- walletApi.deriveChildKeysPartial(mainKey, 1, 1)
-  // highlight-next-line
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, xyKey.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKey)
 } yield ()
 
 initializeWallet.unsafeRunSync()

--- a/documentation/docs/service-kit/usage.md
+++ b/documentation/docs/service-kit/usage.md
@@ -15,7 +15,7 @@ The first step is to create a vault. The vault is where the master key is stored
 // You can run this code using scala-cli. Save it in a file called `create-vault.sc` and run it with `scala-cli create-vault.sc`
 //> using scala 2.13
 //> using repository "sonatype-s01:releases"
-//> using dep "co.topl::service-kit:2.0.0-beta0"
+//> using dep "co.topl::service-kit:2.0.0-beta2"
 //> using dep "org.typelevel::cats-core:2.10.0"
 
 import cats.effect.IO
@@ -58,11 +58,10 @@ case class CreateWallet(file: String, password: String) {
       )
     _ <- std.Console[IO].println("Wallet: " + new String(wallet.mainKeyVaultStore.asJson.noSpaces))
     _ <- std.Console[IO].println("Mnemonic: "+ wallet.mnemonic.mkString(","))
-    derivedKey <- walletApi.deriveChildKeysPartial(keyPair, 1, 1)
     _ <- walletStateApi.initWalletState(
       NetworkConstants.PRIVATE_NETWORK_ID,
       NetworkConstants.MAIN_LEDGER_ID,
-      derivedKey.vk
+      keyPair
     )
   } yield ()
 
@@ -87,8 +86,6 @@ This code has several parts:
 
 - first, it creates a wallet in memory (the `walletApi.createNewWallet` function)
 - then, it extracts the main key from the wallet (the `walletApi.extractMainKey` function)
-- then, it derives a child key from the main key (the `walletApi.deriveChildKeysPartial` function),
-this is needed to initialized the wallet database with an initial entry for the "self" and "default" fellowship and template.
 - finally, it initializes the wallet database (the `walletStateApi.initWalletState` function)
 
 ## Updating the Wallet Database
@@ -99,7 +96,7 @@ Users must update the wallet state whenever one of their child keys is used to c
 // You can run this code using scala-cli. Save it in a file called `create-vault.sc` and run it with `scala-cli create-vault.sc`
 //> using scala 2.13
 //> using repository "sonatype-s01:releases"
-//> using dep "co.topl::service-kit:2.0.0-beta0"
+//> using dep "co.topl::service-kit:2.0.0-beta2"
 //> using dep "org.typelevel::cats-core:2.10.0"
 
 import cats.effect.IO
@@ -148,12 +145,11 @@ case class CreateWallet(file: String, password: String) {
       )
     _ <- std.Console[IO].println("Wallet: " + new String(wallet.mainKeyVaultStore.asJson.noSpaces))
     _ <- std.Console[IO].println("Mnemonic: "+ wallet.mnemonic.mkString(","))
-    derivedKey <- walletApi.deriveChildKeysPartial(keyPair, 1, 1)
     // Initialize the wallet state:
     _ <- walletStateApi.initWalletState(
       NetworkConstants.PRIVATE_NETWORK_ID,
       NetworkConstants.MAIN_LEDGER_ID,
-      derivedKey.vk
+      keyPair
     )
   } yield ()
 

--- a/documentation/docs/tutorials/tutorials/mint-asset.md
+++ b/documentation/docs/tutorials/tutorials/mint-asset.md
@@ -63,8 +63,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 // Replace with the address and port of your node's gRPC endpoint

--- a/documentation/docs/tutorials/tutorials/obtain-funds.md
+++ b/documentation/docs/tutorials/tutorials/obtain-funds.md
@@ -66,13 +66,9 @@ provided by the Service Kit to persist to a SQLite database file. See [Initializ
    ```scala
    mainKeyPair <- walletApi.extractMainKey(walletResult.mainKeyVaultStore, "password".getBytes())
    ```
-3. Using the `mainKeyPair` created above, derive a child key at (1, 1).
+3. Using the Topl main key and `walletStateApi` created above, initialize the wallet state using `initWalletState`
    ```scala
-   childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair, 1, 1)
-   ```
-4. Using the `childKeyPair` and `walletStateApi` created above, initialize the wallet state using `initWalletState`
-   ```scala
-   walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+   walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair)
    ```
 
 ### Breakpoint Check
@@ -117,8 +113,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
    walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
    mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-   childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-   _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+   _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 initializeWallet.unsafeRunSync()
@@ -231,8 +226,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 // Replace with the address and port of your node's gRPC endpoint
@@ -330,8 +324,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 // Replace with the address and port of your node's gRPC endpoint
@@ -436,8 +429,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 // Replace with the address and port of your node's gRPC endpoint

--- a/documentation/docs/tutorials/tutorials/simple-transfer.md
+++ b/documentation/docs/tutorials/tutorials/simple-transfer.md
@@ -73,8 +73,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
 } yield mainKeyPair
 
 // Replace with the address and port of your node's gRPC endpoint
@@ -210,8 +209,7 @@ val walletStateApi = WalletStateApi.make[IO](conn, walletApi)
 val initializeWallet = for {
   walletResult <- walletApi.createAndSaveNewWallet[IO]("password".getBytes, name = keyFile, mnemonicName = mnemonicFile)
   mainKeyPair <- walletApi.extractMainKey(walletResult.toOption.get.mainKeyVaultStore, "password".getBytes())
-  childKeyPair <- walletApi.deriveChildKeysPartial(mainKeyPair.toOption.get, 1, 1)
-  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, childKeyPair.vk)
+  _ <- walletStateApi.initWalletState(PRIVATE_NETWORK_ID, MAIN_LEDGER_ID, mainKeyPair.toOption.get)
   sigLock <- walletStateApi.getLock("self", "default", 1)
   lockAddress <- TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID).lockAddress(sigLock.get)
 } yield encodeAddress(lockAddress)

--- a/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
+++ b/service-kit/src/main/scala/co/topl/brambl/servicekit/WalletStateApi.scala
@@ -357,7 +357,7 @@ object WalletStateApi {
       override def initWalletState(
         networkId: Int,
         ledgerId:  Int,
-        mainKey: KeyPair
+        mainKey:   KeyPair
       ): F[Unit] = {
         import TransactionBuilderApi.implicits._
         import cats.implicits._

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/FellowshipStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/FellowshipStorageApiSpec.scala
@@ -14,7 +14,7 @@ class FellowshipStorageApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         init <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _           <- fellowshipApi.addFellowship(fellowship)
         fellowships <- fellowshipApi.findFellowships()
       } yield fellowships.length == 3 && fellowships.last == fellowship,

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/TemplateStorageApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/TemplateStorageApiSpec.scala
@@ -19,7 +19,7 @@ class TemplateStorageApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         init <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _         <- contractApi.addTemplate(contract)
         templates <- contractApi.findTemplates()
       } yield templates.length == 3 && templates.last == contract,

--- a/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
+++ b/service-kit/src/test/scala/co/topl/brambl/servicekit/WalletStateApiSpec.scala
@@ -21,7 +21,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
         _ <- walletStateApi.initWalletState(
           NetworkConstants.PRIVATE_NETWORK_ID,
           NetworkConstants.MAIN_NETWORK_ID,
-          mockMainKeyPair.vk
+          mockMainKeyPair
         )
         fellowshipCount <- dbConnection.use { conn =>
           for {
@@ -67,7 +67,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
         _ <- walletStateApi.initWalletState(
           NetworkConstants.PRIVATE_NETWORK_ID,
           NetworkConstants.MAIN_NETWORK_ID,
-          mockMainKeyPair.vk
+          mockMainKeyPair
         )
         _ <- walletStateApi.updateWalletState(
           testValue,
@@ -113,7 +113,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -134,7 +134,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           Encoding.encodeToBase58Check(predicate.toByteArray),
           testValue,
@@ -154,7 +154,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           Encoding.encodeToBase58Check(predicate.toByteArray),
           lockAddress.toBase58(),
@@ -174,7 +174,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         lock <- walletStateApi.getLockByAddress(lockAddress.toBase58())
       } yield lock.isEmpty,
       true
@@ -185,7 +185,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         someList <- walletStateApi.getInteractionList("self", "default")
       } yield someList.get.size,
       1
@@ -199,7 +199,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           Encoding.encodeToBase58Check(predicate.toByteArray),
           lockAddress.toBase58(),
@@ -224,7 +224,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         someList <- walletStateApi.getInteractionList("self", "default1")
       } yield someList.isEmpty,
       true
@@ -235,7 +235,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         idx <- walletStateApi.getNextIndicesForFunds("self", "default")
       } yield idx.isDefined && idx.get == Indices(1, 1, 2),
       true
@@ -246,7 +246,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         idx <- walletStateApi.validateCurrentIndicesForFunds("self", "default", None)
       } yield idx.isValid && idx.toOption.get == Indices(1, 1, 1),
       true
@@ -258,7 +258,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -276,7 +276,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         idx <- walletStateApi.getCurrentIndicesForFunds("self", "default", None)
       } yield idx.isDefined && idx.get == Indices(1, 1, 1),
       true
@@ -288,7 +288,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.updateWalletState(
           testValue,
           testValue,
@@ -307,7 +307,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         preimage <- walletStateApi.getPreimage(proposition)
       } yield preimage.isEmpty,
       true
@@ -320,7 +320,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         preimageBefore <- walletStateApi.getPreimage(proposition)
         _              <- walletStateApi.addPreimage(secret, proposition)
         preimageAfter  <- walletStateApi.getPreimage(proposition)
@@ -334,7 +334,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _   <- walletStateApi.addEntityVks("test", "default", testValues)
         vks <- walletStateApi.getEntityVks("test", "default")
       } yield vks.isDefined && vks.get == testValues,
@@ -348,7 +348,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _        <- walletStateApi.addNewLockTemplate("height", lockTemplate)
         template <- walletStateApi.getLockTemplate("height")
       } yield template.isDefined && template.get == lockTemplate,
@@ -363,7 +363,7 @@ class WalletStateApiSpec extends CatsEffectSuite with BaseSpec {
     assertIO(
       for {
         _ <- walletStateApi
-          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair.vk)
+          .initWalletState(NetworkConstants.PRIVATE_NETWORK_ID, NetworkConstants.MAIN_NETWORK_ID, mockMainKeyPair)
         _ <- walletStateApi.addNewLockTemplate("test", lockTemplate)
         _ <- walletStateApi.addEntityVks("self", "test", entityVks.map(vk => Encoding.encodeToBase58(vk.toByteArray)))
         lock <- walletStateApi.getLock("self", "test", 2)


### PR DESCRIPTION
## Purpose

Ease of use improvement for using `initWalletState`.  Now users do not have to do a (x=1,y=1) partial derivative of their Topl Main key pair before initializing a wallet state.

## Approach

- Updated Signature of the function to take in a KeyPair (needed for partial derivation).
- Updated Service Kit to perform the partial derivation within the `initWalletState` function
- Updated all callers (tests) to use the updated parameter
- Updated documentation to use the updated parameter

## Testing

- Ensure all tests pass
- Ensure all documentation examples run successfully. Note: The code examples within "Service Kit > Usage" are not directly runnable using `scala-cli` *yet*. This is because it depends on a released version of the SDK. These changes are not yet released but will be a part of `beta2` (which is what the dependency references). In other words, this *will* be runnable once `beta2` is released (which is when the documentation portal will be updated). Despite this, I ensured running the code in a worksheet works as expected (same as the other code examples).
- Used in `brambl-cli` and ensured the unit tests and integration tests all pass.

## Tickets
* TSDK-666