### PR TITLE
TSDK-663 Transaction Pretty Print / Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # BramblSc
 
-Topl's Brambl SDK implemented in Scala
+Topl's Brambl SDK implemented in Scala. [Read the docs to get started](https://topl.github.io/BramblSc/docs/current/reference/getting-started).
 
 Multiple artifacts will be built from this repo. Some will be just for Topl clients and some will be shared. 
 
@@ -12,53 +12,3 @@ The artifacts generated from this repo are:
 - crypto
 - service-kit
 - quivr4s
-
-## Consume with JitPack
-
-This repo can be consumed using jitpack. Here is how:
-
-First, be sure to add jitpack to the end of the resolvers list in build.sbt. It should look like this:
-```sbt
-  resolvers ++= Seq(
-    "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
-    "Sonatype Staging" at "https://s01.oss.sonatype.org/content/repositories/staging",
-    "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
-    "Bintray" at "https://jcenter.bintray.com/",
-    "jitpack" at "https://jitpack.io"
-  )
-```
-
-Then just add the dependency like this:
-```sbt
-  val bramblSc =
-    "com.github.Topl" % "BramblSc" % "1bdc895"
-```
-Where `1bdc895` refers to a commit on this repo's main branch. This will add the artifacts for both `brambl-sdk` and `crypto`.
-Then just use the dependencies like you would any other.
-
-## Consume Maven Release
-
-First, be sure to add Sonatype s01 releases to the end of the resolvers list in build.sbt. It should look like this:
-```sbt
-  resolvers ++= Seq(
-    "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
-    "Sonatype Staging" at "https://s01.oss.sonatype.org/content/repositories/staging",
-    "Sonatype Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots/",
-    "Bintray" at "https://jcenter.bintray.com/",
-    "jitpack" at "https://jitpack.io",
-    "Sonatype Releases" at "https://s01.oss.sonatype.org/content/repositories/releases/"
-  )
-```
-
-Then just add the dependencies for `brambl-sdk` and `crypto` like this:
-```sbt
-  val brambl-sdk =
-    "co.topl" %% "brambl-sdk" % "2.0.0-alpha1"
-```
-
-```sbt
-  val crypto =
-    "co.topl" %% "crypto" % "2.0.0-alpha1"
-```
-
-Replace `2.0.0-alpha1` with the latest released version. Then just use the dependencies like you would any other.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
@@ -9,19 +9,19 @@ trait AssetDisplayOps {
 
   implicit val assetDisplay: DisplayOps[Value.Asset] = (asset: Value.Asset) =>
     s"Asset\n" +
-    s"GroupId      : ${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
-    s"SeriesId     : ${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
-    s"Commitment   : ${asset.commitment
+    s"${padLabel("GroupId")}${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
+    s"${padLabel("SeriesId")}${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
+    s"${padLabel("Commitment")}${asset.commitment
         .map(x => Encoding.encodeToHex(x.toByteArray()))
         .getOrElse("No commitment")}\n" +
-    s"Ephemeral-Metadata: \n" +
+    s"${padLabel("Ephemeral-Metadata")}\n" +
     s"${asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")}"
 
   implicit val assetMintingStatementDisplay: DisplayOps[AssetMintingStatement] = (ams: AssetMintingStatement) => s"""
-Group-Token-Utxo: ${ams.groupTokenUtxo.display}
-Series-Token-Utxo: ${ams.seriesTokenUtxo.display}
-Quantity: ${(ams.quantity: BigInt).toString}
-Permanent-Metadata:
+${padLabel("Group-Token-Utxo")}${ams.groupTokenUtxo.display}
+${padLabel("Series-Token-Utxo")}${ams.seriesTokenUtxo.display}
+${padLabel("Quantity")}${(ams.quantity: BigInt).toString}
+${padLabel("Permanent-Metadata")}
 ${ams.permanentMetadata.map(meta => meta.display).getOrElse("No permanent metadata")}
       """
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
@@ -8,20 +8,23 @@ import co.topl.brambl.syntax.int128AsBigInt
 trait AssetDisplayOps {
 
   implicit val assetDisplay: DisplayOps[Value.Asset] = (asset: Value.Asset) =>
-    s"Asset\n" +
-    s"${padLabel("GroupId")}${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
-    s"${padLabel("SeriesId")}${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
-    s"${padLabel("Commitment")}${asset.commitment
+    Seq(
+      "Asset",
+      padLabel("GroupId") + asset.groupId.map(gId => gId.display).getOrElse("N/A"),
+      padLabel("SeriesId") + asset.seriesId.map(sId => sId.display).getOrElse("N/A"),
+      padLabel("Commitment") + asset.commitment
         .map(x => Encoding.encodeToHex(x.toByteArray()))
-        .getOrElse("No commitment")}\n" +
-    s"${padLabel("Ephemeral-Metadata")}\n" +
-    s"${asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")}"
+        .getOrElse("No commitment"),
+      padLabel("Ephemeral-Metadata"),
+      asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")
+    ).mkString("\n")
 
-  implicit val assetMintingStatementDisplay: DisplayOps[AssetMintingStatement] = (ams: AssetMintingStatement) => s"""
-${padLabel("Group-Token-Utxo")}${ams.groupTokenUtxo.display}
-${padLabel("Series-Token-Utxo")}${ams.seriesTokenUtxo.display}
-${padLabel("Quantity")}${(ams.quantity: BigInt).toString}
-${padLabel("Permanent-Metadata")}
-${ams.permanentMetadata.map(meta => meta.display).getOrElse("No permanent metadata")}
-      """
+  implicit val assetMintingStatementDisplay: DisplayOps[AssetMintingStatement] = (ams: AssetMintingStatement) =>
+    Seq(
+      padLabel("Group-Token-Utxo") + ams.groupTokenUtxo.display,
+      padLabel("Series-Token-Utxo") + ams.seriesTokenUtxo.display,
+      padLabel("Quantity") + (ams.quantity: BigInt).toString,
+      padLabel("Permanent-Metadata"),
+      ams.permanentMetadata.map(meta => meta.display).getOrElse("No permanent metadata")
+    ).mkString("\n")
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/AssetDisplayOps.scala
@@ -1,0 +1,27 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.box.{AssetMintingStatement, Value}
+import co.topl.brambl.utils.Encoding
+import co.topl.brambl.syntax.int128AsBigInt
+
+trait AssetDisplayOps {
+
+  implicit val assetDisplay: DisplayOps[Value.Asset] = (asset: Value.Asset) =>
+    s"Asset\n" +
+    s"GroupId      : ${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
+    s"SeriesId     : ${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
+    s"Commitment   : ${asset.commitment
+        .map(x => Encoding.encodeToHex(x.toByteArray()))
+        .getOrElse("No commitment")}\n" +
+    s"Ephemeral-Metadata: \n" +
+    s"${asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")}"
+
+  implicit val assetMintingStatementDisplay: DisplayOps[AssetMintingStatement] = (ams: AssetMintingStatement) => s"""
+Group-Token-Utxo: ${ams.groupTokenUtxo.display}
+Series-Token-Utxo: ${ams.seriesTokenUtxo.display}
+Quantity: ${(ams.quantity: BigInt).toString}
+Permanent-Metadata:
+${ams.permanentMetadata.map(meta => meta.display).getOrElse("No permanent metadata")}
+      """
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/BlockDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/BlockDisplayOps.scala
@@ -1,0 +1,10 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.utils.Encoding
+import co.topl.consensus.models.BlockId
+
+trait BlockDisplayOps {
+
+  implicit val blockIdDisplay: DisplayOps[BlockId] = (blockId: BlockId) =>
+    Encoding.encodeToBase58(blockId.value.toByteArray())
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
@@ -1,8 +1,24 @@
 package co.topl.brambl.display
 
-import co.topl.brambl.models.GroupId
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.{Datum, GroupId, SeriesId}
 import co.topl.brambl.utils.Encoding
+import co.topl.brambl.models.box.Value
 
 trait GroupDisplayOps {
   implicit val groupIdDisplay: DisplayOps[GroupId] = (id: GroupId) => Encoding.encodeToHex(id.value.toByteArray())
+
+  implicit val groupPolicyDisplay: DisplayOps[Datum.GroupPolicy] = (gp: Datum.GroupPolicy) => s"""
+Label: ${gp.event.label}
+Regitration-Utxo: ${gp.event.registrationUtxo.display}
+Fixed-Series: ${displayFixedSeries(gp.event.fixedSeries)}
+    """
+
+  implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>
+    s"Group Constructor\n" +
+    s"Id           : ${group.groupId.display}\n" +
+    s"Fixed-Series : ${displayFixedSeries(group.fixedSeries)}"
+
+  private def displayFixedSeries(fixedSeries: Option[SeriesId]): String =
+    fixedSeries.map(sId => sId.display).getOrElse("NO FIXED SERIES")
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
@@ -8,16 +8,19 @@ import co.topl.brambl.models.box.Value
 trait GroupDisplayOps {
   implicit val groupIdDisplay: DisplayOps[GroupId] = (id: GroupId) => Encoding.encodeToHex(id.value.toByteArray())
 
-  implicit val groupPolicyDisplay: DisplayOps[Datum.GroupPolicy] = (gp: Datum.GroupPolicy) => s"""
-${padLabel("Label")}${gp.event.label}
-${padLabel("Regitration-Utxo")}${gp.event.registrationUtxo.display}
-${padLabel("Fixed-Series")}${displayFixedSeries(gp.event.fixedSeries)}
-"""
+  implicit val groupPolicyDisplay: DisplayOps[Datum.GroupPolicy] = (gp: Datum.GroupPolicy) =>
+    Seq(
+      padLabel("Label") + gp.event.label,
+      padLabel("Registration-Utxo") + gp.event.registrationUtxo.display,
+      padLabel("Fixed-Series") + displayFixedSeries(gp.event.fixedSeries)
+    ).mkString("\n")
 
   implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>
-    s"Group Constructor\n" +
-    s"${padLabel("Id")}${group.groupId.display}\n" +
-    s"${padLabel("Fixed-Series")}${displayFixedSeries(group.fixedSeries)}"
+    Seq(
+      "Group Constructor",
+      padLabel("Id") + group.groupId.display,
+      padLabel("Fixed-Series") + displayFixedSeries(group.fixedSeries)
+    ).mkString("\n")
 
   private def displayFixedSeries(fixedSeries: Option[SeriesId]): String =
     fixedSeries.map(sId => sId.display).getOrElse("NO FIXED SERIES")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
@@ -1,0 +1,8 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.models.GroupId
+import co.topl.brambl.utils.Encoding
+
+trait GroupDisplayOps {
+  implicit val groupIdDisplay: DisplayOps[GroupId] = (id: GroupId) => Encoding.encodeToHex(id.value.toByteArray())
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/GroupDisplayOps.scala
@@ -9,15 +9,15 @@ trait GroupDisplayOps {
   implicit val groupIdDisplay: DisplayOps[GroupId] = (id: GroupId) => Encoding.encodeToHex(id.value.toByteArray())
 
   implicit val groupPolicyDisplay: DisplayOps[Datum.GroupPolicy] = (gp: Datum.GroupPolicy) => s"""
-Label: ${gp.event.label}
-Regitration-Utxo: ${gp.event.registrationUtxo.display}
-Fixed-Series: ${displayFixedSeries(gp.event.fixedSeries)}
-    """
+${padLabel("Label")}${gp.event.label}
+${padLabel("Regitration-Utxo")}${gp.event.registrationUtxo.display}
+${padLabel("Fixed-Series")}${displayFixedSeries(gp.event.fixedSeries)}
+"""
 
   implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>
     s"Group Constructor\n" +
-    s"Id           : ${group.groupId.display}\n" +
-    s"Fixed-Series : ${displayFixedSeries(group.fixedSeries)}"
+    s"${padLabel("Id")}${group.groupId.display}\n" +
+    s"${padLabel("Fixed-Series")}${displayFixedSeries(group.fixedSeries)}"
 
   private def displayFixedSeries(fixedSeries: Option[SeriesId]): String =
     fixedSeries.map(sId => sId.display).getOrElse("NO FIXED SERIES")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
@@ -1,8 +1,10 @@
 package co.topl.brambl.display
 
-import co.topl.brambl.models.SeriesId
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.{Datum, SeriesId}
 import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
 import co.topl.brambl.utils.Encoding
+import co.topl.brambl.models.box.Value
 
 trait SeriesDisplayOps {
 
@@ -22,4 +24,26 @@ trait SeriesDisplayOps {
     case QuantityDescriptorType.IMMUTABLE    => "immutable"
     case _ => throw new Exception("Unknown quantity descriptor type") // should not happen
   }
+
+  implicit val seriesPolicyDisplay: DisplayOps[Datum.SeriesPolicy] = (sp: Datum.SeriesPolicy) => s"""
+Label: ${sp.event.label}
+Regitration-Utxo: ${sp.event.registrationUtxo.display}
+Fungibility: ${sp.event.fungibility.display}
+Quantity-Descriptor: ${sp.event.quantityDescriptor.display}
+Token-Supply: ${displayTokenSupply(sp.event.tokenSupply)}
+Permanent-Metadata-Scheme:
+${sp.event.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata")}
+Ephemeral-Metadata-Scheme:
+${sp.event.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")}
+    """
+
+  implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>
+    s"Series Constructor\n" +
+    s"Id           : ${series.seriesId.display}\n" +
+    s"Fungibility  : ${series.fungibility.display}\n" +
+    s"Token-Supply : ${displayTokenSupply(series.tokenSupply)}\n" +
+    s"Quant-Descr. : ${series.quantityDescriptor.display}"
+
+  private def displayTokenSupply(tokenSupply: Option[Int]): String =
+    tokenSupply.map(_.toString).getOrElse("UNLIMITED")
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
@@ -1,0 +1,25 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.models.SeriesId
+import co.topl.brambl.models.box.{FungibilityType, QuantityDescriptorType}
+import co.topl.brambl.utils.Encoding
+
+trait SeriesDisplayOps {
+
+  implicit val seriesIdDisplay: DisplayOps[SeriesId] = (id: SeriesId) => Encoding.encodeToHex(id.value.toByteArray())
+
+  implicit val fungibilityDisplay: DisplayOps[FungibilityType] = {
+    case FungibilityType.GROUP_AND_SERIES => "group-and-series"
+    case FungibilityType.GROUP            => "group"
+    case FungibilityType.SERIES           => "series"
+    case _                                => throw new Exception("Unknown fungibility type") // this should not happen
+  }
+
+  implicit val quantityDescriptorDisplay: DisplayOps[QuantityDescriptorType] = {
+    case QuantityDescriptorType.LIQUID       => "liquid"
+    case QuantityDescriptorType.ACCUMULATOR  => "accumulator"
+    case QuantityDescriptorType.FRACTIONABLE => "fractionable"
+    case QuantityDescriptorType.IMMUTABLE    => "immutable"
+    case _ => throw new Exception("Unknown quantity descriptor type") // should not happen
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
@@ -26,23 +26,23 @@ trait SeriesDisplayOps {
   }
 
   implicit val seriesPolicyDisplay: DisplayOps[Datum.SeriesPolicy] = (sp: Datum.SeriesPolicy) => s"""
-Label: ${sp.event.label}
-Regitration-Utxo: ${sp.event.registrationUtxo.display}
-Fungibility: ${sp.event.fungibility.display}
-Quantity-Descriptor: ${sp.event.quantityDescriptor.display}
-Token-Supply: ${displayTokenSupply(sp.event.tokenSupply)}
-Permanent-Metadata-Scheme:
+${padLabel("Label")}${sp.event.label}
+${padLabel("Regitration-Utxo")}${sp.event.registrationUtxo.display}
+${padLabel("Fungibility")}${sp.event.fungibility.display}
+${padLabel("Quantity-Descriptor")}${sp.event.quantityDescriptor.display}
+${padLabel("Token-Supply")}${displayTokenSupply(sp.event.tokenSupply)}
+${padLabel("Permanent-Metadata-Scheme")}
 ${sp.event.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata")}
-Ephemeral-Metadata-Scheme:
+${padLabel("Ephemeral-Metadata-Scheme")}
 ${sp.event.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")}
-    """
+"""
 
   implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>
     s"Series Constructor\n" +
-    s"Id           : ${series.seriesId.display}\n" +
-    s"Fungibility  : ${series.fungibility.display}\n" +
-    s"Token-Supply : ${displayTokenSupply(series.tokenSupply)}\n" +
-    s"Quant-Descr. : ${series.quantityDescriptor.display}"
+    s"${padLabel("Id")}${series.seriesId.display}\n" +
+    s"${padLabel("Fungibility")}${series.fungibility.display}\n" +
+    s"${padLabel("Token-Supply")}${displayTokenSupply(series.tokenSupply)}\n" +
+    s"${padLabel("Quant-Descr.")}${series.quantityDescriptor.display}"
 
   private def displayTokenSupply(tokenSupply: Option[Int]): String =
     tokenSupply.map(_.toString).getOrElse("UNLIMITED")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/SeriesDisplayOps.scala
@@ -25,24 +25,27 @@ trait SeriesDisplayOps {
     case _ => throw new Exception("Unknown quantity descriptor type") // should not happen
   }
 
-  implicit val seriesPolicyDisplay: DisplayOps[Datum.SeriesPolicy] = (sp: Datum.SeriesPolicy) => s"""
-${padLabel("Label")}${sp.event.label}
-${padLabel("Regitration-Utxo")}${sp.event.registrationUtxo.display}
-${padLabel("Fungibility")}${sp.event.fungibility.display}
-${padLabel("Quantity-Descriptor")}${sp.event.quantityDescriptor.display}
-${padLabel("Token-Supply")}${displayTokenSupply(sp.event.tokenSupply)}
-${padLabel("Permanent-Metadata-Scheme")}
-${sp.event.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata")}
-${padLabel("Ephemeral-Metadata-Scheme")}
-${sp.event.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")}
-"""
+  implicit val seriesPolicyDisplay: DisplayOps[Datum.SeriesPolicy] = (sp: Datum.SeriesPolicy) =>
+    Seq(
+      padLabel("Label") + sp.event.label,
+      padLabel("Registration-Utxo") + sp.event.registrationUtxo.display,
+      padLabel("Fungibility") + sp.event.fungibility.display,
+      padLabel("Quantity-Descriptor") + sp.event.quantityDescriptor.display,
+      padLabel("Token-Supply") + displayTokenSupply(sp.event.tokenSupply),
+      padLabel("Permanent-Metadata-Scheme"),
+      sp.event.permanentMetadataScheme.map(meta => meta.display).getOrElse("No permanent metadata"),
+      padLabel("Ephemeral-Metadata-Scheme"),
+      sp.event.ephemeralMetadataScheme.map(meta => meta.display).getOrElse("No ephemeral metadata")
+    ).mkString("\n")
 
   implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>
-    s"Series Constructor\n" +
-    s"${padLabel("Id")}${series.seriesId.display}\n" +
-    s"${padLabel("Fungibility")}${series.fungibility.display}\n" +
-    s"${padLabel("Token-Supply")}${displayTokenSupply(series.tokenSupply)}\n" +
-    s"${padLabel("Quant-Descr.")}${series.quantityDescriptor.display}"
+    Seq(
+      "Series Constructor",
+      padLabel("Id") + series.seriesId.display,
+      padLabel("Fungibility") + series.fungibility.display,
+      padLabel("Token-Supply") + displayTokenSupply(series.tokenSupply),
+      padLabel("Quant-Descr.") + series.quantityDescriptor.display
+    ).mkString("\n")
 
   private def displayTokenSupply(tokenSupply: Option[Int]): String =
     tokenSupply.map(_.toString).getOrElse("UNLIMITED")

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/StructDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/StructDisplayOps.scala
@@ -1,0 +1,47 @@
+package co.topl.brambl.display
+
+import com.google.protobuf.struct.{Struct, Value}
+import com.google.protobuf.struct.Value.Kind.{
+  BoolValue,
+  Empty,
+  ListValue,
+  NullValue,
+  NumberValue,
+  StringValue,
+  StructValue
+}
+
+trait StructDisplayOps {
+  private val Indent = 2
+  private val InitialIndent = Indent
+
+  implicit val structDisplay: DisplayOps[Struct] = (struct: Struct) =>
+    " " * InitialIndent + display(struct, InitialIndent)
+
+  private def display(struct: Struct, indent: Int): String =
+    struct.fields.view.keys
+      .map({ key =>
+        struct.fields(key).kind match {
+          case StructValue(s) =>
+            s"$key:\n" + " " * (indent + Indent) + s"${display(s, indent + Indent)}"
+          case ListValue(l) =>
+            s"$key:\n" + l.values
+              .map(s => " " * (indent + Indent) + s"-${display(s, 0)}")
+              .mkString("\n")
+          case _ => s"$key: ${display(struct.fields(key), indent)}"
+        }
+      })
+      .mkString("\n" + " " * indent)
+
+  private def display(v: Value, indent: Int): String = v match {
+    case Value(NullValue(_), _)   => "null"
+    case Value(Empty, _)          => "empty"
+    case Value(BoolValue(b), _)   => b.toString()
+    case Value(NumberValue(n), _) => n.toString()
+    case Value(StringValue(s), _) => s
+    case Value(ListValue(l), _) =>
+      l.values.map(s => " " * indent + s"- ${display(s, 0)}").mkString("\n")
+    case Value(StructValue(s), _) =>
+      " " * indent + display(s, indent)
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
@@ -1,0 +1,21 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.utils.Encoding
+
+trait StxoDisplayOps {
+
+  implicit val stxoDisplay: DisplayOps[SpentTransactionOutput] = (stxo: SpentTransactionOutput) => s"""
+TxoAddress  : ${stxo.address.display}
+Attestation  : Not implemented
+${stxo.value.value.display}
+"""
+
+  implicit val txoAddressDisplay: DisplayOps[TransactionOutputAddress] = (txoAddress: TransactionOutputAddress) =>
+    s"${Encoding.encodeToBase58(
+        txoAddress.id.value.toByteArray()
+      )}#${txoAddress.index}"
+
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
@@ -4,6 +4,7 @@ import co.topl.brambl.display.DisplayOps.DisplayTOps
 import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.transaction.SpentTransactionOutput
 import co.topl.brambl.utils.Encoding
+import co.topl.genus.services.Txo
 
 trait StxoDisplayOps {
 
@@ -17,5 +18,11 @@ ${stxo.value.value.display}
     s"${Encoding.encodeToBase58(
         txoAddress.id.value.toByteArray()
       )}#${txoAddress.index}"
+
+  implicit val txoDisplay: DisplayOps[Txo] = (txo: Txo) => s"""
+TxoAddress : ${txo.outputAddress.display}
+LockAddress: ${txo.transactionOutput.address.display}
+${txo.transactionOutput.value.value.display}
+"""
 
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
@@ -8,21 +8,21 @@ import co.topl.genus.services.Txo
 
 trait StxoDisplayOps {
 
-  implicit val stxoDisplay: DisplayOps[SpentTransactionOutput] = (stxo: SpentTransactionOutput) => s"""
-${padLabel("TxoAddress")}  : ${stxo.address.display}
-${padLabel("Attestation")}  : Not implemented
-${stxo.value.value.display}
-"""
+  implicit val stxoDisplay: DisplayOps[SpentTransactionOutput] = (stxo: SpentTransactionOutput) =>
+    Seq(
+      padLabel("TxoAddress") + stxo.address.display,
+      padLabel("Attestation") + "Not implemented",
+      stxo.value.value.display
+    ).mkString("\n")
 
   implicit val txoAddressDisplay: DisplayOps[TransactionOutputAddress] = (txoAddress: TransactionOutputAddress) =>
-    s"${Encoding.encodeToBase58(
-        txoAddress.id.value.toByteArray()
-      )}#${txoAddress.index}"
+    s"${Encoding.encodeToBase58(txoAddress.id.value.toByteArray())}#${txoAddress.index}"
 
-  implicit val txoDisplay: DisplayOps[Txo] = (txo: Txo) => s"""
-${padLabel("TxoAddress")} : ${txo.outputAddress.display}
-${padLabel("LockAddress")}: ${txo.transactionOutput.address.display}
-${txo.transactionOutput.value.value.display}
-"""
+  implicit val txoDisplay: DisplayOps[Txo] = (txo: Txo) =>
+    Seq(
+      padLabel("TxoAddress") + txo.outputAddress.display,
+      padLabel("LockAddress") + txo.transactionOutput.address.display,
+      txo.transactionOutput.value.value.display
+    ).mkString("\n")
 
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/StxoDisplayOps.scala
@@ -9,8 +9,8 @@ import co.topl.genus.services.Txo
 trait StxoDisplayOps {
 
   implicit val stxoDisplay: DisplayOps[SpentTransactionOutput] = (stxo: SpentTransactionOutput) => s"""
-TxoAddress  : ${stxo.address.display}
-Attestation  : Not implemented
+${padLabel("TxoAddress")}  : ${stxo.address.display}
+${padLabel("Attestation")}  : Not implemented
 ${stxo.value.value.display}
 """
 
@@ -20,8 +20,8 @@ ${stxo.value.value.display}
       )}#${txoAddress.index}"
 
   implicit val txoDisplay: DisplayOps[Txo] = (txo: Txo) => s"""
-TxoAddress : ${txo.outputAddress.display}
-LockAddress: ${txo.transactionOutput.address.display}
+${padLabel("TxoAddress")} : ${txo.outputAddress.display}
+${padLabel("LockAddress")}: ${txo.transactionOutput.address.display}
 ${txo.transactionOutput.value.value.display}
 """
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
@@ -17,19 +17,15 @@ ${padLabel("TransactionId")}${tx.transactionId.getOrElse(tx.computeId).display}
 
 Group Policies
 ==============
-
 ${tx.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
 
 Series Policies
 ===============
-
 ${tx.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
 
 Asset Minting Statements
 ========================
-
 ${tx.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
-
 
 Inputs
 ======

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
@@ -1,0 +1,54 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.{Datum, TransactionId}
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.utils.Encoding
+
+trait TransactionDisplayOps {
+
+  implicit val transactionIdDisplay: DisplayOps[TransactionId] = (id: TransactionId) =>
+    Encoding.encodeToBase58(id.value.toByteArray())
+
+  implicit val transactionDisplay: DisplayOps[IoTransaction] = (tx: IoTransaction) =>
+    s"""
+TransactionId : ${tx.transactionId.getOrElse(tx.computeId).display}
+
+Group Policies
+==============
+
+${tx.groupPolicies.map(gp => gp.display).mkString("\n-----------\n")}
+
+Series Policies
+===============
+
+${tx.seriesPolicies.map(sp => sp.display).mkString("\n-----------\n")}
+
+Asset Minting Statements
+========================
+
+${tx.mintingStatements.map(ams => ams.display).mkString("\n-----------\n")}
+
+
+Inputs
+======
+${if (tx.inputs.isEmpty) ("No inputs")
+      else tx.inputs.map(stxo => stxo.display).mkString("\n-----------\n")}
+
+Outputs
+=======
+${if (tx.outputs.isEmpty) ("No outputs")
+      else tx.outputs.map(utxo => utxo.display).mkString("\n-----------\n")}
+Datum        :
+${tx.datum.display}
+"""
+
+  implicit val txDatumDisplay: DisplayOps[Datum.IoTransaction] = (datumIoTransation: Datum.IoTransaction) =>
+    s"""
+Value      : ${Encoding.encodeToBase58(
+        datumIoTransation.event.metadata.value.toByteArray()
+      )}
+"""
+
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/TransactionDisplayOps.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.display
 
 import co.topl.brambl.display.DisplayOps.DisplayTOps
-import co.topl.brambl.models.{Datum, TransactionId}
+import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
 import co.topl.brambl.utils.Encoding
@@ -13,7 +13,7 @@ trait TransactionDisplayOps {
 
   implicit val transactionDisplay: DisplayOps[IoTransaction] = (tx: IoTransaction) =>
     s"""
-TransactionId : ${tx.transactionId.getOrElse(tx.computeId).display}
+${padLabel("TransactionId")}${tx.transactionId.getOrElse(tx.computeId).display}
 
 Group Policies
 ==============
@@ -40,15 +40,9 @@ Outputs
 =======
 ${if (tx.outputs.isEmpty) ("No outputs")
       else tx.outputs.map(utxo => utxo.display).mkString("\n-----------\n")}
-Datum        :
-${tx.datum.display}
-"""
 
-  implicit val txDatumDisplay: DisplayOps[Datum.IoTransaction] = (datumIoTransation: Datum.IoTransaction) =>
-    s"""
-Value      : ${Encoding.encodeToBase58(
-        datumIoTransation.event.metadata.value.toByteArray()
-      )}
+Datum
+=====
+${padLabel("Value")}${Encoding.encodeToBase58(tx.datum.event.metadata.value.toByteArray())}
 """
-
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
@@ -1,0 +1,18 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.codecs.AddressCodecs
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+
+trait UtxoDisplayOps {
+
+  implicit val utxoDisplay: DisplayOps[UnspentTransactionOutput] = (utxo: UnspentTransactionOutput) => s"""
+LockAddress  : ${utxo.address.display}
+${utxo.value.value.display}
+"""
+
+  implicit val lockAddressDisplay: DisplayOps[LockAddress] = (lockAddress: LockAddress) =>
+    AddressCodecs.encodeAddress(lockAddress)
+
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
@@ -7,10 +7,11 @@ import co.topl.brambl.models.transaction.UnspentTransactionOutput
 
 trait UtxoDisplayOps {
 
-  implicit val utxoDisplay: DisplayOps[UnspentTransactionOutput] = (utxo: UnspentTransactionOutput) => s"""
-${padLabel("LockAddress")}${utxo.address.display}
-${utxo.value.value.display}
-"""
+  implicit val utxoDisplay: DisplayOps[UnspentTransactionOutput] = (utxo: UnspentTransactionOutput) =>
+    Seq(
+      padLabel("LockAddress") + utxo.address.display,
+      utxo.value.value.display
+    ).mkString("\n")
 
   implicit val lockAddressDisplay: DisplayOps[LockAddress] = (lockAddress: LockAddress) =>
     AddressCodecs.encodeAddress(lockAddress)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/UtxoDisplayOps.scala
@@ -8,7 +8,7 @@ import co.topl.brambl.models.transaction.UnspentTransactionOutput
 trait UtxoDisplayOps {
 
   implicit val utxoDisplay: DisplayOps[UnspentTransactionOutput] = (utxo: UnspentTransactionOutput) => s"""
-LockAddress  : ${utxo.address.display}
+${padLabel("LockAddress")}${utxo.address.display}
 ${utxo.value.value.display}
 """
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
@@ -2,9 +2,8 @@ package co.topl.brambl.display
 
 import co.topl.brambl.display.DisplayOps.DisplayTOps
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.box.Value.Value.{Asset, Group, Lvl, Series, Topl}
+import co.topl.brambl.models.box.Value.Value._
 import co.topl.brambl.syntax.{int128AsBigInt, valueToQuantitySyntaxOps}
-import co.topl.brambl.utils.Encoding
 
 import scala.util.{Failure, Success, Try}
 
@@ -12,28 +11,6 @@ trait ValueDisplayOps {
 
   implicit val valueDisplay: DisplayOps[Value.Value] = (value: Value.Value) =>
     s"""${typeDisplay(value)}\n${quantityDisplay(value)}"""
-
-  implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>
-    s"Group Constructor\n" +
-    s"Id           : ${group.groupId.display}\n" +
-    s"Fixed-Series : ${group.fixedSeries.map(sId => sId.display).getOrElse("NO FIXED SERIES")}"
-
-  implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>
-    s"Series Constructor\n" +
-    s"Id           : ${series.seriesId.display}\n" +
-    s"Fungibility  : ${series.fungibility.display}\n" +
-    s"Token-Supply : ${series.tokenSupply.getOrElse("UNLIMITED")}\n" +
-    s"Quant-Descr. : ${series.quantityDescriptor.display}"
-
-  implicit val assetDisplay: DisplayOps[Value.Asset] = (asset: Value.Asset) =>
-    s"Asset\n" +
-    s"GroupId      : ${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
-    s"SeriesId     : ${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
-    s"Commitment   : ${asset.commitment
-        .map(x => Encoding.encodeToHex(x.toByteArray()))
-        .getOrElse("No commitment")}\n" +
-    s"Ephemeral-Metadata: \n" +
-    s"${asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")}"
 
   def typeDisplay(value: Value.Value): String = {
     val vType = value match {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 trait ValueDisplayOps {
 
   implicit val valueDisplay: DisplayOps[Value.Value] = (value: Value.Value) =>
-    s"""${typeDisplay(value)}\n${quantityDisplay(value)}"""
+    s"${typeDisplay(value)}\n${quantityDisplay(value)}"
 
   def typeDisplay(value: Value.Value): String = {
     val vType = value match {
@@ -21,7 +21,7 @@ trait ValueDisplayOps {
       case Topl(_)   => "TOPL"
       case _         => "Unknown txo type"
     }
-    "Type         : " + vType
+    padLabel("Type") + vType
   }
 
   def quantityDisplay(value: Value.Value): String = {
@@ -31,6 +31,6 @@ trait ValueDisplayOps {
       case Success(asInt128) => (asInt128: BigInt).toString()
       case Failure(_)        => "Undefine type"
     }
-    "Value      : " + quantity
+    padLabel("Value") + quantity
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 trait ValueDisplayOps {
 
   implicit val valueDisplay: DisplayOps[Value.Value] = (value: Value.Value) =>
-    s"${typeDisplay(value)}\n${quantityDisplay(value)}"
+    Seq(typeDisplay(value), quantityDisplay(value)).mkString("\n")
 
   def typeDisplay(value: Value.Value): String = {
     val vType = value match {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/ValueDisplayOps.scala
@@ -1,0 +1,59 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.Value.Value.{Asset, Group, Lvl, Series, Topl}
+import co.topl.brambl.syntax.{int128AsBigInt, valueToQuantitySyntaxOps}
+import co.topl.brambl.utils.Encoding
+
+import scala.util.{Failure, Success, Try}
+
+trait ValueDisplayOps {
+
+  implicit val valueDisplay: DisplayOps[Value.Value] = (value: Value.Value) =>
+    s"""${typeDisplay(value)}\n${quantityDisplay(value)}"""
+
+  implicit val groupDisplay: DisplayOps[Value.Group] = (group: Value.Group) =>
+    s"Group Constructor\n" +
+    s"Id           : ${group.groupId.display}\n" +
+    s"Fixed-Series : ${group.fixedSeries.map(sId => sId.display).getOrElse("NO FIXED SERIES")}"
+
+  implicit val seriesDisplay: DisplayOps[Value.Series] = (series: Value.Series) =>
+    s"Series Constructor\n" +
+    s"Id           : ${series.seriesId.display}\n" +
+    s"Fungibility  : ${series.fungibility.display}\n" +
+    s"Token-Supply : ${series.tokenSupply.getOrElse("UNLIMITED")}\n" +
+    s"Quant-Descr. : ${series.quantityDescriptor.display}"
+
+  implicit val assetDisplay: DisplayOps[Value.Asset] = (asset: Value.Asset) =>
+    s"Asset\n" +
+    s"GroupId      : ${asset.groupId.map(gId => gId.display).getOrElse("N/A")}\n" +
+    s"SeriesId     : ${asset.seriesId.map(sId => sId.display).getOrElse("N/A")}\n" +
+    s"Commitment   : ${asset.commitment
+        .map(x => Encoding.encodeToHex(x.toByteArray()))
+        .getOrElse("No commitment")}\n" +
+    s"Ephemeral-Metadata: \n" +
+    s"${asset.ephemeralMetadata.map(meta => meta.display).getOrElse("No ephemeral metadata")}"
+
+  def typeDisplay(value: Value.Value): String = {
+    val vType = value match {
+      case Lvl(_)    => "LVL"
+      case Group(g)  => g.display
+      case Series(s) => s.display
+      case Asset(a)  => a.display
+      case Topl(_)   => "TOPL"
+      case _         => "Unknown txo type"
+    }
+    "Type         : " + vType
+  }
+
+  def quantityDisplay(value: Value.Value): String = {
+    val quantity = Try {
+      value.quantity
+    } match {
+      case Success(asInt128) => (asInt128: BigInt).toString()
+      case Failure(_)        => "Undefine type"
+    }
+    "Value      : " + quantity
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
@@ -11,7 +11,7 @@ package object display
     with TransactionDisplayOps
     with BlockDisplayOps {
 
-  val LabelLength = 14
+  val LabelLength = 27
 
   def padLabel(label: String): String = {
     val padding = " " * (LabelLength - label.length).max(0)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
@@ -2,11 +2,13 @@ package co.topl.brambl
 
 package object display
     extends UtxoDisplayOps
+    with StxoDisplayOps
     with ValueDisplayOps
     with StructDisplayOps
+    with AssetDisplayOps
     with GroupDisplayOps
-    with SeriesDisplayOps {
-  val Sep = "\n-----------\n"
+    with SeriesDisplayOps
+    with TransactionDisplayOps {
 
   trait DisplayOps[T] {
     def display(t: T): String

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
@@ -8,7 +8,8 @@ package object display
     with AssetDisplayOps
     with GroupDisplayOps
     with SeriesDisplayOps
-    with TransactionDisplayOps {
+    with TransactionDisplayOps
+    with BlockDisplayOps {
 
   trait DisplayOps[T] {
     def display(t: T): String

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
@@ -1,0 +1,22 @@
+package co.topl.brambl
+
+package object display
+    extends UtxoDisplayOps
+    with ValueDisplayOps
+    with StructDisplayOps
+    with GroupDisplayOps
+    with SeriesDisplayOps {
+  val Sep = "\n-----------\n"
+
+  trait DisplayOps[T] {
+    def display(t: T): String
+  }
+
+  object DisplayOps {
+    def apply[T](implicit ev: DisplayOps[T]): DisplayOps[T] = ev
+
+    implicit class DisplayTOps[T: DisplayOps](t: T) {
+      def display: String = DisplayOps[T].display(t)
+    }
+  }
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/display/package.scala
@@ -11,6 +11,13 @@ package object display
     with TransactionDisplayOps
     with BlockDisplayOps {
 
+  val LabelLength = 14
+
+  def padLabel(label: String): String = {
+    val padding = " " * (LabelLength - label.length).max(0)
+    s"${label}${padding}: "
+  }
+
   trait DisplayOps[T] {
     def display(t: T): String
   }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/display/DisplaySpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/display/DisplaySpec.scala
@@ -1,0 +1,144 @@
+package co.topl.brambl.display
+
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.transaction.Schedule
+import co.topl.brambl.models.{Datum, Event}
+import co.topl.brambl.syntax.longAsInt128
+import com.google.protobuf.ByteString
+import quivr.models.SmallData
+
+import scala.language.implicitConversions
+
+class DisplaySpec extends munit.FunSuite with MockHelpers {
+
+  test("Display Complex Transaction") {
+    val testTx = txFull
+      .withDatum(
+        Datum.IoTransaction(
+          Event
+            .IoTransaction(
+              Schedule(0, Long.MaxValue, System.currentTimeMillis),
+              SmallData(ByteString.copyFrom("metadata".getBytes))
+            )
+        )
+      )
+      .withGroupPolicies(Seq(Datum.GroupPolicy(mockGroupPolicy)))
+      .withSeriesPolicies(Seq(Datum.SeriesPolicy(mockSeriesPolicy)))
+      .withMintingStatements(
+        Seq(
+          AssetMintingStatement(mockGroupPolicy.registrationUtxo, mockSeriesPolicy.registrationUtxo, 1)
+        )
+      )
+      .withInputs(
+        Seq(
+          lvlValue,
+          groupValue,
+          seriesValue,
+          assetGroupSeries
+        ).map(value => inputFull.withValue(value))
+      )
+      .withOutputs(
+        Seq(
+          lvlValue,
+          groupValue,
+          seriesValue,
+          assetGroupSeries
+        ).map(value => output.withValue(value))
+      )
+    assertNoDiff(
+      testTx.display.trim(),
+      s"""
+TransactionId              : 3G1TsJUpmurYxMnzQ8NaBrnK3DymVGzRKLUwLysinjb6
+
+Group Policies
+==============
+Label                      : Mock Group Policy
+Registration-Utxo          : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Fixed-Series               : NO FIXED SERIES
+
+Series Policies
+===============
+Label                      : Mock Series Policy
+Registration-Utxo          : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Fungibility                : group-and-series
+Quantity-Descriptor        : liquid
+Token-Supply               : UNLIMITED
+Permanent-Metadata-Scheme  : \nNo permanent metadata
+Ephemeral-Metadata-Scheme  : \nNo ephemeral metadata
+
+Asset Minting Statements
+========================
+Group-Token-Utxo           : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Series-Token-Utxo          : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Quantity                   : 1
+Permanent-Metadata         : \nNo permanent metadata
+
+Inputs
+======
+TxoAddress                 : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Attestation                : Not implemented
+Type                       : LVL
+Value                      : 1
+-----------
+TxoAddress                 : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Attestation                : Not implemented
+Type                       : Group Constructor
+Id                         : cabf98baf365915d2282eca423bfae4a6425bad6064b8d97f2c39ba6e9fceafb
+Fixed-Series               : NO FIXED SERIES
+Value                      : 1
+-----------
+TxoAddress                 : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Attestation                : Not implemented
+Type                       : Series Constructor
+Id                         : 094c5a3acf338bcca90c91c9adcae5f4b59dec385740e80660111a3d6b10a8ce
+Fungibility                : group-and-series
+Token-Supply               : UNLIMITED
+Quant-Descr.               : liquid
+Value                      : 1
+-----------
+TxoAddress                 : 4pX2G4weCKBHDT9axEm3HChq6jURV7ZYRPgeb7KWkEzm#0
+Attestation                : Not implemented
+Type                       : Asset
+GroupId                    : cabf98baf365915d2282eca423bfae4a6425bad6064b8d97f2c39ba6e9fceafb
+SeriesId                   : 094c5a3acf338bcca90c91c9adcae5f4b59dec385740e80660111a3d6b10a8ce
+Commitment                 : No commitment
+Ephemeral-Metadata         : \nNo ephemeral metadata
+Value                      : 1
+
+Outputs
+=======
+LockAddress                : 1111111145ALDDRQ2EubxAYgTNdCKvTaP6GZXEWzi2vz6JmTAvryHY6ok
+Type                       : LVL
+Value                      : 1
+-----------
+LockAddress                : 1111111145ALDDRQ2EubxAYgTNdCKvTaP6GZXEWzi2vz6JmTAvryHY6ok
+Type                       : Group Constructor
+Id                         : cabf98baf365915d2282eca423bfae4a6425bad6064b8d97f2c39ba6e9fceafb
+Fixed-Series               : NO FIXED SERIES
+Value                      : 1
+-----------
+LockAddress                : 1111111145ALDDRQ2EubxAYgTNdCKvTaP6GZXEWzi2vz6JmTAvryHY6ok
+Type                       : Series Constructor
+Id                         : 094c5a3acf338bcca90c91c9adcae5f4b59dec385740e80660111a3d6b10a8ce
+Fungibility                : group-and-series
+Token-Supply               : UNLIMITED
+Quant-Descr.               : liquid
+Value                      : 1
+-----------
+LockAddress                : 1111111145ALDDRQ2EubxAYgTNdCKvTaP6GZXEWzi2vz6JmTAvryHY6ok
+Type                       : Asset
+GroupId                    : cabf98baf365915d2282eca423bfae4a6425bad6064b8d97f2c39ba6e9fceafb
+SeriesId                   : 094c5a3acf338bcca90c91c9adcae5f4b59dec385740e80660111a3d6b10a8ce
+Commitment                 : No commitment
+Ephemeral-Metadata         : \nNo ephemeral metadata
+Value                      : 1
+
+Datum
+=====
+Value                      : KJHK1EAZuVA
+""".trim()
+    )
+  }
+}


### PR DESCRIPTION
## Purpose

To add Pretty Print capabilities (allow users to Display) a transaction using the SDK

## Approach

The structure and display format already existing in brambl-cli. This PR refactors the code

-  Added a display package to the SDK
- Refactored the `display` functions to be accessible using `.display`. This aligns with our `ContainsImmutable` and `ContainsEvidence` pattern

## Testing

- Added a test with a complex transaction to the unit tests
- Ensured nothing in brambl-cli broke using this (see brambl-cli's PR)

## Tickets
* TSDK-663