### PR TITLE
TSDK-729 Support for Sha256 Digest Locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD - TODO replace date after release 
 
+### Added
+
+- Support for Sha256 Digest Propositions in the SDK. This change allows successful Quivr validation of a Digest Proposition with routine="Sha256".
+
 ## [v2.0.0-beta2] - 2024-01-10
 
 ### Added

--- a/brambl-sdk/src/main/scala/co/topl/brambl/Context.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/Context.scala
@@ -6,7 +6,11 @@ import co.topl.brambl.models.Datum
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
-import co.topl.brambl.validation.{Blake2b256DigestInterpreter, ExtendedEd25519SignatureInterpreter}
+import co.topl.brambl.validation.{
+  Blake2b256DigestInterpreter,
+  ExtendedEd25519SignatureInterpreter,
+  Sha256DigestInterpreter
+}
 import co.topl.common.ParsableDataInterface
 import co.topl.quivr.runtime.DynamicContext
 import co.topl.quivr.algebras.{DigestVerifier, SignatureVerifier}
@@ -17,8 +21,10 @@ import quivr.models.SignableBytes
 case class Context[F[_]: Monad](tx: IoTransaction, curTick: Long, heightDatums: String => Option[Datum])
     extends DynamicContext[F, String, Datum] {
 
-  override val hashingRoutines: Map[String, DigestVerifier[F]] =
-    Map("Blake2b256" -> Blake2b256DigestInterpreter.make())
+  override val hashingRoutines: Map[String, DigestVerifier[F]] = Map(
+    "Blake2b256" -> Blake2b256DigestInterpreter.make(),
+    "Sha256"     -> Sha256DigestInterpreter.make()
+  )
 
   override val signingRoutines: Map[String, SignatureVerifier[F]] =
     Map("ExtendedEd25519" -> ExtendedEd25519SignatureInterpreter.make())

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/Sha256DigestInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/Sha256DigestInterpreter.scala
@@ -1,0 +1,37 @@
+package co.topl.brambl.validation
+
+import cats.Monad
+import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherId}
+import co.topl.crypto.hash.implicits.sha256Hash
+import co.topl.quivr.algebras.DigestVerifier
+import co.topl.quivr.runtime.QuivrRuntimeError
+import co.topl.quivr.runtime.QuivrRuntimeErrors.ValidationError.{
+  LockedPropositionIsUnsatisfiable,
+  UserProvidedInterfaceFailure
+}
+import quivr.models.{Digest, DigestVerification, Preimage}
+
+/**
+ * Validates that a Sha256 digest is valid.
+ */
+object Sha256DigestInterpreter {
+
+  def make[F[_]: Monad](): DigestVerifier[F] = new DigestVerifier[F] {
+
+    /**
+     * Validates that an Sha256 digest is valid.
+     * @param t DigestVerification object containing the digest and preimage
+     * @return The DigestVerification object if the digest is valid, otherwise an error
+     */
+    override def validate(t: DigestVerification): F[Either[QuivrRuntimeError, DigestVerification]] = t match {
+      case DigestVerification(Digest(expectedDigest, _), Preimage(p, salt, _), _) =>
+        val testHash: Array[Byte] = sha256Hash.hash(p.toByteArray ++ salt.toByteArray).value
+        if (java.util.Arrays.equals(testHash, expectedDigest.toByteArray))
+          t.asRight[QuivrRuntimeError].pure[F]
+        else
+          (LockedPropositionIsUnsatisfiable: QuivrRuntimeError).asLeft[DigestVerification].pure[F]
+      case _ =>
+        (UserProvidedInterfaceFailure: QuivrRuntimeError).asLeft[DigestVerification].pure[F]
+    }
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockHelpers.scala
@@ -36,6 +36,7 @@ import quivr.models.{
 }
 import co.topl.brambl.syntax.{cryptoToPbKeyPair, pbKeyPairToCryptoKeyPair}
 import co.topl.crypto.generation.Bip32Indexes
+import co.topl.crypto.hash.implicits.sha256Hash
 import co.topl.crypto.signing.ExtendedEd25519
 
 trait MockHelpers {
@@ -70,10 +71,17 @@ trait MockHelpers {
 
   // Hardcoding Blake2b256
   val MockDigestRoutine: String = "Blake2b256"
+  val MockSha256DigestRoutine: String = "Sha256"
 
   val MockDigest: Digest =
     Digest(ByteString.copyFrom((new Blake2b256).hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray)))
+
+  val MockSha256Digest: Digest =
+    Digest(ByteString.copyFrom(sha256Hash.hash(MockPreimage.input.toByteArray ++ MockPreimage.salt.toByteArray).value))
   val MockDigestProposition: Id[Proposition] = Proposer.digestProposer[Id].propose((MockDigestRoutine, MockDigest))
+
+  val MockSha256DigestProposition: Id[Proposition] =
+    Proposer.digestProposer[Id].propose((MockSha256DigestRoutine, MockSha256Digest))
   val MockDigestProof: Id[Proof] = Prover.digestProver[Id].prove(MockPreimage, fakeMsgBind)
 
   val MockMin: Long = 0L

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletStateApi.scala
@@ -24,7 +24,8 @@ object MockWalletStateApi extends WalletStateAlgebra[IO] with MockHelpers {
   )
 
   var propEvidenceToPreimage: Map[Evidence, Preimage] = Map(
-    MockDigestProposition.value.digest.get.sizedEvidence -> MockPreimage
+    MockDigestProposition.value.digest.get.sizedEvidence       -> MockPreimage,
+    MockSha256DigestProposition.value.digest.get.sizedEvidence -> MockPreimage
   )
 
   override def getIndicesBySignature(signatureProposition: Proposition.DigitalSignature): F[Option[Indices]] =

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/locks/PropositionTemplateSpec.scala
@@ -4,8 +4,8 @@ import cats.Id
 import co.topl.brambl.MockHelpers
 import co.topl.brambl.builders.locks.PropositionTemplate.UnableToBuildPropositionTemplate
 import com.google.protobuf.ByteString
-import quivr.models.Proposition.Value._
 import quivr.models.Data
+import quivr.models.Proposition.Value._
 
 class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
 
@@ -48,6 +48,17 @@ class PropositionTemplateSpec extends munit.FunSuite with MockHelpers {
     assert(digestProposition.value.isDigest)
     assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, MockDigestRoutine)
     assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, MockDigest)
+  }
+
+  test("Build Sha256 Digest Proposition via Template") {
+    val digestTemplate = PropositionTemplate.DigestTemplate[Id](MockSha256DigestRoutine, MockSha256Digest)
+    // No verification keys needed for digest. However, supplying them should not affect the result.
+    val digestInstance = digestTemplate.build(Nil)
+    assert(digestInstance.isRight)
+    val digestProposition = digestInstance.toOption.get
+    assert(digestProposition.value.isDigest)
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.routine, "Sha256")
+    assertEquals(digestProposition.value.asInstanceOf[Digest].value.digest, MockSha256Digest)
   }
 
   test("Build Signature Proposition via Template") {

--- a/documentation/docs/reference/locks/create-template.mdx
+++ b/documentation/docs/reference/locks/create-template.mdx
@@ -128,7 +128,8 @@ case class DigestTemplate[F[_]: Monad](
 ) extends PropositionTemplate[F]
 ```
 
-The parameters are the same as a Digest proposition.
+The parameters are the same as a Digest proposition. Currently, the only supported values of the `routine` parameter are
+`Blake2b256` and `Sha256`.
 
 :::note
 When creating a Digest Template or Proposition, the preimage of the digest should be added to the Wallet State. The preimage
@@ -155,6 +156,8 @@ The parameters are similar to a DigitalSignature proposition. The key difference
 in a list of verification keys. `entityIdx` in conjunction with this list of verification keys (which is provided when building
 the lock), will be used to populate the `verificationKey` field in the built DigitalSignature proposition.
 See [Generate a Lock](./build-lock) for more information.
+
+Currently, the only supported value of the `routine` parameter is `ExtendedEd25519`.
 
 ### AndTemplate
 


### PR DESCRIPTION
## Purpose

With the upcoming BTC bridge, we need to support Sha256 Digest propositions in our ecosystem (so the preimages and digests are cross compatible with bitcoin). This PR adds this support.

## Approach

- Propositions themselves are routine-agnostic, so no changes were needed to the quivr package
- We already have a Sha256 implementation, so no changes were needed to the crypto package
- In brambl-sdk, added a Sha256DigestInterpreter which validates a given Digest and Preimage using the Sha256 routine.
- In brambl-sdk, added the "Sha256" routine to `hashingRoutines` in the Context object; this routine uses the newly created Sha256DigestInterpreter, allowing the quivr verifier to validate for any Digest propositions using a "Sha256" routine.
-  In the docs, we now list the possible values for `routine` (for both digest and signature operations) 

## Testing

- Ensured exiting tests pass
- Added a test for Proposition Templates (sanity): Ensure a Digest Template with routine "Sha256" creates a Digest Proposition with routine "Sha256"
- Added a test for proving and verifying: Ensure that a Transaction requiring both Blake2b256 and Sha256 digest propositions to be satisfied can be proven and valid, given that the WalletStateApi contains the relevant preimages. This tests that the "Sha256" routine within Context works as expected.

## Tickets
* Closes TSDK-729