### PR TITLE
CatsUnsafeResource Use cede

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreter.scala
@@ -53,6 +53,8 @@ object TransactionCostCalculatorInterpreter {
             p.responses.map(proofCost).sum
           case Attestation.Value.Commitment(p) =>
             p.responses.map(proofCost).sum
+          case _ =>
+            0L
         })
 
       /**


### PR DESCRIPTION
## Purpose
- CatsUnsafeResource usually wraps cryptographic routines, which are generally CPU-intensive
- CPU-intensive calls should be wrapped in `Async[F].cede` to prevent starvation
- Unrelated: Fixed Match warnings in TransactionCostCalculator and TransactionAuthorizationInterpreter
- Unrelated: Noticed logic error in TransactionAuthorizationInterpreter that would only validate the _last_ input of a transaction
## Approach
- Modify CatsUnsafeResource implementation to `cede` before and after the Resource allocation.  Also `cede` after resource initialization
- Add case statements for empty attestation
- Modify TransactionAuthorizationValidation to use `.foldLeftM` instead of `foldLeft` to account for the F-context.  If `Left` is found, short-circuit.
## Testing
- `preparePR`
- Tested in Bifrost's NodeAppTest
## Tickets
- #BN-1386