### PR TITLE
TSDK-758 Monitor Bifrost Blocks (live)

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -115,8 +115,10 @@ jobs:
       - name: Run integration tests
         run: |
           docker run -d --rm --add-host host.docker.internal:host-gateway -p 18444:18444 -p 18443:18443 -p 28332:28332 --name=bitcoind ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
+          docker run -d --rm --name bifrost -p 9084:9084 docker.io/toplprotocol/bifrost-node:2.0.0-beta3
           sbt "integration / test"
           docker kill bitcoind
+          docker kill bifrost
       - uses: actions/download-artifact@v3
         with:
           path: target/test-reports/

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/AggregationOps.scala
@@ -5,7 +5,6 @@ import co.topl.brambl.models.box.Value._
 import co.topl.brambl.syntax.{
   bigIntAsInt128,
   int128AsBigInt,
-  valueToQuantityDescriptorSyntaxOps,
   valueToQuantitySyntaxOps,
   valueToTypeIdentifierSyntaxOps,
   AssetType,
@@ -13,7 +12,6 @@ import co.topl.brambl.syntax.{
   UnknownType
 }
 
-import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 /**

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -1,8 +1,8 @@
 package co.topl.brambl.builders
 
 import cats.data.{Chain, NonEmptyChain, Validated, ValidatedNec}
-import cats.implicits.{catsSyntaxEitherId, catsSyntaxOptionId, catsSyntaxValidatedIdBinCompat0, toFoldableOps}
-import co.topl.brambl.models.box.{AssetMintingStatement, FungibilityType, Lock, QuantityDescriptorType}
+import cats.implicits.{catsSyntaxEitherId, catsSyntaxValidatedIdBinCompat0, toFoldableOps}
+import co.topl.brambl.models.box.{AssetMintingStatement, QuantityDescriptorType}
 import co.topl.brambl.models.{LockAddress, SeriesId, TransactionOutputAddress}
 import co.topl.brambl.models.box.Value._
 import quivr.models.Int128

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/LockTemplate.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/locks/LockTemplate.scala
@@ -4,7 +4,7 @@ import co.topl.brambl.builders.BuilderError
 import co.topl.brambl.models.box.{Challenge, Lock}
 import LockTemplate.LockType
 import cats.Monad
-import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherId, toFlatMapOps, toFunctorOps}
+import cats.implicits.{catsSyntaxApplicativeId, catsSyntaxEitherId, toFlatMapOps}
 import co.topl.brambl.builders.locks.PropositionTemplate.ThresholdTemplate
 import quivr.models.{Proposition, VerificationKey}
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/AddressCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/AddressCodecs.scala
@@ -3,8 +3,6 @@ package co.topl.brambl.codecs
 import co.topl.brambl.utils.EncodingError
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.utils.Encoding._
-import co.topl.brambl.models.Evidence
-import quivr.models.Digest
 import com.google.protobuf.ByteString
 import co.topl.brambl.models.LockId
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/codecs/PropositionTemplateCodecs.scala
@@ -6,10 +6,8 @@ import co.topl.brambl.builders.locks.PropositionTemplate
 import co.topl.brambl.builders.locks.PropositionTemplate._
 import co.topl.brambl.utils.Encoding.{decodeFromBase58, encodeToBase58}
 import com.google.protobuf.ByteString
-import io.circe.DecodingFailure.Reason.CustomReason
 import io.circe.syntax.EncoderOps
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
-import org.bouncycastle.util.Strings
 import quivr.models.{Data, Digest}
 
 object PropositionTemplateCodecs {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsEvidence.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsEvidence.scala
@@ -52,7 +52,7 @@ object ContainsEvidence {
               MerkleTree
                 .apply[Blake2b, Digest32](
                   list.zipWithIndex
-                    .map { case (item, index) =>
+                    .map { case (item, _) =>
                       LeafData(ContainsImmutable[T].immutableBytes(item).value.toByteArray)
                     }
                 )

--- a/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsSignable.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/common/ContainsSignable.scala
@@ -8,7 +8,6 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.models.transaction.SpentTransactionOutput
 import quivr.models._
 
-import scala.language.implicitConversions
 // Long -> longSignable -> longSignableEvidence -> longSignableEvidenceId
 // Long -> longSignable -> longSignableEvidence -> longSingableEvidenceSignable -> longSingableEvidenceSignableEvidence
 // Object -> Signable -> Evidence -> Identifier -> Address -> KnownIdentifier

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
@@ -1,7 +1,7 @@
 package co.topl.brambl.dataApi
 
 import cats.data.OptionT
-import cats.effect.kernel.{Async, Resource}
+import cats.effect.kernel.{Resource, Sync}
 import cats.free.Free
 import co.topl.brambl.models.TransactionId
 import co.topl.brambl.models.transaction.IoTransaction
@@ -114,7 +114,7 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
   def broadcastTransactionF(tx: IoTransaction): BifrostQueryADTMonad[TransactionId] =
     Free.liftF(BroadcastTransaction(tx))
 
-  def make[F[_]: Async](channelResource: Resource[F, ManagedChannel]): BifrostQueryAlgebra[F] =
+  def make[F[_]: Sync](channelResource: Resource[F, ManagedChannel]): BifrostQueryAlgebra[F] =
     new BifrostQueryAlgebra[F] {
 
       override def blockByDepth(depth: Long): F[Option[(BlockId, BlockHeader, BlockBody, Seq[IoTransaction])]] = {

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
@@ -81,8 +81,6 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
 
   case class BlockByDepth(depth: Long) extends BifrostQueryADT[Option[BlockId]]
 
-//  case class SynchronizationTraversal() extends BifrostQueryADT[Stream[_, SynchronizationTraversalRes]]
-
   case class SynchronizationTraversal() extends BifrostQueryADT[Iterator[SynchronizationTraversalRes]]
 
   case class BroadcastTransaction(tx: IoTransaction) extends BifrostQueryADT[TransactionId]

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
@@ -109,6 +109,7 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
 
   def blockByDepthF(depth: Long): BifrostQueryADTMonad[Option[BlockId]] =
     Free.liftF(BlockByDepth(depth))
+
   def synchronizationTraversalF[F[_]](): BifrostQueryADTMonad[Iterator[SynchronizationTraversalRes]] =
     Free.liftF(SynchronizationTraversal())
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
@@ -112,39 +112,4 @@ trait BifrostQueryInterpreter {
     }
   }
 
-//  def interpretADTStream[A, F[_] : Async](
-//                                    channelResource: Resource[F, ManagedChannel],
-//                                    computation: BifrostQueryAlgebra.BifrostQueryADTMonad[A]
-//                                  ): F[A] = {
-//    type ChannelContextKlesli[A] =
-//      Kleisli[F, NodeRpcFs2Grpc[F, Metadata], A]
-//    val kleisliComputation = computation.foldMap[ChannelContextKlesli](
-//      new FunctionK[BifrostQueryAlgebra.BifrostQueryADT, ChannelContextKlesli] {
-//
-//        override def apply[A](
-//                               fa: BifrostQueryAlgebra.BifrostQueryADT[A]
-//                             ): ChannelContextKlesli[A] = {
-//          import cats.implicits._
-//          fa match {
-//            case BifrostQueryAlgebra.SynchronizationTraversal() =>
-//              Kleisli(blockingStub =>
-//                Sync[F]
-//                  .blocking(
-//                    blockingStub
-//                      .synchronizationTraversal(SynchronizationTraversalReq(), new Metadata())
-//                  )
-//                  .map(_.asInstanceOf[A])
-//              )
-//          }
-//        }
-//      }
-//    )
-//    (for {
-//      channel <- channelResource
-//      stubResource <- NodeRpcFs2Grpc.stubResource[F](channel)
-//    } yield stubResource).use { stubResource =>
-//      kleisliComputation.run(stubResource)
-//    }
-//  }
-
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
@@ -1,0 +1,73 @@
+package co.topl.brambl.monitoring
+
+import cats.effect.IO
+import co.topl.brambl.dataApi.BifrostQueryAlgebra
+import co.topl.brambl.display.blockIdDisplay.display
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.monitoring.BifrostMonitor.{AppliedBifrostBlock, BifrostBlockSync, UnappliedBifrostBlock}
+import co.topl.consensus.models.BlockId
+import co.topl.node.models.FullBlockBody
+import co.topl.node.services.SynchronizationTraversalRes
+import co.topl.node.services.SynchronizationTraversalRes.Status.{Applied, Unapplied}
+import fs2.Stream
+
+/**
+ * Class to monitor incoming bifrost blocks via an iterator.
+ * @param blockIterator The iterator in which block changes will be added to
+ * @param startingBlocks Past blocks that should be reported.
+ */
+class BifrostMonitor(
+  blockIterator:     Iterator[SynchronizationTraversalRes],
+  getFullBlock: BlockId => IO[FullBlockBody],
+  startingBlocks: Vector[BifrostBlockSync],
+) {
+  def pipe(in: Stream[IO, SynchronizationTraversalRes]): Stream[IO, BifrostBlockSync] = in.evalMap(sync => sync.status match {
+    case Applied(blockId) => getFullBlock(blockId).map(AppliedBifrostBlock)
+    case Unapplied(blockId) => getFullBlock(blockId).map(UnappliedBifrostBlock)
+  })
+  /**
+   * Return a stream of block updates.
+   * @return The infinite stream of block updatess. If startingBlocks was provided, they will be at the front of the stream.
+   */
+  def monitorBlocks(): Stream[IO, BifrostBlockSync] = Stream.emits(startingBlocks) ++
+    Stream.fromIterator[IO](blockIterator, 1).through(pipe)
+
+}
+
+object BifrostMonitor {
+  /**
+   * A wrapper for a Bifrost Block Sync update.
+   */
+  trait BifrostBlockSync {
+    // The bifrost Block being wrapped. This represents either an Applied block or an Unapplied block
+    val block: FullBlockBody
+    def transactions[F[_]]: Stream[F, IoTransaction] = Stream.emits(block.transactions)
+  }
+
+  // Represents a new block applied to the chain tip
+  case class AppliedBifrostBlock(block: FullBlockBody) extends BifrostBlockSync
+  // Represents an existing block that has been unapplied from the chain tip
+  case class UnappliedBifrostBlock(block: FullBlockBody) extends BifrostBlockSync
+
+  /**
+   * Initialize and return a BifrostMonitor instance.
+   * @param bifrostQuery The bifrost query api to retrieve updates from
+   * @param startBlock The blockId of a past block. Used to retroactively report blocks. The bifrost monitor will report all blocks starting at this block.
+   * @return An instance of a BifrostMonitor
+   */
+  def apply(
+   bifrostQuery:   BifrostQueryAlgebra[IO],
+   startBlock: Option[BlockId] = None
+  ): IO[BifrostMonitor] = {
+    def getFullBlock(blockId: BlockId): IO[FullBlockBody] = for {
+      block <- bifrostQuery.blockById(blockId)
+    } yield block match {
+      case None => throw new Exception(s"Unable to query block ${display(blockId)}")
+      case Some((_, _, _, txs)) => FullBlockBody(txs)
+    }
+    for {
+      updates <- bifrostQuery.synchronizationTraversal()
+    } yield new BifrostMonitor(updates,getFullBlock, Vector.empty)
+  }
+
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionCostCalculatorInterpreter.scala
@@ -1,7 +1,6 @@
 package co.topl.brambl.validation
 
 import cats.Applicative
-import cats.implicits._
 import co.topl.brambl.common.ContainsImmutable.instances.ioTransactionImmutable
 import co.topl.brambl.models.box.Attestation
 import co.topl.brambl.models.transaction._

--- a/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/validation/TransactionSyntaxInterpreter.scala
@@ -6,9 +6,6 @@ import cats.implicits._
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.TransactionOutputAddress
-import co.topl.brambl.models.{SeriesId, TransactionOutputAddress}
-import co.topl.brambl.models.Datum.GroupPolicy
-import co.topl.brambl.models.{SeriesId, TransactionOutputAddress}
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.{IoTransaction, SpentTransactionOutput, UnspentTransactionOutput}
 import co.topl.brambl.syntax._

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/Credentialler.scala
@@ -3,7 +3,6 @@ package co.topl.brambl.wallet
 import co.topl.brambl.Context
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.validation.ValidationError
-import quivr.models.Proof
 
 /**
  * Defines a Credentialler. A Credentialler is responsible for proving and verifying transactions.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/wallet/WalletApi.scala
@@ -1,9 +1,7 @@
 package co.topl.brambl.wallet
 
-import cats.implicits.catsSyntaxApplicativeId
 import co.topl.crypto.generation.mnemonic.{Entropy, MnemonicSize, MnemonicSizes}
-import cats.{Eq, Monad}
-import cats.implicits.{toFlatMapOps, toFunctorOps}
+import cats.Monad
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra
 import co.topl.crypto.generation.{Bip32Indexes, KeyInitializer}
 import KeyInitializer.Instances.extendedEd25519Initializer
@@ -13,22 +11,14 @@ import co.topl.crypto.encryption.kdf.SCrypt
 import co.topl.crypto.encryption.cipher.Cipher
 import co.topl.crypto.encryption.cipher.Aes
 import co.topl.crypto.signing.ExtendedEd25519
-import co.topl.crypto.signing
-import com.google.protobuf.ByteString
 import quivr.models._
-import quivr.models.VerificationKey._
-import quivr.models.SigningKey._
 import co.topl.brambl.syntax.{cryptoToPbKeyPair, cryptoVkToPbVk, pbKeyPairToCryptoKeyPair, pbVkToCryptoVk}
 import cats.implicits._
 
-import scala.language.implicitConversions
 import cats.data.EitherT
 import cats.arrow.FunctionK
-import cats.effect.IO.asyncForIO
-import cats.effect.kernel.implicits._
-import cats.effect.implicits._
 import cats.effect.kernel.Async
-import cats.effect.{IO, Resource}
+import cats.effect.Resource
 import co.topl.brambl.models.Indices
 import co.topl.brambl.utils.CatsUnsafeResource
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/MockWalletKeyApi.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl
 
-import cats.Id
 import cats.effect.IO
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra
 import co.topl.brambl.dataApi.WalletKeyApiAlgebra.WalletKeyException

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/AggregationOpsSpec.scala
@@ -1,8 +1,7 @@
 package co.topl.brambl.builders
 
 import cats.implicits.catsSyntaxOptionId
-import co.topl.brambl.models.box.Value
-import co.topl.brambl.syntax.{bigIntAsInt128, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps, UnknownType}
+import co.topl.brambl.syntax.{bigIntAsInt128, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 
 class AggregationOpsSpec extends TransactionBuilderInterpreterSpecBase {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMintingSpec.scala
@@ -3,24 +3,25 @@ package co.topl.brambl.builders
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.common.ContainsEvidence.Ops
 import co.topl.brambl.common.ContainsImmutable.instances.lockImmutable
-import co.topl.brambl.models.{LockAddress, LockId}
-import co.topl.brambl.models.box.FungibilityType.{GROUP, SERIES}
-import co.topl.brambl.models.box.QuantityDescriptorType.{ACCUMULATOR, FRACTIONABLE, IMMUTABLE}
-import co.topl.brambl.models.box.{AssetMintingStatement, Value}
-import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
-import co.topl.brambl.syntax.{
-  assetAsBoxVal,
-  bigIntAsInt128,
-  groupAsBoxVal,
-  groupPolicyAsGroupPolicySyntaxOps,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  seriesAsBoxVal,
-  seriesPolicyAsSeriesPolicySyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType
-}
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.LockId
+import co.topl.brambl.models.box.FungibilityType.GROUP
+import co.topl.brambl.models.box.FungibilityType.SERIES
+import co.topl.brambl.models.box.QuantityDescriptorType.ACCUMULATOR
+import co.topl.brambl.models.box.QuantityDescriptorType.FRACTIONABLE
+import co.topl.brambl.models.box.QuantityDescriptorType.IMMUTABLE
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax.LvlType
+import co.topl.brambl.syntax.assetAsBoxVal
+import co.topl.brambl.syntax.bigIntAsInt128
+import co.topl.brambl.syntax.groupAsBoxVal
+import co.topl.brambl.syntax.groupPolicyAsGroupPolicySyntaxOps
+import co.topl.brambl.syntax.int128AsBigInt
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.seriesAsBoxVal
+import co.topl.brambl.syntax.seriesPolicyAsSeriesPolicySyntaxOps
+import co.topl.brambl.syntax.valueToTypeIdentifierSyntaxOps
 import quivr.models.Int128
 
 class TransactionBuilderInterpreterAssetMintingSpec extends TransactionBuilderInterpreterSpecBase {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetTransferSpec.scala
@@ -2,15 +2,9 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType,
-  UnknownType
-}
+import co.topl.brambl.syntax.LvlType
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.valueToTypeIdentifierSyntaxOps
 
 class TransactionBuilderInterpreterAssetTransferSpec extends TransactionBuilderInterpreterSpecBase {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterGroupTransferSpec.scala
@@ -2,15 +2,10 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType,
-  UnknownType
-}
+import co.topl.brambl.syntax.LvlType
+import co.topl.brambl.syntax.UnknownType
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.valueToTypeIdentifierSyntaxOps
 
 class TransactionBuilderInterpreterGroupTransferSpec extends TransactionBuilderInterpreterSpecBase {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterLvlsTransferSpec.scala
@@ -2,14 +2,9 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType
-}
+import co.topl.brambl.syntax.LvlType
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.valueToTypeIdentifierSyntaxOps
 
 class TransactionBuilderInterpreterLvlsTransferSpec extends TransactionBuilderInterpreterSpecBase {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSeriesTransferSpec.scala
@@ -2,14 +2,9 @@ package co.topl.brambl.builders
 
 import co.topl.brambl.models.box.Value
 import co.topl.brambl.models.transaction.IoTransaction
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  int128AsBigInt,
-  ioTransactionAsTransactionSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType
-}
+import co.topl.brambl.syntax.LvlType
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.valueToTypeIdentifierSyntaxOps
 
 class TransactionBuilderInterpreterSeriesTransferSpec extends TransactionBuilderInterpreterSpecBase {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/codecs/AddressCodecsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/codecs/AddressCodecsSpec.scala
@@ -1,10 +1,10 @@
 package co.topl.brambl.codecs
 
+import co.topl.brambl.constants.NetworkConstants
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.LockId
 import com.google.protobuf.ByteString
-import co.topl.brambl.utils.Encoding
-import co.topl.brambl.constants.NetworkConstants
+
 import scala.util.Random
 
 class AddressCodecsSpec extends munit.FunSuite with AddressCodecTestCases {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/common/ContainsSignableSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/common/ContainsSignableSpec.scala
@@ -7,8 +7,6 @@ import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
 import co.topl.brambl.common.ContainsSignable.instances._
 import co.topl.brambl.models.box.Attestation
 
-import scala.language.implicitConversions
-
 class ContainsSignableSpec extends munit.FunSuite with MockHelpers {
 
   test("IoTransaction.signable should return the same bytes as IoTransaction.immutable minus the Proofs") {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/display/DisplaySpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/display/DisplaySpec.scala
@@ -1,18 +1,23 @@
 package co.topl.brambl.display
 
 import cats.effect.unsafe.implicits.global
+import co.topl.brambl.Context
+import co.topl.brambl.MockHelpers
+import co.topl.brambl.MockWalletKeyApi
+import co.topl.brambl.MockWalletStateApi
 import co.topl.brambl.display.DisplayOps.DisplayTOps
+import co.topl.brambl.models.Datum
+import co.topl.brambl.models.Event
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.Schedule
-import co.topl.brambl.models.{Datum, Event}
-import co.topl.brambl.syntax.{bigIntAsInt128, longAsInt128}
-import co.topl.brambl.wallet.{CredentiallerInterpreter, WalletApi}
-import co.topl.brambl.{Context, MockHelpers, MockWalletKeyApi, MockWalletStateApi}
+import co.topl.brambl.syntax.bigIntAsInt128
+import co.topl.brambl.syntax.longAsInt128
+import co.topl.brambl.wallet.CredentiallerInterpreter
+import co.topl.brambl.wallet.WalletApi
 import co.topl.quivr.api.Proposer
 import com.google.protobuf.ByteString
-import quivr.models.{Proof, SmallData}
-
-import scala.language.implicitConversions
+import quivr.models.Proof
+import quivr.models.SmallData
 
 class DisplaySpec extends munit.FunSuite with MockHelpers {
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntaxSpec.scala
@@ -3,7 +3,6 @@ package co.topl.brambl.syntax
 import cats.implicits.catsSyntaxOptionId
 import co.topl.brambl.MockHelpers
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.box.Value.{Value => BoxValue}
 import com.google.protobuf.ByteString
 
 class TokenTypeIdentifierSyntaxSpec extends munit.FunSuite with MockHelpers {

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterAssetSpec.scala
@@ -3,13 +3,16 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.QuantityDescriptorType.{IMMUTABLE, LIQUID}
-import co.topl.brambl.models.box.{AssetMintingStatement, FungibilityType, Value}
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Event, TransactionOutputAddress}
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.box.FungibilityType
+import co.topl.brambl.models.box.QuantityDescriptorType.IMMUTABLE
+import co.topl.brambl.models.box.QuantityDescriptorType.LIQUID
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseASpec.scala
@@ -3,11 +3,13 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.{AssetMintingStatement, FungibilityType, Value}
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.Datum
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseBSpec.scala
@@ -3,11 +3,13 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.Datum
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseCSpec.scala
@@ -3,11 +3,13 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.{AssetMintingStatement, Value}
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Event, TransactionOutputAddress}
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterMintingCaseProposalUpdateSpec.scala
@@ -3,11 +3,11 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
+import co.topl.brambl.models.TransactionOutputAddress
 import co.topl.brambl.models.box.Value
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterRuleBSpec.scala
@@ -3,11 +3,14 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.{AssetMintingStatement, Value}
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, TransactionOutputAddress}
+import co.topl.brambl.models.Datum
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.AssetMintingStatement
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation:

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterSpec.scala
@@ -3,14 +3,17 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.{Attestation, Challenge, Lock, Value}
-import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Datum, Event, GroupId, SeriesId}
-import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
-import co.topl.quivr.api.{Proposer, Prover}
+import co.topl.brambl.models.box.Attestation
+import co.topl.brambl.models.box.Challenge
+import co.topl.brambl.models.box.Lock
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.Schedule
+import co.topl.quivr.api.Proposer
+import co.topl.quivr.api.Prover
 import com.google.protobuf.ByteString
-import quivr.models.{Int128, Proof, Proposition, SmallData}
-import scala.language.implicitConversions
+import quivr.models.Int128
+import quivr.models.Proof
+import quivr.models.Proposition
 
 class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
 
@@ -156,7 +159,7 @@ class TransactionSyntaxInterpreterSpec extends munit.FunSuite with MockHelpers {
   }
 
   test("Invalid data-length transaction > MaxDataLength ") {
-    val invalidData = ByteString.copyFrom(Array.fill(TransactionSyntaxInterpreter.MaxDataLength + 1)(1.toByte))
+    ByteString.copyFrom(Array.fill(TransactionSyntaxInterpreter.MaxDataLength + 1)(1.toByte))
     val testTx = txFull.copy(outputs = List.fill(5000)(output))
 
     val validator = TransactionSyntaxInterpreter.make[Id]()

--- a/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/validation/TransactionSyntaxInterpreterTransferSeriesSpec.scala
@@ -3,11 +3,12 @@ package co.topl.brambl.validation
 import cats.Id
 import cats.implicits._
 import co.topl.brambl.MockHelpers
-import co.topl.brambl.models.box.{AssetMintingStatement, Value}
-import co.topl.brambl.models.transaction.{SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.models.{Event, TransactionOutputAddress}
+import co.topl.brambl.models.Event
+import co.topl.brambl.models.TransactionOutputAddress
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.SpentTransactionOutput
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.syntax._
-import scala.language.implicitConversions
 
 /**
  * Test to coverage this specific syntax validation: Transfer series
@@ -16,7 +17,7 @@ import scala.language.implicitConversions
 class TransactionSyntaxInterpreterTransferSeriesSpec extends munit.FunSuite with MockHelpers {
 
   private val txoAddress_1 = TransactionOutputAddress(1, 0, 0, dummyTxIdentifier)
-  private val txoAddress_2 = TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
+  TransactionOutputAddress(2, 0, 0, dummyTxIdentifier)
 
   test("Valid data-input case, transfer a simple series ") {
     val seriesPolicy = Event.SeriesPolicy(label = "seriesLabelB", registrationUtxo = txoAddress_1)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/wallet/WalletApiSpec.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl.wallet
 
-import cats.Id
 import co.topl.brambl.{MockHelpers, MockWalletKeyApi}
 import co.topl.crypto.encryption.VaultStore
 import co.topl.crypto.generation.mnemonic.MnemonicSizes
@@ -12,7 +11,7 @@ import io.circe.syntax.EncoderOps
 import co.topl.crypto.encryption.VaultStore.Codecs._
 import co.topl.crypto.generation.mnemonic.EntropyFailures.PhraseToEntropyFailure
 import co.topl.crypto.generation.mnemonic.PhraseFailures.InvalidWordLength
-import co.topl.brambl.syntax.{cryptoToPbKeyPair, cryptoVkToPbVk, pbKeyPairToCryptoKeyPair, pbVkToCryptoVk}
+import co.topl.brambl.syntax.{pbKeyPairToCryptoKeyPair, pbVkToCryptoVk}
 
 class WalletApiSpec extends munit.CatsEffectSuite with MockHelpers {
   implicit val idToId: FunctionK[F, F] = FunctionK.id[F]

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonScalacOptions = Seq(
   "-language:higherKinds",
   "-language:postfixOps",
   "-unchecked",
-  "-Ywarn-unused:-implicits,-privates",
+  "-Ywarn-unused",
   "-Yrangepos"
 )
 

--- a/crypto/src/main/scala/co/topl/crypto/encryption/VaultStore.scala
+++ b/crypto/src/main/scala/co/topl/crypto/encryption/VaultStore.scala
@@ -1,14 +1,19 @@
 package co.topl.crypto.encryption
 
 import cats.Monad
-import cats.implicits.{catsSyntaxEitherId, toFlatMapOps, toFunctorOps}
+import cats.implicits.catsSyntaxEitherId
+import cats.implicits.toFlatMapOps
+import cats.implicits.toFunctorOps
 import co.topl.crypto.encryption.cipher.Cipher
-import co.topl.crypto.encryption.kdf.Kdf
-import co.topl.crypto.encryption.kdf.Codecs._
 import co.topl.crypto.encryption.cipher.Codecs._
+import co.topl.crypto.encryption.kdf.Codecs._
+import co.topl.crypto.encryption.kdf.Kdf
+import io.circe.Decoder
 import io.circe.Decoder.Result
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, Json}
-import io.circe.generic.codec.DerivedAsObjectCodec.deriveCodec
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
 import io.circe.syntax._
 import org.bouncycastle.util.Strings
 

--- a/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/accumulators/MerkleTreeSpec.scala
@@ -4,7 +4,6 @@ import co.topl.crypto.accumulators.merkle.{Leaf, MerkleTree}
 import co.topl.crypto.hash.digest.{Digest, Digest32}
 import co.topl.crypto.hash.implicits._
 import co.topl.crypto.hash.{Blake2b, Hash}
-import co.topl.crypto.utils.Generators._
 import co.topl.crypto.utils.randomBytes
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/EntropySpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/EntropySpec.scala
@@ -8,7 +8,6 @@ import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}
-import co.topl.crypto.utils.EntropySupport._
 import org.scalatest.EitherValues
 
 class EntropySpec

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/LanguageSpec.scala
@@ -3,8 +3,6 @@ package co.topl.crypto.generation.mnemonic
 import cats.implicits._
 import co.topl.crypto.generation.mnemonic.Language._
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
-import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
+++ b/crypto/src/test/scala/co/topl/crypto/generation/mnemonic/PhraseSpec.scala
@@ -1,9 +1,6 @@
 package co.topl.crypto.generation.mnemonic
 
-import co.topl.crypto.generation.mnemonic.Language.LanguageWordList
-import co.topl.crypto.generation.mnemonic.MnemonicSizes.{words12, words18, words24}
 import co.topl.crypto.utils.Generators
-import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks, ScalaCheckPropertyChecks}

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
@@ -1,0 +1,69 @@
+package co.topl.brambl.monitoring
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import co.topl.brambl.builders.TransactionBuilderApi
+import co.topl.brambl.builders.locks.LockTemplate.PredicateTemplate
+import co.topl.brambl.builders.locks.PropositionTemplate.HeightTemplate
+import co.topl.brambl.common.ContainsSignable.ContainsSignableTOps
+import co.topl.brambl.common.ContainsSignable.instances.ioTransactionSignable
+import co.topl.brambl.constants.NetworkConstants.{MAIN_LEDGER_ID, PRIVATE_NETWORK_ID}
+import co.topl.brambl.dataApi.{BifrostQueryAlgebra, GenusQueryAlgebra, RpcChannelResource}
+import co.topl.brambl.models.box.Attestation
+import co.topl.brambl.monitoring.BifrostMonitor.AppliedBifrostBlock
+import co.topl.brambl.syntax.{LvlType, ioTransactionAsTransactionSyntaxOps}
+import co.topl.quivr.api.Prover
+import io.grpc.ManagedChannel
+
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+
+class BifrostMonitorTest extends munit.CatsEffectSuite {
+
+  override val munitTimeout: FiniteDuration = Duration(180, "s")
+
+  val channelResource: Resource[IO, ManagedChannel] =
+    RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
+  val bifrostQuery: BifrostQueryAlgebra[IO] = BifrostQueryAlgebra.make[IO](channelResource)
+
+  test("Monitor only new blocks (empty)") {
+    assertIO(for {
+      monitor <- BifrostMonitor(bifrostQuery)
+      blockStream = monitor.monitorBlocks()
+      // At approx. 1 block/10 seconds, we expect there to be at least 2 blocks after 30 seconds
+      blocks <- blockStream.interruptAfter(30.seconds).compile.toList
+    } yield blocks.count(_.isInstanceOf[AppliedBifrostBlock]) >= 2,
+      true
+    )
+  }
+
+  test("Monitor only new blocks (trivial transaction)") {
+    val heightLockTemplate = PredicateTemplate(Seq(HeightTemplate[IO]("header",  1, Long.MaxValue)), 1)
+    val genusQueryApi = GenusQueryAlgebra.make[IO](channelResource)
+    val txBuilder = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
+    assertIO(for {
+      heightLock <- heightLockTemplate.build(Nil).map(_.toOption.get)
+      heightAddress <- txBuilder.lockAddress(heightLock)
+      txos <- genusQueryApi.queryUtxo(heightAddress)
+      tx <- txBuilder.buildTransferAmountTransaction(
+        LvlType,
+        txos,
+        heightLock.getPredicate,
+        100L,
+        heightAddress, // Trivial, resend to genesis address
+        heightAddress,
+        1L
+      ).map(_.toOption.get)
+      proof <- Prover.heightProver[IO].prove((), tx.signable)
+      provedTx = tx.withInputs(tx.inputs.map(in => in.withAttestation(Attestation().withPredicate(in.attestation.getPredicate.withResponses(Seq(proof))))))
+      // Start monitoring
+      monitor <- BifrostMonitor(bifrostQuery)
+      blockStream = monitor.monitorBlocks()
+      // Then broadcast transaction
+      txId <- bifrostQuery.broadcastTransaction(provedTx)
+      // At approx. 1 block/10 seconds, we expect the broadcasted tx to be captured after 20 seconds
+      txIds <- blockStream.through(_.flatMap(_.transactions.map(_.computeId))).interruptAfter(20.seconds).compile.toList
+    } yield txIds.contains(txId),
+      true
+    )
+  }
+}

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,6 +1,8 @@
+// format: off
 // DO NOT EDIT! This file is auto-generated.
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.15")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.17")
 
+// format: on


### PR DESCRIPTION
## Purpose

Similar to how we monitor incoming Bitcoin blocks, we should monitor incoming Bifrost blocks.

## Approach

- Added `SynchronizationTraversal` to the DataApi bifrost query algebra
- Added a BifrostMonitor class and object for which incoming blocks will be returned live via a stream
- The blocks returned can either represent an Applied or Unapplied block. Both of which would contain a stream of the contained transactions

## Testing

Added 2 integration tests

- Verify that multiple live incoming applied blocks will be reported as expected
- Verify that the transactions within an incoming applied block is reported as expected

## Tickets
* closes TSDK-758
