### PR TITLE
Hot fix: Fix responsiveness warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD - TODO replace date after release 
 
+### Changed
+
+- Fixed responsiveness warning: Bifrost monitor uses fromBlockingIterator
+
 ## [v2.0.0-beta5] - 2024-05-08
 
 ### Added

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
@@ -36,7 +36,7 @@ class BifrostMonitor(
    * @return The infinite stream of block updatess. If startingBlocks was provided, they will be at the front of the stream.
    */
   def monitorBlocks(): Stream[IO, BifrostBlockSync] = Stream.emits(startingBlocks) ++
-    Stream.fromIterator[IO](blockIterator, 1).through(pipe)
+    Stream.fromBlockingIterator[IO](blockIterator, 1).through(pipe)
 
 }
 


### PR DESCRIPTION
## Purpose

Address warning that appears when using the Bifrost monitor

```
[WARNING] Your app's responsiveness to a new asynchronous event (such as a new connection, an upstream response, or a timer) was in excess of 100 milliseconds. Your CPU is probably starving. Consider increasing the granularity of your delays or adding more cedes. This may also be a sign that you are unintentionally running blocking I/O operations (such as File or InetAddress) without the blocking combinator.
```

## Approach

Replace `Stream.fromIterator` with `Stream.fromBlockingIterator`

## Testing
(manual)
Ran the bifrost monitor for a long period of time, previously , the warning would appear. I have not encountered the warning since

## Tickets
* n/a
