### PR TITLE
Bitcoin monitor >  add height field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Bifrost network monitoring. This change allows the ability to monitor a bifrost network for applied and unapplied blocks, returning a stream.
-
+- Added a height field to the blocks in the Bitcoin monitor stream
 
 ## [v2.0.0-beta4] - 2024-04-23
 

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
@@ -37,7 +37,7 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
       // After 0.5 second to allow the minted blocks to occur on the bitcoin instance
       blocks <- blockStream.interruptAfter(500.millis).compile.toList
       _ = monitor.stop()
-    } yield blocks.map(_.block.blockHeader.hashBE).toVector == mintBlocks,
+    } yield blocks.map(_.block.blockHeader.hashBE).toVector == mintBlocks && blocks.map(_.height) == mintBlocks.zipWithIndex.map(_._2 + 1),
       true
     )
   }
@@ -56,7 +56,9 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
       println(existingBlocks)
       println(mintBlocks)
       println(blocks.map(_.block.blockHeader.hashBE).toVector)
-      blocks.map(_.block.blockHeader.hashBE).toVector == (existingBlocks ++ mintBlocks)
+      val expectedBlocks = existingBlocks ++ mintBlocks
+      val startingHeight = blocks.head.height
+      blocks.map(_.block.blockHeader.hashBE).toVector == expectedBlocks && blocks.map(_.height) == expectedBlocks.zipWithIndex.map(_._2 + startingHeight)
     },
       true
     )


### PR DESCRIPTION
## Purpose

The blocks within the bitcoin monitor stream did not contain block-height information. This PR adds this information

## Approach

- For both retroactive and live block updates, query the bitcoin RPC  to retrieve block information (via getBlockHeight) and add it to the BitcoinBlock case class
- The live reporting required giving Zmq (addToQueue and initZmqSubscriber) access to the BitcoindRpcClient instance.

## Testing

In the existing tests for BitcoinMonitor, ensure the height fields are what we expect

## Tickets
* n/a