### PR TITLE
TSDK-801 Support Bitcoin Reorgs to the Bitcoin Monitor

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -115,9 +115,11 @@ jobs:
       - name: Run integration tests
         run: |
           docker run -d --rm --add-host host.docker.internal:host-gateway -p 18444:18444 -p 18443:18443 -p 28332:28332 --name=bitcoind ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
+          docker run -d --rm --name bitcoind2 --add-host host.docker.internal:host-gateway -p 12224:18444 -p 12223:18443 -p 12222:28332 ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
           docker run -d --rm --name bifrost -p 9084:9084 docker.io/toplprotocol/bifrost-node:2.0.0-beta3
           sbt "integration / test"
           docker kill bitcoind
+          docker kill bitcoind2
           docker kill bifrost
       - uses: actions/download-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed responsiveness warning: Bifrost monitor uses fromBlockingIterator
+- Added height field to the Bitcoin Monitor Stream
+- Added support for reorgs to the Bitcoin Monitor Stream. The stream sends back blocks to be either Applied or Unapplied.
 
 ## [v2.0.0-beta5] - 2024-05-08
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
@@ -75,7 +75,6 @@ class BitcoinMonitor(
           )
         } yield {
           currentTip = Some(adoptedBlock)
-          println(unappliedChain, appliedChain)
           unappliedChain ++ appliedChain // report the unapplied first, then the applied.
         }
     }
@@ -117,7 +116,10 @@ class BitcoinMonitor(
         if (
           updatedNewTip.head.height == updatedOldTip.head.height && updatedNewTip.head.block.blockHeader.hashBE == updatedOldTip.head.block.blockHeader.hashBE
         )
-          IO.pure(updatedOldTip, updatedNewTip) // common ancestor is found
+          IO.pure(
+            updatedOldTip.tail,
+            updatedNewTip.tail
+          ) // common ancestor is found. We return .tail so to not duplicate unapply/apply of the ancestor
         else findCommonAncestor(updatedOldTip, updatedNewTip) // keep traversing
     } yield res
 

--- a/service-kit/project/build.properties
+++ b/service-kit/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.0


### PR DESCRIPTION
## Purpose

To capture affected blocks when a bitcoin reorg occurs.

## Approach

If a reorg is detected (incoming block's parent does not match the last reported block), we find the common ancestor of the two. From this common ancestor, we unapply the chain (emit UnapplyBitcoinBlocks) leading to the previous last reported block. We also apply the new chain (emit AppliedBitcoinBlocks) leading to the newly adopted block.

## Testing

Added an integration test

## Tickets
* Closes TSDK-801