### PR TITLE
TSDK-811 Added Height Field to Bifrost Monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docker/*.jar
 
 # Scala Worksheet files
 *.sc
+playground/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD - TODO replace date after release 
 
+### Added
+
+- Added a height field to the blocks in the Bifrost monitor stream
+
 ## [v2.0.0-beta6] - 2024-05-22
 
 ### Changed

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
@@ -6,7 +6,7 @@ import co.topl.brambl.dataApi.BifrostQueryAlgebra
 import co.topl.brambl.display.blockIdDisplay.display
 import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.monitoring.BifrostMonitor.{AppliedBifrostBlock, BifrostBlockSync, UnappliedBifrostBlock}
-import co.topl.consensus.models.BlockId
+import co.topl.consensus.models.{BlockHeader, BlockId}
 import co.topl.node.models.FullBlockBody
 import co.topl.node.services.SynchronizationTraversalRes
 import co.topl.node.services.SynchronizationTraversalRes.Status.{Applied, Empty, Unapplied}
@@ -19,14 +19,14 @@ import fs2.Stream
  */
 class BifrostMonitor(
   blockIterator:  Iterator[SynchronizationTraversalRes],
-  getFullBlock:   BlockId => IO[FullBlockBody],
+  getFullBlock:   BlockId => IO[(BlockHeader, FullBlockBody)],
   startingBlocks: Vector[BifrostBlockSync]
 ) {
 
   def pipe(in: Stream[IO, SynchronizationTraversalRes]): Stream[IO, BifrostBlockSync] = in.evalMapFilter(sync =>
     sync.status match {
-      case Applied(blockId)   => getFullBlock(blockId).map(block => Some(AppliedBifrostBlock(block, blockId)))
-      case Unapplied(blockId) => getFullBlock(blockId).map(block => Some(UnappliedBifrostBlock(block, blockId)))
+      case Applied(blockId)   => getFullBlock(blockId).map(block => Some(AppliedBifrostBlock(block._2, blockId, block._1.height)))
+      case Unapplied(blockId) => getFullBlock(blockId).map(block => Some(UnappliedBifrostBlock(block._2, blockId, block._1.height)))
       case Empty              => IO.pure(None)
     }
   )
@@ -49,13 +49,14 @@ object BifrostMonitor {
     // The bifrost Block being wrapped. This represents either an Applied block or an Unapplied block
     val block: FullBlockBody
     val id: BlockId
+    val height: Long
     def transactions[F[_]]: Stream[F, IoTransaction] = Stream.emits(block.transactions)
   }
 
   // Represents a new block applied to the chain tip
-  case class AppliedBifrostBlock(block: FullBlockBody, id: BlockId) extends BifrostBlockSync
+  case class AppliedBifrostBlock(block: FullBlockBody, id: BlockId, height: Long) extends BifrostBlockSync
   // Represents an existing block that has been unapplied from the chain tip
-  case class UnappliedBifrostBlock(block: FullBlockBody, id: BlockId) extends BifrostBlockSync
+  case class UnappliedBifrostBlock(block: FullBlockBody, id: BlockId, height: Long) extends BifrostBlockSync
 
   /**
    * Initialize and return a BifrostMonitor instance.
@@ -67,11 +68,11 @@ object BifrostMonitor {
     bifrostQuery: BifrostQueryAlgebra[IO],
     startBlock:   Option[BlockId] = None
   ): IO[BifrostMonitor] = {
-    def getFullBlock(blockId: BlockId): IO[FullBlockBody] = for {
+    def getFullBlock(blockId: BlockId): IO[(BlockHeader, FullBlockBody)] = for {
       block <- bifrostQuery.blockById(blockId)
     } yield block match {
       case None                 => throw new Exception(s"Unable to query block ${display(blockId)}")
-      case Some((_, _, _, txs)) => FullBlockBody(txs)
+      case Some((_, header, _, txs)) => (header, FullBlockBody(txs))
     }
     def getBlockIds(startHeight: Option[Long], tipHeight: Option[Long]): IO[Vector[BlockId]] =
       (startHeight, tipHeight) match {
@@ -86,10 +87,10 @@ object BifrostMonitor {
       // The height of the startBlock
       startBlockHeight <- startBlock.map(bId => bifrostQuery.blockById(bId)).sequence.map(_.flatten.map(_._2.height))
       // the height of the chain tip
-      tipHeight        <- bifrostQuery.blockByDepth(1).map(_.map(_._2.height))
+      tipHeight        <- bifrostQuery.blockByDepth(0).map(_.map(_._2.height))
       startingBlockIds <- getBlockIds(startBlockHeight, tipHeight)
       startingBlocks <- startingBlockIds
-        .map(bId => getFullBlock(bId).map(block => AppliedBifrostBlock(block, bId)))
+        .map(bId => getFullBlock(bId).map(block => AppliedBifrostBlock(block._2, bId, block._1.height)))
         .sequence
       updates <- bifrostQuery.synchronizationTraversal()
     } yield new BifrostMonitor(updates, getFullBlock, startingBlocks)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
@@ -25,9 +25,11 @@ class BifrostMonitor(
 
   def pipe(in: Stream[IO, SynchronizationTraversalRes]): Stream[IO, BifrostBlockSync] = in.evalMapFilter(sync =>
     sync.status match {
-      case Applied(blockId)   => getFullBlock(blockId).map(block => Some(AppliedBifrostBlock(block._2, blockId, block._1.height)))
-      case Unapplied(blockId) => getFullBlock(blockId).map(block => Some(UnappliedBifrostBlock(block._2, blockId, block._1.height)))
-      case Empty              => IO.pure(None)
+      case Applied(blockId) =>
+        getFullBlock(blockId).map(block => Some(AppliedBifrostBlock(block._2, blockId, block._1.height)))
+      case Unapplied(blockId) =>
+        getFullBlock(blockId).map(block => Some(UnappliedBifrostBlock(block._2, blockId, block._1.height)))
+      case Empty => IO.pure(None)
     }
   )
 
@@ -71,7 +73,7 @@ object BifrostMonitor {
     def getFullBlock(blockId: BlockId): IO[(BlockHeader, FullBlockBody)] = for {
       block <- bifrostQuery.blockById(blockId)
     } yield block match {
-      case None                 => throw new Exception(s"Unable to query block ${display(blockId)}")
+      case None                      => throw new Exception(s"Unable to query block ${display(blockId)}")
       case Some((_, header, _, txs)) => (header, FullBlockBody(txs))
     }
     def getBlockIds(startHeight: Option[Long], tipHeight: Option[Long]): IO[Vector[BlockId]] =


### PR DESCRIPTION
## Purpose

Add a height field in the Bifrost monitor stream

## Approach

We already queried bifrost for the Transactions. We utilized this call to retrieve the height from the header as well

## Testing

- Verified accuracy of returned heights in the existing tests
- These tests found a bug (now fixed) that there was a gap in between reporting retroactive blocks and live blocks. The reason is because `.blockByDepth(1)` did not return the tip of the chain. This was replaced with `blockByDepth(0)`.

## Tickets
* closes TSDK-811