### PR TITLE
TSDK-852 Changes to BifrostMonitor and BitcoinMonitor

### DIFF
--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -117,10 +117,16 @@ jobs:
           docker run -d --rm --add-host host.docker.internal:host-gateway -p 18444:18444 -p 18443:18443 -p 28332:28332 --name=bitcoind ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
           docker run -d --rm --name bitcoind2 --add-host host.docker.internal:host-gateway -p 12224:18444 -p 12223:18443 -p 12222:28332 ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
           docker run -d --rm --name bifrost -p 9084:9084 docker.io/toplprotocol/bifrost-node:2.0.0-beta3
+          ls -lai
+          ./setupBifrostRegtest.sh
           sbt "integration / test"
           docker kill bitcoind
           docker kill bitcoind2
           docker kill bifrost
+          docker kill bifrost01
+          docker kill bifrost02
+          docker rm bifrost01
+          docker rm bifrost02
       - uses: actions/download-artifact@v3
         with:
           path: target/test-reports/

--- a/.github/workflows/_sbt_build.yml
+++ b/.github/workflows/_sbt_build.yml
@@ -118,6 +118,7 @@ jobs:
           docker run -d --rm --name bitcoind2 --add-host host.docker.internal:host-gateway -p 12224:18444 -p 12223:18443 -p 12222:28332 ruimarinho/bitcoin-core -chain=regtest -zmqpubrawblock=tcp://0.0.0.0:28332 -rpcuser=test -rpcpassword=test -port=18444 -rpcport=18443 -rpcbind=:18443 -rpcallowip=0.0.0.0/0
           docker run -d --rm --name bifrost -p 9084:9084 docker.io/toplprotocol/bifrost-node:2.0.0-beta3
           ls -lai
+          chmod 777 setupBifrostRegtest.sh
           ./setupBifrostRegtest.sh
           sbt "integration / test"
           docker kill bitcoind

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ docker/*.jar
 # Scala Worksheet files
 *.sc
 playground/
+node01/*
+node02/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a height field to the blocks in the Bifrost monitor stream
+- Added integration test for the Bifrost Monitor to ensure reorgs are handled as expected
+- Added the bifrost RPC function "makeBlock" to the BifrostQuery API. This is to force block production and is only meant to be used in "RegTest" mode.
 
 ### Changed
 
 - Removed specific Topl branding from documentation site. Documentation will be more generic or refer to "Apparatus"
+- Bifrost and Bitcoin monitor APIs now return a resource containing their respective block stream.
+- Retroactive reporting of existing blocks in the bifrost monitor is now inclusive (includes the starting block).
+- Bifrost monitor's update stream is now self-contained. It's channel will now shutdown when the monitor is released. 
+- The ZMQ subscriber that is used in the Bitcoin Monitor now stops when the monitor is released. Users no longer have to explicitly call ".stop()"
+- Updated existing BitcoinMonitor and BifrostMonitor tests (including the workflow in GH actions) to account for these changes.
 
 ## [v2.0.0-beta6] - 2024-05-22
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryAlgebra.scala
@@ -72,8 +72,8 @@ trait BifrostQueryAlgebra[F[_]] {
    * @param nbOfBlocks the number of blocks to mint.
    */
   def makeBlock(
-                 nbOfBlocks: Int
-               ): F[Unit]
+    nbOfBlocks: Int
+  ): F[Unit]
 
 }
 
@@ -93,15 +93,16 @@ object BifrostQueryAlgebra extends BifrostQueryInterpreter {
 
   case class MakeBlock(nbOfBlocks: Int) extends BifrostQueryADT[Unit]
 
-  case class SynchronizationTraversal(observer: StreamObserver[SynchronizationTraversalRes]) extends BifrostQueryADT[Unit]
+  case class SynchronizationTraversal(observer: StreamObserver[SynchronizationTraversalRes])
+      extends BifrostQueryADT[Unit]
 
   case class BroadcastTransaction(tx: IoTransaction) extends BifrostQueryADT[TransactionId]
 
   type BifrostQueryADTMonad[A] = Free[BifrostQueryADT, A]
 
   def makeBlockF(
-                  nbOfBlocks: Int
-                ): BifrostQueryADTMonad[Unit] =
+    nbOfBlocks: Int
+  ): BifrostQueryADTMonad[Unit] =
     Free.liftF(MakeBlock(nbOfBlocks))
 
   def fetchBlockBodyF(

--- a/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/dataApi/BifrostQueryInterpreter.scala
@@ -95,12 +95,11 @@ trait BifrostQueryInterpreter {
               )
             case BifrostQueryAlgebra.SynchronizationTraversal(respObserver) =>
               Kleisli(blockingStubAndRegTestStub =>
-                    Sync[F]
-                      .blocking(
-                        blockingStubAndRegTestStub._3.synchronizationTraversal(SynchronizationTraversalReq(), respObserver)
-                      )
-                      .map(_.asInstanceOf[A])
-
+                Sync[F]
+                  .blocking(
+                    blockingStubAndRegTestStub._3.synchronizationTraversal(SynchronizationTraversalReq(), respObserver)
+                  )
+                  .map(_.asInstanceOf[A])
               )
             case BifrostQueryAlgebra.BroadcastTransaction(tx) =>
               Kleisli(blockingStubAndRegTestStub =>
@@ -120,7 +119,9 @@ trait BifrostQueryInterpreter {
     (for {
       channel <- channelResource
     } yield channel).use { channel =>
-      kleisliComputation.run((NodeRpcGrpc.blockingStub(channel), RegtestRpcGrpc.blockingStub(channel), NodeRpcGrpc.stub(channel)))
+      kleisliComputation.run(
+        (NodeRpcGrpc.blockingStub(channel), RegtestRpcGrpc.blockingStub(channel), NodeRpcGrpc.stub(channel))
+      )
     }
   }
 

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BifrostMonitor.scala
@@ -1,6 +1,7 @@
 package co.topl.brambl.monitoring
 
 import cats.effect.IO
+import cats.effect.kernel.{Resource, Sync}
 import cats.effect.std.Queue
 import cats.effect.unsafe.implicits.global
 import cats.implicits.{catsSyntaxParallelSequence1, toTraverseOps}
@@ -10,18 +11,41 @@ import co.topl.brambl.models.transaction.IoTransaction
 import co.topl.brambl.monitoring.BifrostMonitor.{AppliedBifrostBlock, BifrostBlockSync, UnappliedBifrostBlock}
 import co.topl.consensus.models.{BlockHeader, BlockId}
 import co.topl.node.models.FullBlockBody
-import co.topl.node.services.SynchronizationTraversalRes
+import co.topl.node.services.{NodeRpcFs2Grpc, SynchronizationTraversalReq, SynchronizationTraversalRes}
 import co.topl.node.services.SynchronizationTraversalRes.Status.{Applied, Empty, Unapplied}
 import fs2.Stream
+import fs2.grpc.syntax.all.fs2GrpcSyntaxManagedChannelBuilder
+import io.grpc.{ManagedChannelBuilder, Metadata}
 import io.grpc.stub.StreamObserver
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.effect.kernel.Sync
+import cats.implicits.catsSyntaxParallelSequence1
+import cats.implicits.toTraverseOps
+import co.topl.brambl.dataApi.BifrostQueryAlgebra
+import co.topl.brambl.display.blockIdDisplay.display
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.consensus.models.BlockHeader
+import co.topl.consensus.models.BlockId
+import co.topl.node.models.FullBlockBody
+import co.topl.node.services.NodeRpcFs2Grpc
+import co.topl.node.services.SynchronizationTraversalReq
+import co.topl.node.services.SynchronizationTraversalRes
+import co.topl.node.services.SynchronizationTraversalRes.Status.Applied
+import co.topl.node.services.SynchronizationTraversalRes.Status.Empty
+import co.topl.node.services.SynchronizationTraversalRes.Status.Unapplied
+import fs2.Stream
+import fs2.grpc.syntax.all._
+import io.grpc.ManagedChannelBuilder
+import io.grpc.Metadata
 
 /**
  * Class to monitor incoming bifrost blocks via an iterator.
- * @param blockIterator The iterator in which block changes will be added to
+ * @param blockStream The stream in which block changes are reported through
  * @param startingBlocks Past blocks that should be reported.
  */
 class BifrostMonitor(
-  blockQueue:     Queue[IO, SynchronizationTraversalRes],
+  blockStream: Stream[IO, SynchronizationTraversalRes],
   getFullBlock:   BlockId => IO[(BlockHeader, FullBlockBody)],
   startingBlocks: Vector[BifrostBlockSync]
 ) {
@@ -40,12 +64,24 @@ class BifrostMonitor(
    * Return a stream of block updates.
    * @return The infinite stream of block updatess. If startingBlocks was provided, they will be at the front of the stream.
    */
-  def monitorBlocks(): Stream[IO, BifrostBlockSync] = Stream.emits(startingBlocks) ++
-    Stream.fromQueueUnterminated(blockQueue).through(pipe)
+  def monitorBlocks(): Stream[IO, BifrostBlockSync] = Stream.emits(startingBlocks) ++ blockStream.through(pipe)
 
 }
 
 object BifrostMonitor {
+
+  def getChannelResource[F[_] : Sync](address: String, port: Int, secureConnection: Boolean) = {
+    val x = (if (secureConnection)
+      ManagedChannelBuilder
+        .forAddress(address, port)
+        .useTransportSecurity()
+    else
+      ManagedChannelBuilder
+        .forAddress(address, port)
+        .usePlaintext())
+    val y = ManagedChannelBuilder
+      .forAddress(address, port).resource[F].resource[F]
+  }
 
   /**
    * A wrapper for a Bifrost Block Sync update.
@@ -70,9 +106,12 @@ object BifrostMonitor {
    * @return An instance of a BifrostMonitor
    */
   def apply(
+    address: String,
+    port: Int,
+    secureConnection: Boolean,
     bifrostQuery: BifrostQueryAlgebra[IO],
     startBlock:   Option[BlockId] = None
-  ): IO[BifrostMonitor] = {
+  ): IO[Resource[IO, BifrostMonitor]] = {
     def getFullBlock(blockId: BlockId): IO[(BlockHeader, FullBlockBody)] = for {
       block <- bifrostQuery.blockById(blockId)
     } yield block match {
@@ -89,8 +128,6 @@ object BifrostMonitor {
         case _ => IO.pure(Vector.empty)
       }
     for {
-      blockQueue <- Queue.unbounded[IO, SynchronizationTraversalRes]
-
       // The height of the startBlock
       startBlockHeight <- startBlock.map(bId => bifrostQuery.blockById(bId)).sequence.map(_.flatten.map(_._2.height))
       // the height of the chain tip
@@ -99,14 +136,15 @@ object BifrostMonitor {
       startingBlocks <- startingBlockIds
         .map(bId => getFullBlock(bId).map(block => AppliedBifrostBlock(block._2, bId, block._1.height)))
         .sequence
-      _ <- bifrostQuery.synchronizationTraversal(new StreamObserver[SynchronizationTraversalRes] {
-        override def onNext(value: SynchronizationTraversalRes): Unit = blockQueue.offer(value).unsafeRunSync()
-
-        override def onError(t: Throwable): Unit = println("ERROR: " + t.getMessage) // TODO: Properly log
-
-        override def onCompleted(): Unit = ()
-      })
-    } yield new BifrostMonitor(blockQueue, getFullBlock, startingBlocks)
+    } yield for {
+      channel <- getChannelResource[IO](address, port, secureConnection)
+      stub <- NodeRpcFs2Grpc.stubResource[IO](channel)
+      stream <- IO(stub.synchronizationTraversal(SynchronizationTraversalReq(), new Metadata()).handleErrorWith { e =>
+        e.printStackTrace()
+        println("Error in BifrostMonitorBis")
+        Stream.empty[IO]
+      }).toResource
+    } yield new BifrostMonitor(stream, getFullBlock, startingBlocks)
   }
 
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
@@ -249,7 +249,6 @@ object BitcoinMonitor {
     }
 
     val existingHashes = getBlockHashes(startBlock)
-    println("Retroactively fetching blocks:")
     existingHashes.foreach(h => println(h.hex))
     (for {
       blockQueue <- Queue.unbounded[IO, AppliedBitcoinBlock]

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
@@ -22,13 +22,114 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
 
   override val munitTimeout: FiniteDuration = Duration(180, "s")
 
-  val channelResource: Resource[IO, ManagedChannel] =
+  val channelResource1: Resource[IO, ManagedChannel] =
     RpcChannelResource.channelResource[IO]("localhost", 9084, secureConnection = false)
-  val bifrostQuery: BifrostQueryAlgebra[IO] = BifrostQueryAlgebra.make[IO](channelResource)
+  val channelResource2: Resource[IO, ManagedChannel] =
+    RpcChannelResource.channelResource[IO]("localhost", 9086, secureConnection = false)
+  val bifrostQuery1: BifrostQueryAlgebra[IO] = BifrostQueryAlgebra.make[IO](channelResource1)
+  val bifrostQuery2: BifrostQueryAlgebra[IO] = BifrostQueryAlgebra.make[IO](channelResource2)
+
+
+
+  test("Monitor blocks with a reorg") {
+    assertIO(for {
+      _ <- IO.println("node 1 tip:")
+      node1Tip <- bifrostQuery1.blockByDepth(0)
+      _ <- IO.println(node1Tip)
+      _ <- IO.println("node 2 tip:")
+      node2Tip <- bifrostQuery2.blockByDepth(0)
+      _ <- IO.println(node2Tip)
+      _ <- IO.println("disconnecting node 2 from network")
+      _ <- disconnectBifrostNodes("bridge", "bifrost02").start.allocated // The 2 nodes start disconnected
+      _ <- IO.println("starting monitor service")
+      monitor <- BifrostMonitor(bifrostQuery1) // monitoring node 1
+      blockStream = monitor.monitorBlocks().through(s => s.map(r => {
+        println(r)
+        r
+      }))
+      _ <- IO.println("node 1 making 1 block")
+      node1MintBlocks <- bifrostQuery1.makeBlock(1) // monitor should report this 1 block
+      _ <- IO.println("node 2 making 2 blocks")
+      node2MintBlocks <- bifrostQuery2.makeBlock(2)
+
+      // connect blocks. the monitor should unapply the 1 block, and then apply the 2 new blocks
+      _ <- IO.println("reconnecting node 2 from network")
+      _ <- connectBifrostNodes("bridge", "bifrost02").start.allocated
+
+      _ <- IO.println("node 2 making 1 block").andWait(5.seconds)
+      additionalMintBlocks <- bifrostQuery2.makeBlock(1) // monitor should report this
+
+      _ <- IO.println("compiling stream")
+      blocks <- blockStream.interruptAfter(10.seconds).compile.toList
+    } yield {
+      println(s"blocks:  $blocks")
+      blocks.length == 5
+    } // applied, unapplied, applied, applied, applied
+      , true )
+  }
+
+  /**
+
+   --- works
+
+   new version, no staker arguments (works):
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9
+
+   old version, no staker arguments (works):
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 ghcr.io/topl/bifrost-node:2.0.0-beta3
+
+   --- does not work (TimeoutException)
+
+   old version, with staker arguments; config.yaml does not contain line "regtest-enabled" (does not work):
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 -v /home/diadem/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3 -- --config /bifrost-staking/config.yaml
+
+   new version, with staker arguments; not regtest mode & config.yaml does not contain line "regtest-enabled" (does not work):
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 -v /home/diadem/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 -- --config /bifrost-staking/config.yaml
+
+   new version, with staker arguments and regtest mode (config.yaml contains "regtest-enabled: true") (does not work):
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 -v /home/diadem/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 -- --config /bifrost-staking/config.yaml --regtest
+
+   new version, no staker arguments but with regtest mode (only via flag)
+   docker run --rm -d -p 9085:9085 -p 9084:9084 -p 9091:9091 ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 -- --regtest
+
+   */
+
+  // works without staker arguments
+  // does not work with staker arguments (regtest not enabled, without flag and disabled in config file).
+  // does not work with staker arguments (regtest enabled)
+  // Staker arguments include volume mounting and config
+  // "does not work" most of the time is TimeoutException.
+  // try old version but with staker arguments? => does not work
+  test("control") {
+    import cats.effect.std.Queue
+    assertIO(for {
+      randomCall <- bifrostQuery1.blockByDepth(0)
+      _ <- IO.println((randomCall)) // to verify that its not ALL rpc functions that are broken.
+      _ <- IO.println("starting stream")
+      monitor <- BifrostMonitor(bifrostQuery1) // monitoring node 1
+      blockStream = monitor.monitorBlocks().through(s => s.map(r => {
+        println(r)
+        r
+      }))
+      _ <- IO.println("make block")
+      _ <- bifrostQuery1.makeBlock(1)
+      _ <- IO.println("make block")
+      _ <- bifrostQuery1.makeBlock(1)
+      _ <- IO.println("before interrupt")
+//      blocks <- (IO.println("delayed block by depth").andWait(22.seconds) *> bifrostQuery1.blockByDepth(0)) &> blockStream.interruptAfter(20.seconds).compile.toList
+      blocks <- blockStream.interruptAfter(20.seconds).compile.toList
+      _ <- IO.println("D")
+    } yield {
+      println(blocks)
+      true
+    },
+      true
+    )
+  }
 
   test("Monitor only new blocks (empty)") {
     assertIO(for {
-      monitor <- BifrostMonitor(bifrostQuery)
+      monitor <- BifrostMonitor(bifrostQuery1)
       blockStream = monitor.monitorBlocks()
       // At approx. 1 block/10 seconds, we expect there to be at least 2 blocks after 30 seconds
       blocks <- blockStream.interruptAfter(30.seconds).compile.toList
@@ -39,7 +140,7 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
 
   test("Monitor only new blocks (trivial transaction)") {
     val heightLockTemplate = PredicateTemplate(Seq(HeightTemplate[IO]("header",  1, Long.MaxValue)), 1)
-    val genusQueryApi = GenusQueryAlgebra.make[IO](channelResource)
+    val genusQueryApi = GenusQueryAlgebra.make[IO](channelResource1)
     val txBuilder = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
     assertIO(for {
       heightLock <- heightLockTemplate.build(Nil).map(_.toOption.get)
@@ -57,14 +158,14 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
       proof <- Prover.heightProver[IO].prove((), tx.signable)
       provedTx = tx.withInputs(tx.inputs.map(in => in.withAttestation(Attestation().withPredicate(in.attestation.getPredicate.withResponses(Seq(proof))))))
       // Start monitoring
-      monitor <- BifrostMonitor(bifrostQuery)
+      monitor <- BifrostMonitor(bifrostQuery1)
       blockStream = monitor.monitorBlocks()
       // Then broadcast transaction
-      txId <- bifrostQuery.broadcastTransaction(provedTx)
+      txId <- bifrostQuery1.broadcastTransaction(provedTx)
       // At approx. 1 block/10 seconds, we expect the broadcasted tx to be captured after 20 seconds
       blockUpdates <- blockStream.through(_.map(b => (b.block.transactions.map(_.computeId), b.height))).interruptAfter(20.seconds).compile.toList
       // Ensure the reported height is correct
-      queriedHeights <- blockUpdates.map(b => bifrostQuery.blockByHeight(b._2).map(r => (r.get._4.map(_.computeId), r.get._2.height))).sequence
+      queriedHeights <- blockUpdates.map(b => bifrostQuery1.blockByHeight(b._2).map(r => (r.get._4.map(_.computeId), r.get._2.height))).sequence
     } yield {
       val foundUpdate = blockUpdates.find(_._1.contains(txId))
       foundUpdate.isDefined && queriedHeights.exists(_._2 == foundUpdate.get._2) &&
@@ -76,12 +177,12 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
 
   test("Monitor live and retroactive blocks") {
     assertIO(for {
-      startingBlockId <- bifrostQuery.blockByDepth(0).map(_.get._1)
-      startingHeight <- bifrostQuery.blockById(startingBlockId).map(_.get._2.height)
+      startingBlockId <- bifrostQuery1.blockByDepth(0).map(_.get._1)
+      startingHeight <- bifrostQuery1.blockById(startingBlockId).map(_.get._2.height)
       // At approx. 1 block/10 seconds, we expect there to be at least 2 blocks after 30 seconds
       _ <- IO.unit.andWait(30.seconds)
-      tipBlockId <- bifrostQuery.blockByDepth(1).map(_.get._1)
-      monitor <- BifrostMonitor(bifrostQuery, Some(startingBlockId))
+      tipBlockId <- bifrostQuery1.blockByDepth(1).map(_.get._1)
+      monitor <- BifrostMonitor(bifrostQuery1, Some(startingBlockId))
       blockStream = monitor.monitorBlocks()
       // At approx. 1 block/10 seconds, we expect there to be at least 2 blocks after 30 seconds
       blocks <- blockStream.interruptAfter(30.seconds).compile.toList

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BifrostMonitorTest.scala
@@ -30,56 +30,51 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
   val bifrostQuery2: BifrostQueryAlgebra[IO] = BifrostQueryAlgebra.make[IO](channelResource2)
 
 
-
   test("Monitor blocks with a reorg") {
-    assertIO(for {
-      // ensure the 2 nodes are in sync prior to starting
-      _ <- IO.println("connecting the nodes")
-      _ <- connectBifrostNodes("bifrost02", "bifrost01").start.andWait(15.seconds)
-      _ <- IO.println("after connect")
-      node1Tip <- bifrostQuery1.blockByDepth(0)
-      _ <- IO.println(node1Tip)
-      node2Tip <- bifrostQuery2.blockByDepth(0)
-      _ <- IO.println(node2Tip)
-      // The 2 nodes start disconnected
-      _ <- IO.println("disconnecting the nodes")
-      _ <- disconnectBifrostNodes("bifrost02").start.andWait(15.seconds)
-      _ <- IO.println("starting monitor")
-      monitor <- BifrostMonitor(bifrostQuery1) // monitoring node 1
-      blockStream = monitor.monitorBlocks().through(s => s.map(r => {
-        println(r)
-        r
-      }))
-      _ <- IO.println("making blocks: node 1")
-      _ <- bifrostQuery1.makeBlock(1)
-      _ <- IO.println("making blocks: node 2")
-      _ <- bifrostQuery2.makeBlock(2)
+    assertIO(
+      BifrostMonitor("localhost", 9184, secureConnection = false, bifrostQuery1).use(blockStream => {
+        blockStream.interruptAfter(80.seconds).compile.toList <& (for {
+          // ensure the 2 nodes are in sync prior to starting
+          _ <- IO.println("connecting the nodes")
+          _ <- connectBifrostNodes("bifrost02", "bifrost01").start.andWait(20.seconds)
+          _ <- IO.println("after connect")
+          node1Tip <- bifrostQuery1.blockByDepth(0)
+          _ <- IO.println(node1Tip)
+          node2Tip <- bifrostQuery2.blockByDepth(0)
+          _ <- IO.println(node2Tip)
+          // The 2 nodes start disconnected
+          _ <- IO.println("disconnecting the nodes")
+          _ <- disconnectBifrostNodes("bifrost02").start.andWait(20.seconds)
+          _ <- IO.println("starting monitor")
 
-      _ <- IO.println("waiting after making blocks").andWait(10.seconds)
+          _ <- IO.println("making blocks: node 1")
+          _ <- bifrostQuery1.makeBlock(1)
+          _ <- IO.println("making blocks: node 2")
+          _ <- bifrostQuery2.makeBlock(2)
 
-      // connect blocks. the monitor should unapply the 1 block, and then apply the 2 new blocks
-      _ <- IO.println("connecting the nodes")
-      _ <- connectBifrostNodes("bifrost02", "bifrost01").start.andWait(15.seconds)
+          _ <- IO.println("waiting after making blocks").andWait(15.seconds)
 
-      blocks <- blockStream.interruptAfter(5.seconds).compile.toList
-    } yield {
-      println(s"blocks:  $blocks")
-      blocks.length == 4 &&
-        blocks.head.isInstanceOf[AppliedBifrostBlock] &&
-        blocks(1).isInstanceOf[UnappliedBifrostBlock] &&
-        blocks(2).isInstanceOf[AppliedBifrostBlock] &&
-        blocks(3).isInstanceOf[AppliedBifrostBlock]
-    } // applied, unapplied, applied, applied
-      , true )
+          // connect blocks. the monitor should unapply the 1 block, and then apply the 2 new blocks
+          _ <- IO.println("connecting the nodes")
+          _ <- connectBifrostNodes("bifrost02", "bifrost01").start.andWait(20.seconds)
+        } yield ()) map { blocks =>
+          println(s"blocks:  $blocks") // applied, unapplied, applied, applied
+          blocks.length == 4 &&
+            blocks.head.isInstanceOf[AppliedBifrostBlock] &&
+            blocks(1).isInstanceOf[UnappliedBifrostBlock] &&
+            blocks(2).isInstanceOf[AppliedBifrostBlock] &&
+            blocks(3).isInstanceOf[AppliedBifrostBlock]
+        }
+      }), true )
   }
 
   test("Monitor only new blocks (empty)") {
-    assertIO(for {
-      monitor <- BifrostMonitor(bifrostQuery1)
-      blockStream = monitor.monitorBlocks()
-      _ <- bifrostQuery1.makeBlock(2)
-      blocks <- blockStream.interruptAfter(5.seconds).compile.toList
-    } yield blocks.count(_.isInstanceOf[AppliedBifrostBlock]) == 2,
+    assertIO(
+      BifrostMonitor("localhost", 9184, secureConnection = false, bifrostQuery1).use(blockStream => {
+        (blockStream.interruptAfter(15.seconds).compile.toList <& bifrostQuery1.makeBlock(2)) map { blocks =>
+          println(blocks)
+          blocks.count(_.isInstanceOf[AppliedBifrostBlock]) == 2
+        }}) ,
       true
     )
   }
@@ -88,61 +83,64 @@ class BifrostMonitorTest extends munit.CatsEffectSuite {
     val heightLockTemplate = PredicateTemplate(Seq(HeightTemplate[IO]("header",  1, Long.MaxValue)), 1)
     val genusQueryApi = GenusQueryAlgebra.make[IO](channelResource1)
     val txBuilder = TransactionBuilderApi.make[IO](PRIVATE_NETWORK_ID, MAIN_LEDGER_ID)
-    assertIO(for {
-      heightLock <- heightLockTemplate.build(Nil).map(_.toOption.get)
-      heightAddress <- txBuilder.lockAddress(heightLock)
-      txos <- genusQueryApi.queryUtxo(heightAddress)
-      tx <- txBuilder.buildTransferAmountTransaction(
-        LvlType,
-        txos,
-        heightLock.getPredicate,
-        100L,
-        heightAddress, // Trivial, resend to genesis address
-        heightAddress,
-        1L
-      ).map(_.toOption.get)
-      proof <- Prover.heightProver[IO].prove((), tx.signable)
-      provedTx = tx.withInputs(tx.inputs.map(in => in.withAttestation(Attestation().withPredicate(in.attestation.getPredicate.withResponses(Seq(proof))))))
-      // Start monitoring
-      monitor <- BifrostMonitor(bifrostQuery1)
-      blockStream = monitor.monitorBlocks()
-      // Then broadcast transaction
-      txId <- bifrostQuery1.broadcastTransaction(provedTx)
-      _ <- bifrostQuery1.makeBlock(1)
-      blockUpdates <- blockStream.through(_.map(b => (b.block.transactions.map(_.computeId), b.height))).interruptAfter(5.seconds).compile.toList
-      // Ensure the reported height is correct
-      queriedHeights <- blockUpdates.map(b => bifrostQuery1.blockByHeight(b._2).map(r => (r.get._4.map(_.computeId), r.get._2.height))).sequence
-    } yield {
-      val foundUpdate = blockUpdates.find(_._1.contains(txId))
-      foundUpdate.isDefined && queriedHeights.exists(_._2 == foundUpdate.get._2) &&
-        (foundUpdate.get._1 equals queriedHeights.find(_._2 == foundUpdate.get._2).get._1)
-    },
+    assertIO(
+      BifrostMonitor("localhost", 9184, secureConnection = false, bifrostQuery1).use(blockStream => {
+        (for {
+          blockUpdates <- blockStream.through(_.map(b => (b.block.transactions.map(_.computeId), b.height))).interruptAfter(20.seconds).compile.toList
+          // Ensure the reported height is correct
+          queriedHeights <- blockUpdates.map(b => bifrostQuery1.blockByHeight(b._2).map(r => (r.get._4.map(_.computeId), r.get._2.height))).sequence
+        } yield (blockUpdates, queriedHeights)) both (for {
+          heightLock <- heightLockTemplate.build(Nil).map(_.toOption.get)
+          heightAddress <- txBuilder.lockAddress(heightLock)
+          txos <- genusQueryApi.queryUtxo(heightAddress)
+          tx <- txBuilder.buildTransferAmountTransaction(
+            LvlType,
+            txos,
+            heightLock.getPredicate,
+            100L,
+            heightAddress, // Trivial, resend to genesis address
+            heightAddress,
+            1L
+          ).map(_.toOption.get)
+          proof <- Prover.heightProver[IO].prove((), tx.signable)
+          provedTx = tx.withInputs(tx.inputs.map(in => in.withAttestation(Attestation().withPredicate(in.attestation.getPredicate.withResponses(Seq(proof))))))
+          // Then broadcast transaction
+          txId <- bifrostQuery1.broadcastTransaction(provedTx).andWait(5.seconds)
+          _ <- bifrostQuery1.makeBlock(1).andWait(5.seconds)
+        } yield txId) map { res =>
+          val ((blockUpdates, queriedHeights), txId) = res
+          val foundUpdate = blockUpdates.find(_._1.contains(txId))
+          foundUpdate.isDefined && queriedHeights.exists(_._2 == foundUpdate.get._2) &&
+            (foundUpdate.get._1 equals queriedHeights.find(_._2 == foundUpdate.get._2).get._1)
+        }
+      }),
       true
     )
   }
 
   test("Monitor live and retroactive blocks") {
-    assertIO(for {
-      startingBlockId <- bifrostQuery1.blockByDepth(0).map(_.get._1)
-      startingHeight <- bifrostQuery1.blockById(startingBlockId).map(_.get._2.height)
-      _ <- bifrostQuery1.makeBlock(2)
-      _ <- IO.unit.andWait(5.seconds)
-      tipBlockId <- bifrostQuery1.blockByDepth(1).map(_.get._1)
-      monitor <- BifrostMonitor(bifrostQuery1, Some(startingBlockId))
-      blockStream = monitor.monitorBlocks()
-      _ <- bifrostQuery1.makeBlock(2).andWait(5.seconds)
-      blocks <- blockStream.interruptAfter(5.seconds).compile.toList
-    } yield {
-      val blockIds = blocks.map(_.id)
-      val startingIdx = blockIds.indexOf(startingBlockId)
-      val tipBlockIdx = blockIds.indexOf(tipBlockId)
-      val expectedHeights = Seq.range(startingHeight, startingHeight + blocks.length).toList
-      blocks.head.id == startingBlockId &&
-        blocks.slice(startingIdx, tipBlockIdx+1).length >= 2 &&
-        blocks.slice(tipBlockIdx+1, blocks.length).length >= 2 &&
-        (blocks.map(_.height) equals expectedHeights) && // ensure heights are correct
-        blockIds.distinct.length == blockIds.length // ensure no duplicate reporting
-    },
+    val startingBlockId = bifrostQuery1.blockByDepth(0).map(_.get._1).unsafeRunSync()
+    assertIO(
+      BifrostMonitor("localhost", 9184, secureConnection = false, bifrostQuery1, Some(startingBlockId)).use(blockStream => {
+        blockStream.interruptAfter(20.seconds).compile.toList both (
+        for {
+          retroactiveHeight <- bifrostQuery1.blockById(startingBlockId).map(_.get._2.height)
+          _ <- bifrostQuery1.makeBlock(2)
+        } yield retroactiveHeight) map { res =>
+          val (blocks, startingHeight) = res
+          println(startingHeight)
+          println(s"blocks: $blocks")
+          val expectedHeights = Seq.range(startingHeight, startingHeight + blocks.length).toList
+          val tests = Seq(
+            blocks.headOption.map(_.id).contains(startingBlockId),// retroactive block is reported
+            blocks.tail.length == 2,// ensure live blocks are reported
+            (blocks.map(_.height) equals expectedHeights),// ensure heights are correct
+            blocks.map(_.id).distinct.length == blocks.length// ensure no duplicate reporting
+          )
+          println(tests)
+          tests.forall(_ == true)
+        }
+      }),
       true
     )
   }

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
@@ -48,65 +48,71 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
   test("Monitor blocks with a reorg") {
     val bitcoindInstance = bitcoind()
     val node2Instance = bitcoind.bitcoindInstance2
-
-    assertIO(for {
-      monitor <- BitcoinMonitor(bitcoindInstance)
-      blockStream = monitor.monitorBlocks()
-      node1MintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(1, _))))
-      node2MintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(2, _))))
-      _ <- IO.fromFuture(IO(bitcoindInstance.addNode(bitcoind.bitcoindInstance2Uri, AddNodeArgument.Add))).attempt.andWait(5.seconds)
-      additionalMintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(1, _))))
-      blocks <- blockStream.interruptAfter(5.seconds).compile.toList
-      _ = monitor.stop()
-    } yield {
-      case class BitcoinSyncLite(height: Int, hash: DoubleSha256DigestBE, isApplied: Boolean)
-      val startingHeight = blocks.head.height
-      val expectedBlocks = Seq(
-        BitcoinSyncLite(startingHeight, node1MintBlocks.head, isApplied = true),
-        BitcoinSyncLite(startingHeight, node1MintBlocks.head, isApplied = false),
-        BitcoinSyncLite(startingHeight, node2MintBlocks.head, isApplied = true),
-        BitcoinSyncLite(startingHeight + 1, node2MintBlocks(1), isApplied = true),
-        BitcoinSyncLite(startingHeight + 2, additionalMintBlocks.head, isApplied = true),
-      )
-      val testBlocks = blocks.map(b => BitcoinSyncLite(b.height, b.block.blockHeader.hashBE, b.isInstanceOf[AppliedBitcoinBlock]))
-      expectedBlocks == testBlocks
-    },
-      true
+    assertIO(
+      BitcoinMonitor(bitcoindInstance).use(monitor => {
+        val blockStream = monitor.monitorBlocks()
+        for {
+          node1MintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(1, _))))
+          node2MintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(2, _))))
+          _ <- IO.fromFuture(IO(bitcoindInstance.addNode(bitcoind.bitcoindInstance2Uri, AddNodeArgument.Add))).attempt.andWait(5.seconds)
+          additionalMintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(1, _))))
+          blocks <- blockStream.interruptAfter(5.seconds).compile.toList
+          _ = monitor.stop()
+        } yield {
+          case class BitcoinSyncLite(height: Int, hash: DoubleSha256DigestBE, isApplied: Boolean)
+          val startingHeight = blocks.head.height
+          val expectedBlocks = Seq(
+            BitcoinSyncLite(startingHeight, node1MintBlocks.head, isApplied = true),
+            BitcoinSyncLite(startingHeight, node1MintBlocks.head, isApplied = false),
+            BitcoinSyncLite(startingHeight, node2MintBlocks.head, isApplied = true),
+            BitcoinSyncLite(startingHeight + 1, node2MintBlocks(1), isApplied = true),
+            BitcoinSyncLite(startingHeight + 2, additionalMintBlocks.head, isApplied = true),
+          )
+          val testBlocks = blocks.map(b => BitcoinSyncLite(b.height, b.block.blockHeader.hashBE, b.isInstanceOf[AppliedBitcoinBlock]))
+          expectedBlocks == testBlocks
+        }
+      }), true
     )
+
   }
 
   test("Monitor only new blocks") {
     val bitcoindInstance = bitcoind()
-    assertIO(for {
-      monitor <- BitcoinMonitor(bitcoindInstance)
-      blockStream = monitor.monitorBlocks()
-      mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
-      // After 0.5 second to allow the minted blocks to occur on the bitcoin instance
-      blocks <- blockStream.interruptAfter(500.millis).compile.toList
-      _ = monitor.stop()
-    } yield {
-      val startingHeight = blocks.head.height
-      blocks.map(_.block.blockHeader.hashBE).toVector == mintBlocks && blocks.map(_.height) == mintBlocks.zipWithIndex.map(_._2 + startingHeight)
-    },
+    assertIO(
+      BitcoinMonitor(bitcoindInstance).use(monitor => {
+        val blockStream = monitor.monitorBlocks()
+        for {
+          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
+          // After 0.5 second to allow the minted blocks to occur on the bitcoin instance
+          blocks <- blockStream.interruptAfter(500.millis).compile.toList
+          _ = monitor.stop()
+        } yield {
+          val startingHeight = blocks.head.height
+          blocks.map(_.block.blockHeader.hashBE).toVector == mintBlocks && blocks.map(_.height) == mintBlocks.zipWithIndex.map(_._2 + startingHeight)
+        }
+      }),
       true
     )
   }
   test("Monitor new blocks and report existing blocks") {
     val bitcoindInstance = bitcoind()
     val existingBlocks = Await.result(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _)), 5.seconds)
-    // Allow 0.5 second to allow the minted blocks to occur on the bitcoin instance
-    Thread.sleep(500)
-    assertIO(for {
-      monitor <- BitcoinMonitor(bitcoindInstance, Some(existingBlocks.head))
-      blockStream = monitor.monitorBlocks()
-      mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
-      blocks <- blockStream.interruptAfter(1.seconds).compile.toList
-      _ = monitor.stop()
-    } yield {
-      val expectedBlocks = existingBlocks ++ mintBlocks
-      val startingHeight = blocks.head.height
-      blocks.map(_.block.blockHeader.hashBE).toVector == expectedBlocks && blocks.map(_.height) == expectedBlocks.zipWithIndex.map(_._2 + startingHeight)
-    },
+    // Allow 1 second to allow the minted blocks to occur on the bitcoin instance
+    Thread.sleep(1000)
+    assertIO(
+      BitcoinMonitor(bitcoindInstance, Some(existingBlocks.head)).use(monitor => {
+        val blockStream = monitor.monitorBlocks()
+        for {
+          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
+          blocks <- blockStream.interruptAfter(1.seconds).compile.toList
+          _ = monitor.stop()
+        } yield {
+          val expectedBlocks = existingBlocks ++ mintBlocks
+          val startingHeight = blocks.head.height
+          blocks.map(_.block.blockHeader.hashBE).toVector == expectedBlocks && blocks.map(_.height) == expectedBlocks.zipWithIndex.map(_._2 + startingHeight)
+        }
+      })
+      ,
       true
     )
   }

--- a/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
@@ -13,15 +13,6 @@ package object monitoring {
       .map(_.trim)
   private def runProcess(args: Seq[String]): IO[String] =
     process.ProcessBuilder(args.head, args.tail.toList).spawn[IO].use(getText)
-
-  def startDockerContainer(container: String): IO[Unit] = runProcess(
-    Seq("docker", "start", container)
-  ).void
-
-  def stopDockerContainer(container: String): IO[Unit] = runProcess(
-    Seq("docker", "stop", container)
-  ).void
-
   def restartDockerContainer(container: String): IO[Unit] = runProcess(
     Seq("docker", "restart", container)
   ).void
@@ -43,27 +34,19 @@ package object monitoring {
 
   def connectBifrostNodes(node: String, otherNode: String): IO[Unit] = for {
     oldConfig <- getConfig(node)
-    _ <- IO.println(oldConfig)
     ip <- getIpAddr(otherNode)
     newConfig = addKnownPeer(oldConfig, ip)
     _ <- IO.println(newConfig)
     _ <- updateConfig(node, newConfig)
-//    _ <- stopDockerContainer(otherNode)
     _ <- restartDockerContainer(node)
-//    _ <- startDockerContainer(otherNode)
   } yield ()
 
   def disconnectBifrostNodes(node: String): IO[Unit] = for {
     oldConfig <- getConfig(node)
-    _ <- IO.println(oldConfig)
-
     newConfig = removeKnownPeer(oldConfig)
     _ <- IO.println(newConfig)
-
     _ <- updateConfig(node, newConfig)
-    //    _ <- stopDockerContainer(otherNode)
     _ <- restartDockerContainer(node)
-    //    _ <- startDockerContainer(otherNode)
   } yield ()
 
   def isRunning(container: String): IO[Boolean] = runProcess(

--- a/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
@@ -1,19 +1,73 @@
 package co.topl.brambl
 
 import cats.effect.IO
-import cats.effect.kernel.Resource
 import fs2.io.process
-import fs2.io.process.Process
+import fs2.text
 
 package object monitoring {
+  private def getText(p: fs2.io.process.Process[IO]): IO[String] =
+    p.stdout
+      .through(text.utf8.decode)
+      .compile
+      .foldMonoid
+      .map(_.trim)
+  private def runProcess(args: Seq[String]): IO[String] =
+    process.ProcessBuilder(args.head, args.tail.toList).spawn[IO].use(getText)
 
-  def runProcess(command: String, args: Seq[String]): Resource[IO, Process[IO]] =
-    process.ProcessBuilder(command, args.toList).spawn[IO]
+  def startDockerContainer(container: String): IO[Unit] = runProcess(
+    Seq("docker", "start", container)
+  ).void
 
-  def connectBifrostNodes(networkName: String, nodeName: String): Resource[IO, Process[IO]] =
-    runProcess("docker", Seq("network", "connect", networkName, nodeName))
+  def stopDockerContainer(container: String): IO[Unit] = runProcess(
+    Seq("docker", "stop", container)
+  ).void
 
-  def disconnectBifrostNodes(networkName: String, nodeName: String): Resource[IO, Process[IO]] =
-    runProcess("docker", Seq("network", "disconnect", networkName, nodeName))
+  def restartDockerContainer(container: String): IO[Unit] = runProcess(
+    Seq("docker", "restart", container)
+  ).void
+
+  def getConfig(container: String): IO[String] = runProcess(
+    Seq("docker", "exec", container, "cat", "/bifrost-staking/config.yaml")
+  )
+
+  def updateConfig(container: String, newConfig: String): IO[Unit] = runProcess(
+    Seq("docker", "exec", container, "sh", "-c", "\"echo", newConfig, ">", "/bifrost-staking/config.yaml\"")
+  ).void
+
+  def addKnownPeer(config: String, ip: String): String = if(config.contains("p2p")) config else config + s"  p2p:\n    known-peers: $ip:9085"
+  def removeKnownPeer(config: String): String = if(config.contains("p2p")) config.substring(0, config.indexOf("p2p")) else config
+
+  def getIpAddr(container: String): IO[String] = runProcess(
+    Seq("docker", "inspect", container, "--format", "{{.NetworkSettings.IPAddress}}")
+  )
+
+  def connectBifrostNodes(node: String, otherNode: String): IO[Unit] = for {
+    oldConfig <- getConfig(node)
+    _ <- IO.println(oldConfig)
+    ip <- getIpAddr(otherNode)
+    newConfig = addKnownPeer(oldConfig, ip)
+    _ <- IO.println(newConfig)
+    _ <- updateConfig(node, newConfig)
+//    _ <- stopDockerContainer(otherNode)
+    _ <- restartDockerContainer(node)
+//    _ <- startDockerContainer(otherNode)
+  } yield ()
+
+  def disconnectBifrostNodes(node: String): IO[Unit] = for {
+    oldConfig <- getConfig(node)
+    _ <- IO.println(oldConfig)
+
+    newConfig = removeKnownPeer(oldConfig)
+    _ <- IO.println(newConfig)
+
+    _ <- updateConfig(node, newConfig)
+    //    _ <- stopDockerContainer(otherNode)
+    _ <- restartDockerContainer(node)
+    //    _ <- startDockerContainer(otherNode)
+  } yield ()
+
+  def isRunning(container: String): IO[Boolean] = runProcess(
+    Seq("docker", "inspect", container, "--format", "{{.State.Running}}")
+  ).map(_.equals("true"))
 
 }

--- a/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
@@ -1,0 +1,19 @@
+package co.topl.brambl
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import fs2.io.process
+import fs2.io.process.Process
+
+package object monitoring {
+
+  def runProcess(command: String, args: Seq[String]): Resource[IO, Process[IO]] =
+    process.ProcessBuilder(command, args.toList).spawn[IO]
+
+  def connectBifrostNodes(networkName: String, nodeName: String): Resource[IO, Process[IO]] =
+    runProcess("docker", Seq("network", "connect", networkName, nodeName))
+
+  def disconnectBifrostNodes(networkName: String, nodeName: String): Resource[IO, Process[IO]] =
+    runProcess("docker", Seq("network", "disconnect", networkName, nodeName))
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,13 +7,15 @@ object Dependencies {
     val catsCoreVersion = "2.10.0"
     val simulacrumVersion = "1.0.1"
     val circeVersion = "0.14.6"
-    val protobufSpecsVersion = "2.0.0-beta2"
+    val protobufSpecsVersion = "2.0.0-beta3"
     val mUnitTeVersion = "0.7.29"
     val btcVersion = "1.9.7"
   }
 
   val catsSlf4j: ModuleID =
     "org.typelevel" %% "log4cats-slf4j" % "2.4.0"
+
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.10.2"
 
   val circe: Seq[ModuleID] = Seq(
     "io.circe" %% "circe-core"    % circeVersion,
@@ -115,7 +117,7 @@ object Dependencies {
   object IntegrationTests {
 
     lazy val sources: Seq[ModuleID] =
-      Crypto.sources ++ BramblSdk.sources ++ ServiceKit.sources
+      Crypto.sources ++ BramblSdk.sources ++ ServiceKit.sources :+ fs2Io
     lazy val tests: Seq[ModuleID] = (sources ++ mUnitTest).map(_ % Test)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
     val protobufSpecsVersion = "2.0.0-beta3"
     val mUnitTeVersion = "0.7.29"
     val btcVersion = "1.9.7"
+    val btcVersionZmq = "1.9.8"
   }
 
   val catsSlf4j: ModuleID =
@@ -72,7 +73,7 @@ object Dependencies {
 
   val btc: Seq[ModuleID] = Seq(
     "org.bitcoin-s" %% "bitcoin-s-core"         % btcVersion,
-    "org.bitcoin-s" %% "bitcoin-s-zmq"          % btcVersion,
+    "org.bitcoin-s" %% "bitcoin-s-zmq"          % btcVersionZmq,
     "org.bitcoin-s" %% "bitcoin-s-bitcoind-rpc" % btcVersion
   )
 

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -3,6 +3,6 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.17")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.18")
 
 // format: on

--- a/setupBifrostRegtest.sh
+++ b/setupBifrostRegtest.sh
@@ -18,9 +18,7 @@ bifrost:
 "
 chmod 777 node01/config.yaml
 echo $(pwd)
-export cmd="docker run -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 --network  -v "$(pwd)/node01:/bifrost-staking:rw" ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config /bifrost-staking/config.yaml --regtest"
-echo $cmd
-export CONTAINER_ID=$(docker run -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config=/bifrost-staking/config.yaml --regtest)
+export CONTAINER_ID=$(docker run -d --name bifrost01 -p 9185:9085 -p 9184:9084 -p 9191:9091 -v $(pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config=/bifrost-staking/config.yaml --regtest)
 export IP_CONTAINER=$(docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
 echo "IP_CONTAINER: $IP_CONTAINER"
 echo > node02/config.yaml "\

--- a/setupBifrostRegtest.sh
+++ b/setupBifrostRegtest.sh
@@ -16,6 +16,13 @@ bifrost:
     regtest-enabled: true
     stakes: [10000, 10000]
 "
+chmod 777 node01/config.yaml
+echo $(pwd)
+export cmd="docker run -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 --network  -v "$(pwd)/node01:/bifrost-staking:rw" ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config /bifrost-staking/config.yaml --regtest"
+echo $cmd
+export CONTAINER_ID=$(docker run -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config=/bifrost-staking/config.yaml --regtest)
+export IP_CONTAINER=$(docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
+echo "IP_CONTAINER: $IP_CONTAINER"
 echo > node02/config.yaml "\
 bifrost:
   big-bang:
@@ -24,11 +31,8 @@ bifrost:
     timestamp: $TIMESTAMP
     regtest-enabled: true
     stakes: [10000, 10000]
+  p2p:
+    known-peers: $IP_CONTAINER:9085
 "
-echo $(pwd)
-export cmd="docker run --rm --add-host host.docker.internal:host-gateway -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 --network  -v "$(pwd)/node01:/bifrost-staking:rw" ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config /bifrost-staking/config.yaml --regtest"
-echo $cmd
-export CONTAINER_ID=$(docker run --rm --add-host host.docker.internal:host-gateway -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config=/bifrost-staking/config.yaml --regtest)
-export IP_CONTAINER=$(docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
-echo "IP_CONTAINER: $IP_CONTAINER"
-docker run  --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config  /bifrost-staking/config.yaml --regtest
+chmod 777 node02/config.yaml
+docker run -d --name bifrost02 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config  /bifrost-staking/config.yaml --regtest

--- a/setupBifrostRegtest.sh
+++ b/setupBifrostRegtest.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+rm -fr node01
+rm -fr node02
+mkdir -p node01
+mkdir -p node02
+chmod 777 node01
+chmod 777 node02
+export TIMESTAMP=$(date --date="+10 seconds" +%s%N | cut -b1-13)
+echo > node01/config.yaml "\
+bifrost:
+  big-bang:
+    staker-count: 2
+    local-staker-index: 0
+    timestamp: $TIMESTAMP
+    regtest-enabled: true
+    stakes: [10000, 10000]
+"
+echo > node02/config.yaml "\
+bifrost:
+  big-bang:
+    staker-count: 2
+    local-staker-index: 1
+    timestamp: $TIMESTAMP
+    regtest-enabled: true
+    stakes: [10000, 10000]
+"
+echo $(pwd)
+export cmd="docker run --rm --add-host host.docker.internal:host-gateway -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 --network  -v "$(pwd)/node01:/bifrost-staking:rw" ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config /bifrost-staking/config.yaml --regtest"
+echo $cmd
+export CONTAINER_ID=$(docker run --rm --add-host host.docker.internal:host-gateway -d --name bifrost01 -p 9085:9085 -p 9084:9084 -p 9091:9091 -v $(pwd)/node01:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config=/bifrost-staking/config.yaml --regtest)
+export IP_CONTAINER=$(docker network inspect bridge | jq  ".[0].Containers.\"$CONTAINER_ID\".IPv4Address" | sed  's:"::g' | sed -n 's:\(.*\)/.*:\1:p')
+echo "IP_CONTAINER: $IP_CONTAINER"
+docker run  --rm -d --name bifrost02 -e BIFROST_P2P_KNOWN_PEERS=$IP_CONTAINER:9085 -p 9087:9085 -p 9086:9084 -p 9092:9091 -v $(pwd)/node02:/bifrost-staking:rw ghcr.io/topl/bifrost-node:2.0.0-beta3-24-7fd725a9 --  --config  /bifrost-staking/config.yaml --regtest


### PR DESCRIPTION
## Changes

- Added integration test for the Bifrost Monitor to ensure reorgs are handled as expected
- Added the bifrost RPC function "makeBlock" to the BifrostQuery API. This is to force block production and is only meant to be used in "RegTest" mode.
- Bifrost and Bitcoin monitor APIs now return a resource containing their respective block stream.
- Retroactive reporting of existing blocks in the bifrost monitor is now inclusive (includes the starting block).
- Bifrost monitor's update stream is now self-contained. It's channel will now shutdown when the monitor is released. 
- The ZMQ subscriber that is used in the Bitcoin Monitor now stops when the monitor is released. Users no longer have to explicitly call ".stop()"
- Updated existing BitcoinMonitor and BifrostMonitor tests (including the workflow in GH actions) to account for these changes.


## Testing

- Updated existing integration tests
- Added new integration test for BifrostMonitor reorgs
- Ensured these tests ran successfully locally and in github actions

## Tickets
* TSDK-852