### PR TITLE
Update Bitcoin-s dependency

### DIFF
--- a/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/monitoring/BitcoinMonitor.scala
@@ -1,6 +1,5 @@
 package co.topl.brambl.monitoring
 
-import akka.actor.ActorSystem
 import cats.effect.kernel.Resource
 import cats.effect.std.Queue
 import cats.effect.{IO, Ref}
@@ -12,7 +11,6 @@ import org.bitcoins.core.protocol.transaction.Transaction
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
 import org.bitcoins.rpc.config.{BitcoindAuthCredentials, BitcoindInstanceLocal, BitcoindInstanceRemote}
-import org.bitcoins.tor.Socks5ProxyParams
 import org.bitcoins.zmq.ZMQSubscriber
 
 import java.io.File
@@ -20,6 +18,8 @@ import java.net.{InetSocketAddress, URI}
 import scala.annotation.tailrec
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
+import org.bitcoins.core.api.tor.Socks5ProxyParams
+import org.apache.pekko.actor.ActorSystem
 
 /**
  * Class to monitor incoming bitcoin blocks via a queue.

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
@@ -2,7 +2,6 @@ package co.topl.brambl.monitoring
 
 import cats.effect.IO
 import co.topl.brambl.monitoring.BitcoinMonitor.AppliedBitcoinBlock
-import org.bitcoins.commons.jsonmodels.bitcoind.RpcOpts.AddNodeArgument
 import org.bitcoins.core.config.RegTest
 import org.bitcoins.crypto.DoubleSha256DigestBE
 import org.bitcoins.rpc.client.common.BitcoindRpcClient
@@ -53,7 +52,7 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
         for {
           node1MintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(walletName = TestWallet).flatMap(bitcoindInstance.generateToAddress(1, _))))
           node2MintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(walletName = TestWallet).flatMap(node2Instance.generateToAddress(2, _))))
-          _ <- IO.fromFuture(IO(bitcoindInstance.addNode(bitcoind.bitcoindInstance2Uri, AddNodeArgument.Add))).attempt.andWait(5.seconds)
+          _ <- connectBitcoinNodes("bitcoind", "bitcoind2", TestWallet).start.andWait(5.seconds)
           additionalMintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(walletName = TestWallet).flatMap(node2Instance.generateToAddress(1, _))))
           blocks <- blockStream.interruptAfter(5.seconds).compile.toList
         } yield {

--- a/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/BitcoinMonitorTest.scala
@@ -51,10 +51,10 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
     assertIO(
       BitcoinMonitor(bitcoindInstance).use(blockStream => {
         for {
-          node1MintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(1, _))))
-          node2MintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(2, _))))
+          node1MintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(walletName = TestWallet).flatMap(bitcoindInstance.generateToAddress(1, _))))
+          node2MintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(walletName = TestWallet).flatMap(node2Instance.generateToAddress(2, _))))
           _ <- IO.fromFuture(IO(bitcoindInstance.addNode(bitcoind.bitcoindInstance2Uri, AddNodeArgument.Add))).attempt.andWait(5.seconds)
-          additionalMintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(Some(TestWallet)).flatMap(node2Instance.generateToAddress(1, _))))
+          additionalMintBlocks <- IO.fromFuture(IO(node2Instance.getNewAddress(walletName = TestWallet).flatMap(node2Instance.generateToAddress(1, _))))
           blocks <- blockStream.interruptAfter(5.seconds).compile.toList
         } yield {
           case class BitcoinSyncLite(height: Int, hash: DoubleSha256DigestBE, isApplied: Boolean)
@@ -79,7 +79,7 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
     assertIO(
       BitcoinMonitor(bitcoindInstance).use(blockStream => {
         for {
-          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
+          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(walletName = TestWallet).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
           // After 0.5 second to allow the minted blocks to occur on the bitcoin instance
           blocks <- blockStream.interruptAfter(500.millis).compile.toList
         } yield {
@@ -92,13 +92,13 @@ class BitcoinMonitorTest extends munit.CatsEffectSuite {
   }
   test("Monitor new blocks and report existing blocks") {
     val bitcoindInstance = bitcoind()
-    val existingBlocks = Await.result(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _)), 5.seconds)
+    val existingBlocks = Await.result(bitcoindInstance.getNewAddress(walletName = TestWallet).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _)), 5.seconds)
     // Allow 1 second to allow the minted blocks to occur on the bitcoin instance
     Thread.sleep(1000)
     assertIO(
       BitcoinMonitor(bitcoindInstance, Some(existingBlocks.head)).use(blockStream => {
         for {
-          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(Some(TestWallet)).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
+          mintBlocks <- IO.fromFuture(IO(bitcoindInstance.getNewAddress(walletName = TestWallet).flatMap(bitcoindInstance.generateToAddress(NumBlocks, _))))
           blocks <- blockStream.interruptAfter(1.seconds).compile.toList
         } yield {
           val expectedBlocks = existingBlocks ++ mintBlocks

--- a/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
+++ b/integration/src/test/scala/co/topl/brambl/monitoring/package.scala
@@ -49,6 +49,13 @@ package object monitoring {
     _ <- restartDockerContainer(node)
   } yield ()
 
+  def connectBitcoinNodes(node: String, otherNode: String, wallet: String): IO[Unit] = for {
+    ip <- getIpAddr(otherNode)
+    _ <- runProcess(
+      Seq("docker", "exec", node, "bitcoin-cli", "-regtest", s"-rpcuser=$wallet", s"-rpcpassword=$wallet", "addnode", ip, "add")
+    )
+  } yield ()
+
   def isRunning(container: String): IO[Boolean] = runProcess(
     Seq("docker", "inspect", container, "--format", "{{.State.Running}}")
   ).map(_.equals("true"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     val circeVersion = "0.14.6"
     val protobufSpecsVersion = "2.0.0-beta3"
     val mUnitTeVersion = "0.7.29"
-    val btcVersion = "1.9.7"
+    val btcVersion = "1.9.9"
     val btcVersionZmq = "1.9.8"
   }
 


### PR DESCRIPTION
## Purpose

To resolve conflicting dependencies with bitcoin-s

## Approach

- upgrade bitcoin-s to 1.9.9 and added 2 imports to BitcoinMonitor (Edmundo)
- Fixed failing tests due to this change (Diadem)
    - Updated arguments to all calls to `getNewAddress` since the update changed the function signature
    - Changed the way we connect 2 bitcoin nodes (using docker exec) since `addNode` was no longer working

## Testing

Ensured all tests work again

## Tickets
* n/a