### PR TITLE
MINOR - specify domain separation string encoding

### DIFF
--- a/crypto/src/main/scala/co/topl/crypto/signing/eddsa/EC.scala
+++ b/crypto/src/main/scala/co/topl/crypto/signing/eddsa/EC.scala
@@ -53,7 +53,11 @@ trait EC {
   private[signing] val PUBLIC_KEY_SIZE: Int = POINT_BYTES
   private[signing] val SECRET_KEY_SIZE: Int = 32
   private[signing] val SIGNATURE_SIZE: Int = POINT_BYTES + SCALAR_BYTES
-  private[signing] val DOM2_PREFIX: Array[Byte] = "SigEd25519 no Ed25519 collisions".getBytes()
+
+  // private[signing] val DOM2_PREFIX: Array[Byte] = "SigEd25519 no Ed25519 collisions".getBytes(StandardCharsets.UTF_8)
+  private[signing] val DOM2_PREFIX: Array[Byte] = Array(0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39,
+    0x20, 0x6e, 0x6f, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6f, 0x6c, 0x6c, 0x69, 0x73, 0x69,
+    0x6f, 0x6e, 0x73)
 
   private val M28L = 0x0fffffffL
   private val M32L = 0xffffffffL


### PR DESCRIPTION
## Purpose
This PR updates a domain separation variable to more fully comply with the Ed25519 specification. The variable is question is used only in special circumstances and IS NOT currently being invoked, so there is no cause for concern.

Within the Ed25519 signing routine, this string used to prevent message collisions in order to constrain signatures produced by the routine. This string is described in the specification [here](https://datatracker.ietf.org/doc/html/rfc8032#section-8.6) and within the implementation is supposed to be represented by the UTF-8 encoding of the string, as illustrated in the bouncycastle implementation [here](https://github.com/bcgit/bc-java/blob/b8e4716f170a63986f8d3144445e3abff0e40475/core/src/main/java/org/bouncycastle/math/ec/rfc8032/Ed25519.java#L57). Also more information may be found [here](https://crypto.stackexchange.com/questions/72035/difference-between-pure-eddsa-ed25519-and-hasheddsa-ed25519ph).

In the current iteration of `EC.scala`, the bytes of this string are retrieved via an unspecified encoding, which may lead to unexpected behavior is this variable is used in a JVM where the default character set is not UTF-8.

https://github.com/Topl/BramblSc/blob/7492edc871d05dc0751005c77cf96737c18e5b94/crypto/src/main/scala/co/topl/crypto/signing/eddsa/EC.scala#L56

## Approach
- Update string definition to concrete UTF-8 bytes as done in BC implementation

## Testing
- All tests passing via `checkPR`

## Tickets
N/A