### PR TITLE
Fix maven deploy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,20 @@ lazy val commonSettings = Seq(
   testFrameworks += TestFrameworks.MUnit
 )
 
+def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
+  val dirtySuffix = out.dirtySuffix.dropPlus.mkString("-", "")
+  if (out.isCleanAfterTag)
+    out.ref.dropPrefix + dirtySuffix // no commit info if clean after tag
+  else
+    out.ref.dropPrefix + out.commitSuffix.mkString("-", "-", "") + dirtySuffix
+}
+
+def fallbackVersion(d: java.util.Date): String =
+  s"HEAD-${sbtdynver.DynVer timestamp d}"
+
 lazy val publishSettings = Seq(
+  version := dynverGitDescribeOutput.value
+    .mkVersion(versionFmt, fallbackVersion(dynverCurrentDate.value)),
   homepage := Some(url("https://github.com/Topl/BramblSc")),
   ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org",
   sonatypeRepository := "https://s01.oss.sonatype.org/service/local",


### PR DESCRIPTION
## Purpose

The maven-release job keeps failing due to Too many Server Redirects (20). We are testing out a possible fix done by normalizing the artifact names (removing "+" from the version).

## Approach

Applied the fix done in https://github.com/Topl/topl-btc-bridge/commit/ceb35cfb3b0c4c0063c57e5511d06ac152436cf1

## Testing

Testing is done manually by seeing if the maven-release job is successful 

## Tickets
n/a