### PR TITLE
TSDK-580 Implement Asset Merging

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["*"]
     tags: ["*"]
+  pull_request:
+    branches:
+      - "main"
 
 jobs:
   sbt-build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: ["*"]
     tags: ["*"]
-  pull_request:
-    branches:
-      - "main"
 
 jobs:
   sbt-build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for merging distinct, but compatible, assets.
+
+## [v2.0.0-beta7] - 2024-07-12
+
+### Added
+
 - Added a height field to the blocks in the Bifrost monitor stream
 - Added integration test for the Bifrost Monitor to ensure reorgs are handled as expected
 - Added the bifrost RPC function "makeBlock" to the BifrostQuery API. This is to force block production and is only meant to be used in "RegTest" mode.

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
@@ -20,27 +20,39 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
 import quivr.models.Int128
 
-import scala.math.Ordering.Implicits._
+import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 object MergingOps {
+
   // We strip ephemeral metadata and commitment because when splitting the alloy in the future, these fields may be different in the outputs.
-  implicit def getPreimageBytes(asset: Value.Asset): Array[Byte] = asset.clearEphemeralMetadata.clearCommitment.immutable.value.toByteArray
+  implicit def getPreimageBytes(asset: Value.Asset): Array[Byte] =
+    asset.clearEphemeralMetadata.clearCommitment.immutable.value.toByteArray
+
   // Get alloy preimages, sort, then construct merkle proof using Sha256.
   def getAlloy(values: Seq[Asset]): ByteString = ByteString.copyFrom(
     MerkleTree[Sha, Digest32](values.map(getPreimageBytes).sortBy(encodeToHex).map(LeafData)).rootHash.value
   )
 
   // Precondition: the values represent a valid merge
-  def merge(values: Seq[Txo], mergedAssetLockAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]): UnspentTransactionOutput = {
+  def merge(
+    values:                 Seq[Txo],
+    mergedAssetLockAddress: LockAddress,
+    ephemeralMetadata:      Option[Struct],
+    commitment:             Option[ByteString]
+  ): UnspentTransactionOutput = {
     val quantity: Int128 = values.map(v => (v.transactionOutput.value.getAsset.quantity: BigInt)).sum
     val isGroupFungible = values.head.transactionOutput.value.getAsset.fungibility == FungibilityType.GROUP
     UnspentTransactionOutput(
       mergedAssetLockAddress,
       Value.defaultInstance.withAsset(
         Value.Asset(
-          groupId = Option.when(isGroupFungible)(GroupId(values.head.transactionOutput.value.getAsset.typeIdentifier.groupIdOrAlloy)),
-          seriesId = Option.when(!isGroupFungible)(SeriesId(values.head.transactionOutput.value.getAsset.typeIdentifier.seriesIdOrAlloy)),
+          groupId = Option.when(isGroupFungible)(
+            GroupId(values.head.transactionOutput.value.getAsset.typeIdentifier.groupIdOrAlloy)
+          ),
+          seriesId = Option.when(!isGroupFungible)(
+            SeriesId(values.head.transactionOutput.value.getAsset.typeIdentifier.seriesIdOrAlloy)
+          ),
           groupAlloy = Option.when(!isGroupFungible)(getAlloy(values.map(_.transactionOutput.value.getAsset))),
           seriesAlloy = Option.when(isGroupFungible)(getAlloy(values.map(_.transactionOutput.value.getAsset))),
           quantity = quantity,
@@ -55,36 +67,76 @@ object MergingOps {
 
   private def nonEmptyValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
     Validated.condNec(values.nonEmpty, (), "UTXOs to merge must not be empty")
+
   private def noDuplicatesValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    Validated.condNec(values.distinctBy(_.outputAddress).length == values.length, (), "UTXOs to merge must not have duplicates")
+    Validated.condNec(
+      values.distinctBy(_.outputAddress).length == values.length,
+      (),
+      "UTXOs to merge must not have duplicates"
+    )
+
   private def validIdentifiersValidation(values: Seq[Txo]): ValidatedNec[String, Unit] = Try {
     values.map(_.transactionOutput.value.value.typeIdentifier)
   } match {
-    case Success(v) => if(v.forall({
-      case AssetType(_, _) => true
-      case _ => false
-    })) ().validNec[String] else "UTXOs to merge must all be assets".invalidNec[Unit]
+    case Success(v) =>
+      if (
+        v.forall {
+          case AssetType(_, _) => true
+          case _               => false
+        }
+      ) ().validNec[String]
+      else "UTXOs to merge must all be assets".invalidNec[Unit]
     case Failure(err) => err.getMessage.invalidNec[Unit]
   }
+
   private def distinctIdentifierValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    Validated.condNec(values.map(_.transactionOutput.value.value.typeIdentifier).distinct.length == values.length, (), "UTXOs to merge must all be distinct (per type identifier)")
+    Validated.condNec(
+      values.map(_.transactionOutput.value.value.typeIdentifier).distinct.length == values.length,
+      (),
+      "UTXOs to merge must all be distinct (per type identifier)"
+    )
+
   private def sameFungibilityTypeValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    Validated.condNec(values.forall(_.transactionOutput.value.getAsset.fungibility == values.head.transactionOutput.value.getAsset.fungibility), (), "Assets to merge must all share the same fungibility type")
+    Validated.condNec(
+      values.forall(
+        _.transactionOutput.value.getAsset.fungibility == values.head.transactionOutput.value.getAsset.fungibility
+      ),
+      (),
+      "Assets to merge must all share the same fungibility type"
+    )
 
   private def validFungibilityTypeValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    (values.head.transactionOutput.value.getAsset.fungibility, values.head.transactionOutput.value.value.typeIdentifier) match {
-    case (FungibilityType.GROUP_AND_SERIES, _) => "Assets to merge must not have Group_And_Series fungibility type".invalidNec[Unit]
-    case (FungibilityType.SERIES, AssetType(_, seriesIdOrAlloy)) => Validated.condNec(
-      values.tail.map(_.transactionOutput.value.getAsset.typeIdentifier.seriesIdOrAlloy).forall(_ == seriesIdOrAlloy), (), "Merging Series fungible assets must share a series ID"
-    )
-    case (FungibilityType.GROUP, AssetType(groupIdOrAlloy, _)) => Validated.condNec(
-      values.tail.map(_.transactionOutput.value.getAsset.typeIdentifier.groupIdOrAlloy).forall(_ == groupIdOrAlloy), (), "Merging Group fungible assets must share a group ID"
-    )
-    case _ => "Merging Group or Series fungible assets do not have valid AssetType identifiers".invalidNec[Unit]
-  }
-  private def sameQuantityDescriptorValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    Validated.condNec(values.nonEmpty, values.forall(_.transactionOutput.value.getAsset.quantityDescriptor == values.head.transactionOutput.value.getAsset.quantityDescriptor), "Merging assets must all share the same Quantity Descriptor Type")
+    (
+      values.head.transactionOutput.value.getAsset.fungibility,
+      values.head.transactionOutput.value.value.typeIdentifier
+    ) match {
+      case (FungibilityType.GROUP_AND_SERIES, _) =>
+        "Assets to merge must not have Group_And_Series fungibility type".invalidNec[Unit]
+      case (FungibilityType.SERIES, AssetType(_, seriesIdOrAlloy)) =>
+        Validated.condNec(
+          values.tail
+            .map(_.transactionOutput.value.getAsset.typeIdentifier.seriesIdOrAlloy)
+            .forall(_ == seriesIdOrAlloy),
+          (),
+          "Merging Series fungible assets must share a series ID"
+        )
+      case (FungibilityType.GROUP, AssetType(groupIdOrAlloy, _)) =>
+        Validated.condNec(
+          values.tail.map(_.transactionOutput.value.getAsset.typeIdentifier.groupIdOrAlloy).forall(_ == groupIdOrAlloy),
+          (),
+          "Merging Group fungible assets must share a group ID"
+        )
+      case _ => "Merging Group or Series fungible assets do not have valid AssetType identifiers".invalidNec[Unit]
+    }
 
+  private def sameQuantityDescriptorValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(
+      values.nonEmpty,
+      values.forall(
+        _.transactionOutput.value.getAsset.quantityDescriptor == values.head.transactionOutput.value.getAsset.quantityDescriptor
+      ),
+      "Merging assets must all share the same Quantity Descriptor Type"
+    )
 
   private val validators: Chain[Seq[Txo] => ValidatedNec[String, Unit]] = Chain(
     nonEmptyValidation, // seq not empty
@@ -93,7 +145,7 @@ object MergingOps {
     distinctIdentifierValidation, // IDs of all TXOs are distinct (combination of group/series ID/alloy)
     sameFungibilityTypeValidation, // All TXOs have same fungibility type
     validFungibilityTypeValidation, // not group_and_Series fungible, group or series fungibility have common ID
-    sameQuantityDescriptorValidation, // ensure all TXOs have same quantity descriptor types
+    sameQuantityDescriptorValidation // ensure all TXOs have same quantity descriptor types
   )
 
   def validMerge(values: Seq[Txo]): ValidatedNec[String, Unit] = validators.foldMap(_ apply values)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
@@ -1,0 +1,37 @@
+package co.topl.brambl.builders
+
+import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
+import co.topl.brambl.common.ContainsImmutable.instances._
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.genus.services.Txo
+import com.google.protobuf.ByteString
+import com.google.protobuf.struct.Struct
+
+object MergingOps {
+  // TODO: strip ephermeral metadata and commitment??.. think about this
+  implicit def getPreimageBytes(utxo: UnspentTransactionOutput): Array[Byte] = utxo.value.immutable.toByteArray // includes quantity
+  // Precondition: the values represent a valid merge
+  def merge(values: Seq[Txo], mergedAssetLockAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]): UnspentTransactionOutput = {
+    val quantity = ??? // fold the values
+    UnspentTransactionOutput(
+      mergedAssetLockAddress,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = ???, // based on fungibility
+          seriesId = ???, // based on fungibility
+          groupAlloy = ???, // based on fungibility AND merkle root - what about case where we are merging pre-existing alloys.. do we overwrite these fields?.. prob not bc the new merkle root will contain them
+          seriesAlloy = ???, // based on fungibility AND merkle root
+          quantity = quantity,
+          fungibility = values.head.transactionOutput.value.getAsset.fungibility,
+          quantityDescriptor = values.head.transactionOutput.value.getAsset.quantityDescriptor,
+          ephemeralMetadata = ephemeralMetadata,
+          commitment = commitment
+        )
+      )
+    )
+  }
+
+  def validMerge(values: Seq[Txo]): Boolean = ??? // check fungibility type
+}

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
@@ -65,8 +65,8 @@ object MergingOps {
     )
   }
 
-  private def nonEmptyValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
-    Validated.condNec(values.nonEmpty, (), "UTXOs to merge must not be empty")
+  private def insufficientAssetsValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.length >= 2, (), "There must be at least 2 UTXOs to merge")
 
   private def noDuplicatesValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
     Validated.condNec(
@@ -139,7 +139,7 @@ object MergingOps {
     )
 
   private val validators: Chain[Seq[Txo] => ValidatedNec[String, Unit]] = Chain(
-    nonEmptyValidation, // seq not empty
+    insufficientAssetsValidation, // seq not empty
     noDuplicatesValidation, // UTXO address does not repeat
     validIdentifiersValidation, // All TXOs have a valid identifier
     distinctIdentifierValidation, // IDs of all TXOs are distinct (combination of group/series ID/alloy)

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
@@ -1,16 +1,21 @@
 package co.topl.brambl.builders
 
+import cats.data.{Chain, Validated, ValidatedNec}
+import cats.implicits.{catsSyntaxValidatedIdBinCompat0, toFoldableOps}
 import co.topl.brambl.common.ContainsImmutable.ContainsImmutableTOps
 import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.LockAddress
-import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.box.{FungibilityType, Value}
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax.{AssetType, assetToAssetTypeSyntaxOps, valueToTypeIdentifierSyntaxOps}
 import co.topl.genus.services.Txo
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
 
+import scala.util.{Failure, Success, Try}
+
 object MergingOps {
-  // TODO: strip ephermeral metadata and commitment??.. think about this
+  // TODO: strip ephermeral metadata and commitment??..
   implicit def getPreimageBytes(utxo: UnspentTransactionOutput): Array[Byte] = utxo.value.immutable.toByteArray // includes quantity
   // Precondition: the values represent a valid merge
   def merge(values: Seq[Txo], mergedAssetLockAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]): UnspentTransactionOutput = {
@@ -33,5 +38,48 @@ object MergingOps {
     )
   }
 
-  def validMerge(values: Seq[Txo]): Boolean = ??? // check fungibility type
+  private def nonEmptyValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.nonEmpty, (), "UTXOs to merge must not be empty")
+  private def noDuplicatesValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.distinctBy(_.outputAddress).length == values.length, (), "UTXOs to merge must not have duplicates")
+  private def validIdentifiersValidation(values: Seq[Txo]): ValidatedNec[String, Unit] = Try {
+    values.map(_.transactionOutput.value.value.typeIdentifier)
+  } match {
+    case Success(v) => if(v.forall({
+      case AssetType(_, _) => true
+      case _ => false
+    })) ().validNec[String] else "UTXOs to merge must all be assets".invalidNec[Unit]
+    case Failure(err) => err.getMessage.invalidNec[Unit]
+  }
+  private def distinctIdentifierValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.map(_.transactionOutput.value.value.typeIdentifier).distinct.length == values.length, (), "UTXOs to merge must all be distinct (per type identifier)")
+  private def sameFungibilityTypeValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.forall(_.transactionOutput.value.getAsset.fungibility == values.head.transactionOutput.value.getAsset.fungibility), (), "Assets to merge must all share the same fungibility type")
+
+  private def validFungibilityTypeValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    (values.head.transactionOutput.value.getAsset.fungibility, values.head.transactionOutput.value.value.typeIdentifier) match {
+    case (FungibilityType.GROUP_AND_SERIES, _) => "Assets to merge must not have Group_And_Series fungibility type".invalidNec[Unit]
+    case (FungibilityType.SERIES, AssetType(_, seriesIdOrAlloy)) => Validated.condNec(
+      values.tail.map(_.transactionOutput.value.getAsset.typeIdentifier.seriesIdOrAlloy).forall(_ == seriesIdOrAlloy), (), "Merging Series fungible assets must share a series ID"
+    )
+    case (FungibilityType.GROUP, AssetType(groupIdOrAlloy, _)) => Validated.condNec(
+      values.tail.map(_.transactionOutput.value.getAsset.typeIdentifier.groupIdOrAlloy).forall(_ == groupIdOrAlloy), (), "Merging Group fungible assets must share a group ID"
+    )
+    case _ => "Merging Group or Series fungible assets do not have valid AssetType identifiers".invalidNec[Unit]
+  }
+  private def sameQuantityDescriptorValidation(values: Seq[Txo]): ValidatedNec[String, Unit] =
+    Validated.condNec(values.nonEmpty, values.forall(_.transactionOutput.value.getAsset.quantityDescriptor == values.head.transactionOutput.value.getAsset.quantityDescriptor), "Merging assets must all share the same Quantity Descriptor Type")
+
+
+  private val validators: Chain[Seq[Txo] => ValidatedNec[String, Unit]] = Chain(
+    nonEmptyValidation, // seq not empty
+    noDuplicatesValidation, // UTXO address does not repeat
+    validIdentifiersValidation, // All TXOs have a valid identifier
+    distinctIdentifierValidation, // IDs of all TXOs are distinct (combination of group/series ID/alloy)
+    sameFungibilityTypeValidation, // All TXOs have same fungibility type
+    validFungibilityTypeValidation, // not group_and_Series fungible, group or series fungibility have common ID
+    sameQuantityDescriptorValidation, // ensure all TXOs have same quantity descriptor types
+  )
+
+  def validMerge(values: Seq[Txo]): ValidatedNec[String, Unit] = validators.foldMap(_ apply values)
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/MergingOps.scala
@@ -8,7 +8,14 @@ import co.topl.brambl.models.box.Value.Asset
 import co.topl.brambl.models.box.{FungibilityType, Value}
 import co.topl.brambl.models.transaction.UnspentTransactionOutput
 import co.topl.brambl.models.{GroupId, LockAddress, SeriesId}
-import co.topl.brambl.syntax.{AssetType, ValueTypeIdentifier, assetToAssetTypeSyntaxOps, bigIntAsInt128, int128AsBigInt, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{
+  assetToAssetTypeSyntaxOps,
+  bigIntAsInt128,
+  int128AsBigInt,
+  valueToTypeIdentifierSyntaxOps,
+  AssetType,
+  ValueTypeIdentifier
+}
 import co.topl.crypto.accumulators.LeafData
 import co.topl.crypto.accumulators.merkle.MerkleTree
 import co.topl.crypto.hash.Sha

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -2,39 +2,21 @@ package co.topl.brambl.builders
 
 import cats.Monad
 import cats.data.EitherT
-import co.topl.brambl.codecs.AddressCodecs
-import co.topl.brambl.models.{Datum, Event, GroupId, LockAddress, LockId, SeriesId}
-import co.topl.brambl.models.box.{
-  AssetMintingStatement,
-  Attestation,
-  FungibilityType,
-  Lock,
-  QuantityDescriptorType,
-  Value
-}
-import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.genus.services.Txo
-import com.google.protobuf.ByteString
-import quivr.models.{Int128, Proof, SmallData}
-import co.topl.brambl.common.ContainsEvidence.Ops
-import co.topl.brambl.common.ContainsImmutable.instances._
 import cats.implicits._
 import co.topl.brambl.builders.UserInputValidations.TransactionBuilder._
+import co.topl.brambl.codecs.AddressCodecs
+import co.topl.brambl.common.ContainsEvidence.Ops
+import co.topl.brambl.common.ContainsImmutable.instances._
 import co.topl.brambl.models.Event.{GroupPolicy, SeriesPolicy}
 import co.topl.brambl.models.box.Value.{Value => BoxValue}
-import co.topl.brambl.syntax.{
-  bigIntAsInt128,
-  groupPolicyAsGroupPolicySyntaxOps,
-  int128AsBigInt,
-  longAsInt128,
-  seriesPolicyAsSeriesPolicySyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType,
-  UnknownType,
-  ValueTypeIdentifier
-}
+import co.topl.brambl.models.box._
+import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
+import co.topl.brambl.models._
+import co.topl.brambl.syntax.{LvlType, UnknownType, ValueTypeIdentifier, bigIntAsInt128, groupPolicyAsGroupPolicySyntaxOps, int128AsBigInt, longAsInt128, seriesPolicyAsSeriesPolicySyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.genus.services.Txo
+import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
+import quivr.models.{Int128, Proof, SmallData}
 
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
@@ -313,6 +295,17 @@ trait TransactionBuilderApi[F[_]] {
     changeAddress:          LockAddress,
     ephemeralMetadata:      Option[Struct] = None,
     commitment:             Option[ByteString] = None
+  ): F[Either[BuilderError, IoTransaction]]
+
+  def buildAssetMergeTransaction(
+    mergingStatement: AssetMergingStatement,
+    txos: Seq[Txo],
+    locks: Map[LockAddress, Lock.Predicate],
+    fee: Long,
+    mergedAssetLockAddress: LockAddress,
+    changeAddress: LockAddress,
+    ephemeralMetadata: Option[Struct] = None,
+    commitment: Option[ByteString] = None
   ): F[Either[BuilderError, IoTransaction]]
 }
 
@@ -756,5 +749,18 @@ object TransactionBuilderApi {
           )
         ).pure[F]
 
+      override def buildAssetMergeTransaction(mergingStatement: AssetMergingStatement, txos: Seq[Txo], locks: Map[LockAddress, Lock.Predicate], fee: Long, mergedAssetLockAddress: LockAddress, changeAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]): F[Either[BuilderError, IoTransaction]] = {
+        // validate arguments
+          // verify all the input utxos are present in the txos
+          // verify the other stuff (same as the other functions)
+        // separate the TXOs. the ones to be merged, vs the ones to go to change
+        // validate that the txos to be merged are all compatible
+        // create a single merged utxo for the ones to be merged. (MergingOps)
+          // merging ops takes all the txos to be merged together, and either throws a validation error or returns a single utxo
+        // merging ops will verify that they are all compatible
+        // use applyFee for the ones to go to change, and create the utxos for that
+        // in the unit tests, test diff cases (its own test suite file, try different utxo combinations (not compatible)).
+        ???
+      }
     }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -12,7 +12,18 @@ import co.topl.brambl.models._
 import co.topl.brambl.models.box.Value.{Value => BoxValue}
 import co.topl.brambl.models.box._
 import co.topl.brambl.models.transaction.{IoTransaction, Schedule, SpentTransactionOutput, UnspentTransactionOutput}
-import co.topl.brambl.syntax.{LvlType, UnknownType, ValueTypeIdentifier, bigIntAsInt128, groupPolicyAsGroupPolicySyntaxOps, int128AsBigInt, longAsInt128, seriesPolicyAsSeriesPolicySyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{
+  bigIntAsInt128,
+  groupPolicyAsGroupPolicySyntaxOps,
+  int128AsBigInt,
+  longAsInt128,
+  seriesPolicyAsSeriesPolicySyntaxOps,
+  valueToQuantitySyntaxOps,
+  valueToTypeIdentifierSyntaxOps,
+  LvlType,
+  UnknownType,
+  ValueTypeIdentifier
+}
 import co.topl.genus.services.Txo
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -755,19 +755,19 @@ object TransactionBuilderApi {
           datum <- EitherT.right[BuilderError](datum())
           filteredTxos = txos.filter(_.transactionOutput.value.value.typeIdentifier != UnknownType)
           _ <- EitherT
-            .fromEither[F](validateAssetMergingParams(utxosToMerge, filteredTxos, locks.keySet, fee))
+            .fromEither[F](validateAssetMergingParams(utxosToMerge.toSeq, filteredTxos.toSeq, locks.keySet, fee))
             .leftMap(errs => UserInputErrors(errs.toList))
           attestations <- toAttestationMap(filteredTxos, locks)
           stxos <- attestations.map(el => buildStxos(el._1, el._2)).toSeq.sequence.map(_.flatten)
           (txosToMerge, otherTxos) = filteredTxos.partition(txo => utxosToMerge.contains(txo.outputAddress))
           utxosChange <- buildUtxos(otherTxos, None, None, changeAddress, changeAddress, fee)
-          mergedUtxo = MergingOps.merge(txosToMerge, mergedAssetLockAddress, ephemeralMetadata, commitment)
-          asm = AssetMergingStatement(utxosToMerge, utxosChange.length)
+          mergedUtxo = MergingOps.merge(txosToMerge.toSeq, mergedAssetLockAddress, ephemeralMetadata, commitment)
+          asm = AssetMergingStatement(utxosToMerge.toSeq, utxosChange.length)
         } yield IoTransaction(
           inputs = stxos,
-          outputs = utxosChange :+ mergedUtxo,
+          outputs = (utxosChange :+ mergedUtxo).toSeq,
           datum = datum,
-          mergingStatements = Seq(asm)
+          mergingStatements = Seq(asm).toSeq
         )
       ).value
     }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/TransactionBuilderApi.scala
@@ -298,7 +298,27 @@ trait TransactionBuilderApi[F[_]] {
     commitment:             Option[ByteString] = None
   ): F[Either[BuilderError, IoTransaction]]
 
-  // TODO
+  /**
+   * Builds a transaction to merge distinct, but compatible, assets. If successful, the transaction will have one or more
+   * outputs; the merged asset and, optionally, the change. The merged asset will contain the sum of the quantities of the
+   * merged inputs. The change will contain the remaining tokens that were not merged into the merged asset.
+   *
+   * @note The assets to merge must be valid. To be valid, the assets must have the same fungibility type and quantity descriptor
+   *       type. The fungibility type must be one of "GROUP" or "SERIES". If "GROUP", then the assets must share the same Group ID.
+   *       If "SERIES", then the assets must share the same Series ID. Fields such as "commitment" and "ephermeralMetadata" do not
+   *       carryover; if desired, these fields in the merged output can be specified using the "ephemeralMetadata" and "commitment"
+   *       arguments.
+   *
+   * @param utxosToMerge The UTXOs to merge. These UTXOs must contain assets that are compatible to merge.
+   * @param txos All the TXOs encumbered by the Locks given by locks. These represent the inputs of the transaction.
+   * @param locks A mapping of Predicate Locks that encumbers the funds in the txos. This will be used in the attestations of the txos' inputs.
+   * @param fee The transaction fee. The txos must contain enough LVLs to satisfy this fee
+   * @param mergedAssetLockAddress The LockAddress to send the merged asset tokens to.
+   * @param changeAddress The LockAddress to send any change to.
+   * @param ephemeralMetadata Optional ephemeral metadata to include in the merged asset token.
+   * @param commitment Optional commitment to include in the merged asset token.
+   * @return An unproven asset merge transaction if possible. Else, an error
+   */
   def buildAssetMergeTransaction(
     utxosToMerge:           Seq[TransactionOutputAddress],
     txos:                   Seq[Txo],

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -305,8 +305,7 @@ object UserInputValidations {
           utxosToMerge.length == txosToMerge.length,
           (),
           UserInputError("All UTXOs to merge must be accounted for in txos")
-        ),
-        MergingOps.validMerge(txosToMerge).leftMap(_.map(UserInputError)),
+        ).andThen(_ => MergingOps.validMerge(txosToMerge).leftMap(_.map(UserInputError))),
         allInputLocksMatch(txoLocks, locks, "the txos", "a lock in the lock map"),
         allInputLocksMatch(locks, txoLocks, "the lock map", "a lock in the txos"),
         validFee(fee, txos.map(_.transactionOutput.value.value))

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -2,22 +2,12 @@ package co.topl.brambl.builders
 
 import cats.data.{Chain, NonEmptyChain, Validated, ValidatedNec}
 import cats.implicits.{catsSyntaxEitherId, catsSyntaxValidatedIdBinCompat0, toFoldableOps}
+import co.topl.brambl.models.box.Value._
 import co.topl.brambl.models.box.{AssetMintingStatement, QuantityDescriptorType}
 import co.topl.brambl.models.{LockAddress, SeriesId, TransactionOutputAddress}
-import co.topl.brambl.models.box.Value._
-import quivr.models.Int128
-import co.topl.brambl.syntax.{
-  int128AsBigInt,
-  longAsInt128,
-  valueToQuantityDescriptorSyntaxOps,
-  valueToQuantitySyntaxOps,
-  valueToTypeIdentifierSyntaxOps,
-  LvlType,
-  ToplType,
-  UnknownType,
-  ValueTypeIdentifier
-}
+import co.topl.brambl.syntax.{LvlType, ToplType, UnknownType, ValueTypeIdentifier, int128AsBigInt, longAsInt128, valueToQuantityDescriptorSyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
 import co.topl.genus.services.Txo
+import quivr.models.Int128
 
 import scala.util.{Failure, Success, Try}
 
@@ -291,5 +281,12 @@ object UserInputValidations {
       case Success(value) => value
       case Failure(err)   => NonEmptyChain.one(UserInputError(err.getMessage)).asLeft
     }
+
+    def validateAssetMergingParams( // verify that utxosToMerge is not empty
+      utxosToMerge: Seq[TransactionOutputAddress], // validate that they are all present in txos, and that they are all compatible
+      txos:             Seq[Txo], // ensure all have a lock
+      locks:            Set[LockAddress],
+      fee:              Long
+    ): Either[NonEmptyChain[UserInputError], Unit] = ???
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -5,7 +5,17 @@ import cats.implicits.{catsSyntaxEitherId, catsSyntaxValidatedIdBinCompat0, toFo
 import co.topl.brambl.models.box.Value._
 import co.topl.brambl.models.box.{AssetMintingStatement, QuantityDescriptorType}
 import co.topl.brambl.models.{LockAddress, SeriesId, TransactionOutputAddress}
-import co.topl.brambl.syntax.{LvlType, ToplType, UnknownType, ValueTypeIdentifier, int128AsBigInt, longAsInt128, valueToQuantityDescriptorSyntaxOps, valueToQuantitySyntaxOps, valueToTypeIdentifierSyntaxOps}
+import co.topl.brambl.syntax.{
+  int128AsBigInt,
+  longAsInt128,
+  valueToQuantityDescriptorSyntaxOps,
+  valueToQuantitySyntaxOps,
+  valueToTypeIdentifierSyntaxOps,
+  LvlType,
+  ToplType,
+  UnknownType,
+  ValueTypeIdentifier
+}
 import co.topl.genus.services.Txo
 import quivr.models.Int128
 
@@ -284,14 +294,18 @@ object UserInputValidations {
 
     def validateAssetMergingParams(
       utxosToMerge: Seq[TransactionOutputAddress],
-      txos:             Seq[Txo],
-      locks:            Set[LockAddress],
-      fee:              Long
+      txos:         Seq[Txo],
+      locks:        Set[LockAddress],
+      fee:          Long
     ): Either[NonEmptyChain[UserInputError], Unit] = Try {
       val txoLocks = txos.map(_.transactionOutput.address).toSet
       val txosToMerge = txos.filter(txo => utxosToMerge.contains(txo.outputAddress))
       Chain(
-        Validated.condNec(utxosToMerge.length == txosToMerge.length, (), UserInputError("All UTXOs to merge must be accounted for in txos")),
+        Validated.condNec(
+          utxosToMerge.length == txosToMerge.length,
+          (),
+          UserInputError("All UTXOs to merge must be accounted for in txos")
+        ),
         MergingOps.validMerge(txosToMerge).leftMap(_.map(UserInputError)),
         allInputLocksMatch(txoLocks, locks, "the txos", "a lock in the lock map"),
         allInputLocksMatch(locks, txoLocks, "the lock map", "a lock in the txos"),
@@ -299,7 +313,7 @@ object UserInputValidations {
       ).fold.toEither
     } match {
       case Success(value) => value
-      case Failure(err) => NonEmptyChain.one(UserInputError(err.getMessage)).asLeft
+      case Failure(err)   => NonEmptyChain.one(UserInputError(err.getMessage)).asLeft
     }
   }
 }

--- a/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/builders/UserInputValidations.scala
@@ -301,11 +301,13 @@ object UserInputValidations {
       val txoLocks = txos.map(_.transactionOutput.address).toSet
       val txosToMerge = txos.filter(txo => utxosToMerge.contains(txo.outputAddress))
       Chain(
-        Validated.condNec(
-          utxosToMerge.length == txosToMerge.length,
-          (),
-          UserInputError("All UTXOs to merge must be accounted for in txos")
-        ).andThen(_ => MergingOps.validMerge(txosToMerge).leftMap(_.map(UserInputError))),
+        Validated
+          .condNec(
+            utxosToMerge.length == txosToMerge.length,
+            (),
+            UserInputError("All UTXOs to merge must be accounted for in txos")
+          )
+          .andThen(_ => MergingOps.validMerge(txosToMerge).leftMap(_.map(UserInputError))),
         allInputLocksMatch(txoLocks, locks, "the txos", "a lock in the lock map"),
         allInputLocksMatch(locks, txoLocks, "the lock map", "a lock in the txos"),
         validFee(fee, txos.map(_.transactionOutput.value.value))

--- a/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
+++ b/brambl-sdk/src/main/scala/co/topl/brambl/syntax/TokenTypeIdentifierSyntax.scala
@@ -16,6 +16,7 @@ trait TokenTypeIdentifierSyntax {
 }
 
 class AssetToAssetTypeSyntaxOps(val a: Asset) extends AnyVal {
+
   def typeIdentifier: AssetType = (a.groupId, a.seriesId, a.groupAlloy, a.seriesAlloy) match {
     // If seriesAlloy is provided, the seriesId is ignored. In this case, groupAlloy should not exist
     case (Some(gId), _, None, Some(sAlloy)) => AssetType(gId.value, sAlloy)
@@ -41,8 +42,8 @@ class ValueToTypeIdentifierSyntaxOps(val value: Value) extends AnyVal {
     case Value.Topl(t)   => ToplType(t.registration)
     case Value.Group(g)  => GroupType(g.groupId)
     case Value.Series(s) => SeriesType(s.seriesId)
-    case Value.Asset(a) => a.typeIdentifier
-    case _ => UnknownType
+    case Value.Asset(a)  => a.typeIdentifier
+    case _               => UnknownType
   }
 }
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
@@ -1,0 +1,48 @@
+package co.topl.brambl.builders
+
+class MergingOpsSpec extends TransactionBuilderInterpreterSpecBase {
+  test("Valid Merge Compatibility > ") {
+
+  }
+  test("Invalid Merge Compatibility > only 1 TXO provided") {
+  }
+  test("Invalid Merge Compatibility > Repeat UTXO address in TXOs") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs contain invalid identifier") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs contain non-asset identifier") {
+
+  }
+  test("Invalid Merge Compatibility > Repeat TypeIdentifier in TXOs") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs do not all share same fungibility type") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs contain Group_and_Series fungibility") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs with Series fungibility do not share SeriesId") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs with Group fungibility do not share GroupId") {
+
+  }
+  test("Invalid Merge Compatibility > TXOs do not all share same quantity descriptor type") {
+
+  }
+  test("Merge > Basic Group fungible") {
+  }
+  test("Merge > Basic Series fungible") {
+  }
+  test("Merge > Group fungible w/ an alloy") {
+  }
+  test("Merge > Series fungible w/ an alloy") {
+  }
+  test("Merge > Validate ephemeral metadata and commitment does not affect merkle root") {
+  }
+  test("Merge > Validate lexicographical order > changing orders does not affect merkle root") {
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
@@ -1,48 +1,236 @@
 package co.topl.brambl.builders
 
-class MergingOpsSpec extends TransactionBuilderInterpreterSpecBase {
-  test("Valid Merge Compatibility > ") {
+import co.topl.brambl.models.box.FungibilityType.{GROUP, SERIES}
+import co.topl.brambl.models.box.QuantityDescriptorType.LIQUID
+import co.topl.brambl.models.box.Value
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax.bigIntAsInt128
+import com.google.protobuf.struct.Value.Kind.StringValue
+import com.google.protobuf.struct.{Struct, Value => StrucValue}
 
+class MergingOpsSpec extends MergingSpecBase {
+  test("Valid Merge Compatibility > ") {
+    val testValidMergeResult = buildValidMerge.run
+    assert(testValidMergeResult.isValid, s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > only 1 TXO provided") {
+    val testValidMergeResult = buildValidMerge
+      .withTxos(Seq(groupTxos.head))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("There must be at least 2 UTXOs to merge"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > Repeat UTXO address in TXOs") {
-
+    val testValidMergeResult = buildValidMerge
+      .addTxo(groupTxos.head)
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must not have duplicates"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs contain invalid identifier") {
-
+    val testValidMergeResult = buildValidMerge
+      .addTxo(valToTxo(groupValue.withAsset(groupValue.getAsset.clearGroupId), txAddr = dummyTxoAddress.withIndex(99)))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Both groupId and seriesId must be provided for non-alloy assets"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs contain non-asset identifier") {
-
+    val testValidMergeResult = buildValidMerge
+      .addTxo(valToTxo(lvlValue, txAddr = dummyTxoAddress.withIndex(99)))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must all be assets"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > Repeat TypeIdentifier in TXOs") {
-
+    val testValidMergeResult = buildValidMerge
+      .addTxo(valToTxo(assetGroup, txAddr = dummyTxoAddress.withIndex(99)))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must all be distinct (per type identifier)"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs do not all share same fungibility type") {
-
+    val testValidMergeResult = buildValidMerge
+      .addTxo(valToTxo(assetSeries, txAddr = dummyTxoAddress.withIndex(99)))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Assets to merge must all share the same fungibility type"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs contain Group_and_Series fungibility") {
-
+    val testValidMergeResult = buildValidMerge
+      .withTxos(valuesToTxos(Seq(assetGroupSeries, withUpdatedGroupId(assetGroupSeries))))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Assets to merge must not have Group_And_Series fungibility type"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs with Series fungibility do not share SeriesId") {
-
+    val testValidMergeResult = buildValidMerge
+      .withTxos(valuesToTxos(withUpdatedSeriesId(seriesValues.head) +: seriesValues.tail))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Merging Series fungible assets must share a series ID"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs with Group fungibility do not share GroupId") {
-
+    val testValidMergeResult = buildValidMerge
+      .withTxos(valuesToTxos(withUpdatedGroupId(groupValues.head) +: groupValues.tail))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Merging Group fungible assets must share a group ID"),
+      s"received: $testValidMergeResult")
   }
   test("Invalid Merge Compatibility > TXOs do not all share same quantity descriptor type") {
-
+    val testValidMergeResult = buildValidMerge
+      .withTxos(valuesToTxos(withUpdatedQuantityDescriptor(groupValues.head) +: groupValues.tail))
+      .run
+    assert(testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head.contentEquals("Merging assets must all share the same Quantity Descriptor Type"),
+      s"received: $testValidMergeResult")
   }
   test("Merge > Basic Group fungible") {
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(groupTxos)
+      .run
+    val merkleRoot = MergingOps.getAlloy(groupValues.map(_.getAsset))
+    val expectedUtxo = UnspentTransactionOutput(
+      RecipientAddr,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = groupValues.head.getAsset.groupId,
+          seriesId = None,
+          groupAlloy = None,
+          seriesAlloy = Some(merkleRoot),
+          quantity = BigInt(2),
+          fungibility = GROUP,
+          quantityDescriptor = LIQUID,
+          ephemeralMetadata = None,
+          commitment = None
+        )
+      )
+    )
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
   test("Merge > Basic Series fungible") {
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(seriesTxos)
+      .run
+    val merkleRoot = MergingOps.getAlloy(seriesValues.map(_.getAsset))
+    val expectedUtxo = UnspentTransactionOutput(
+      RecipientAddr,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = None,
+          seriesId = seriesValues.head.getAsset.seriesId,
+          groupAlloy = Some(merkleRoot),
+          seriesAlloy = None,
+          quantity = BigInt(2),
+          fungibility = SERIES,
+          quantityDescriptor = LIQUID,
+          ephemeralMetadata = None,
+          commitment = None
+        )
+      )
+    )
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
   test("Merge > Group fungible w/ an alloy") {
+    val assetValues = groupValues :+ assetGroup.withAsset(assetGroup.getAsset.clearSeriesId.withSeriesAlloy(trivialByte32))
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(valuesToTxos(assetValues))
+      .run
+    val merkleRoot = MergingOps.getAlloy(assetValues.map(_.getAsset))
+    val expectedUtxo = UnspentTransactionOutput(
+      RecipientAddr,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = assetValues.head.getAsset.groupId,
+          seriesId = None,
+          groupAlloy = None,
+          seriesAlloy = Some(merkleRoot),
+          quantity = BigInt(3),
+          fungibility = GROUP,
+          quantityDescriptor = LIQUID,
+          ephemeralMetadata = None,
+          commitment = None
+        )
+      )
+    )
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
   test("Merge > Series fungible w/ an alloy") {
+    val assetValues = seriesValues :+ assetSeries.withAsset(assetSeries.getAsset.clearGroupId.withGroupAlloy(trivialByte32))
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(valuesToTxos(assetValues))
+      .run
+    val merkleRoot = MergingOps.getAlloy(assetValues.map(_.getAsset))
+    val expectedUtxo = UnspentTransactionOutput(
+      RecipientAddr,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = None,
+          seriesId = assetValues.head.getAsset.seriesId,
+          groupAlloy = Some(merkleRoot),
+          seriesAlloy = None,
+          quantity = BigInt(3),
+          fungibility = SERIES,
+          quantityDescriptor = LIQUID,
+          ephemeralMetadata = None,
+          commitment = None
+        )
+      )
+    )
+    assertEquals(testMergedUtxo, expectedUtxo)
+  }
+  test("Merge > Validate ephemeral metadata and commitment are added to merged UTXO") {
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(groupTxos)
+      .withCommitment(Some(trivialByte32))
+      .withEphemeralMetadata(Some(Struct(Map("test" -> StrucValue(StringValue("test"))))))
+      .run
+    val merkleRoot = MergingOps.getAlloy(groupValues.map(_.getAsset))
+    val expectedUtxo = UnspentTransactionOutput(
+      RecipientAddr,
+      Value.defaultInstance.withAsset(
+        Value.Asset(
+          groupId = groupValues.head.getAsset.groupId,
+          seriesId = None,
+          groupAlloy = None,
+          seriesAlloy = Some(merkleRoot),
+          quantity = BigInt(2),
+          fungibility = GROUP,
+          quantityDescriptor = LIQUID,
+          ephemeralMetadata = Some(Struct(Map("test" -> StrucValue(StringValue("test"))))),
+          commitment = Some(trivialByte32)
+        )
+      )
+    )
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
   test("Merge > Validate ephemeral metadata and commitment does not affect merkle root") {
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(valuesToTxos(
+        groupValues.head.withAsset(
+          groupValues.head.getAsset.withCommitment(trivialByte32).withEphemeralMetadata(Struct(Map("test" -> StrucValue(StringValue("test")))))
+        ) +: groupValues.tail))
+      .run
+    val expectedUtxo = buildMergeUtxo
+      .withTxos(valuesToTxos(groupValues))
+      .run
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
   test("Merge > Validate lexicographical order > changing orders does not affect merkle root") {
+    val expectedUtxo = buildMergeUtxo
+      .withTxos(groupTxos)
+      .run
+    val testMergedUtxo = buildMergeUtxo
+      .withTxos(groupTxos.reverse)
+      .run
+    assertEquals(testMergedUtxo, expectedUtxo)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingOpsSpec.scala
@@ -9,90 +9,128 @@ import com.google.protobuf.struct.Value.Kind.StringValue
 import com.google.protobuf.struct.{Struct, Value => StrucValue}
 
 class MergingOpsSpec extends MergingSpecBase {
+
   test("Valid Merge Compatibility > ") {
     val testValidMergeResult = buildValidMerge.run
     assert(testValidMergeResult.isValid, s"received: $testValidMergeResult")
   }
+
   test("Invalid Merge Compatibility > only 1 TXO provided") {
     val testValidMergeResult = buildValidMerge
       .withTxos(Seq(groupTxos.head))
       .run
-    assert(testValidMergeResult.isInvalid &&
+    assert(
+      testValidMergeResult.isInvalid &&
       testValidMergeResult.swap.toOption.get.head.contentEquals("There must be at least 2 UTXOs to merge"),
-      s"received: $testValidMergeResult")
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > Repeat UTXO address in TXOs") {
     val testValidMergeResult = buildValidMerge
       .addTxo(groupTxos.head)
       .run
-    assert(testValidMergeResult.isInvalid &&
+    assert(
+      testValidMergeResult.isInvalid &&
       testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must not have duplicates"),
-      s"received: $testValidMergeResult")
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs contain invalid identifier") {
     val testValidMergeResult = buildValidMerge
       .addTxo(valToTxo(groupValue.withAsset(groupValue.getAsset.clearGroupId), txAddr = dummyTxoAddress.withIndex(99)))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("Both groupId and seriesId must be provided for non-alloy assets"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("Both groupId and seriesId must be provided for non-alloy assets"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs contain non-asset identifier") {
     val testValidMergeResult = buildValidMerge
       .addTxo(valToTxo(lvlValue, txAddr = dummyTxoAddress.withIndex(99)))
       .run
-    assert(testValidMergeResult.isInvalid &&
+    assert(
+      testValidMergeResult.isInvalid &&
       testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must all be assets"),
-      s"received: $testValidMergeResult")
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > Repeat TypeIdentifier in TXOs") {
     val testValidMergeResult = buildValidMerge
       .addTxo(valToTxo(assetGroup, txAddr = dummyTxoAddress.withIndex(99)))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("UTXOs to merge must all be distinct (per type identifier)"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("UTXOs to merge must all be distinct (per type identifier)"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs do not all share same fungibility type") {
     val testValidMergeResult = buildValidMerge
       .addTxo(valToTxo(assetSeries, txAddr = dummyTxoAddress.withIndex(99)))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("Assets to merge must all share the same fungibility type"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("Assets to merge must all share the same fungibility type"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs contain Group_and_Series fungibility") {
     val testValidMergeResult = buildValidMerge
       .withTxos(valuesToTxos(Seq(assetGroupSeries, withUpdatedGroupId(assetGroupSeries))))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("Assets to merge must not have Group_And_Series fungibility type"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("Assets to merge must not have Group_And_Series fungibility type"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs with Series fungibility do not share SeriesId") {
     val testValidMergeResult = buildValidMerge
       .withTxos(valuesToTxos(withUpdatedSeriesId(seriesValues.head) +: seriesValues.tail))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("Merging Series fungible assets must share a series ID"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("Merging Series fungible assets must share a series ID"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs with Group fungibility do not share GroupId") {
     val testValidMergeResult = buildValidMerge
       .withTxos(valuesToTxos(withUpdatedGroupId(groupValues.head) +: groupValues.tail))
       .run
-    assert(testValidMergeResult.isInvalid &&
+    assert(
+      testValidMergeResult.isInvalid &&
       testValidMergeResult.swap.toOption.get.head.contentEquals("Merging Group fungible assets must share a group ID"),
-      s"received: $testValidMergeResult")
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Invalid Merge Compatibility > TXOs do not all share same quantity descriptor type") {
     val testValidMergeResult = buildValidMerge
       .withTxos(valuesToTxos(withUpdatedQuantityDescriptor(groupValues.head) +: groupValues.tail))
       .run
-    assert(testValidMergeResult.isInvalid &&
-      testValidMergeResult.swap.toOption.get.head.contentEquals("Merging assets must all share the same Quantity Descriptor Type"),
-      s"received: $testValidMergeResult")
+    assert(
+      testValidMergeResult.isInvalid &&
+      testValidMergeResult.swap.toOption.get.head
+        .contentEquals("Merging assets must all share the same Quantity Descriptor Type"),
+      s"received: $testValidMergeResult"
+    )
   }
+
   test("Merge > Basic Group fungible") {
     val testMergedUtxo = buildMergeUtxo
       .withTxos(groupTxos)
@@ -116,6 +154,7 @@ class MergingOpsSpec extends MergingSpecBase {
     )
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Basic Series fungible") {
     val testMergedUtxo = buildMergeUtxo
       .withTxos(seriesTxos)
@@ -139,8 +178,10 @@ class MergingOpsSpec extends MergingSpecBase {
     )
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Group fungible w/ an alloy") {
-    val assetValues = groupValues :+ assetGroup.withAsset(assetGroup.getAsset.clearSeriesId.withSeriesAlloy(trivialByte32))
+    val assetValues =
+      groupValues :+ assetGroup.withAsset(assetGroup.getAsset.clearSeriesId.withSeriesAlloy(trivialByte32))
     val testMergedUtxo = buildMergeUtxo
       .withTxos(valuesToTxos(assetValues))
       .run
@@ -163,8 +204,10 @@ class MergingOpsSpec extends MergingSpecBase {
     )
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Series fungible w/ an alloy") {
-    val assetValues = seriesValues :+ assetSeries.withAsset(assetSeries.getAsset.clearGroupId.withGroupAlloy(trivialByte32))
+    val assetValues =
+      seriesValues :+ assetSeries.withAsset(assetSeries.getAsset.clearGroupId.withGroupAlloy(trivialByte32))
     val testMergedUtxo = buildMergeUtxo
       .withTxos(valuesToTxos(assetValues))
       .run
@@ -187,6 +230,7 @@ class MergingOpsSpec extends MergingSpecBase {
     )
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Validate ephemeral metadata and commitment are added to merged UTXO") {
     val testMergedUtxo = buildMergeUtxo
       .withTxos(groupTxos)
@@ -212,18 +256,25 @@ class MergingOpsSpec extends MergingSpecBase {
     )
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Validate ephemeral metadata and commitment does not affect merkle root") {
     val testMergedUtxo = buildMergeUtxo
-      .withTxos(valuesToTxos(
-        groupValues.head.withAsset(
-          groupValues.head.getAsset.withCommitment(trivialByte32).withEphemeralMetadata(Struct(Map("test" -> StrucValue(StringValue("test")))))
-        ) +: groupValues.tail))
+      .withTxos(
+        valuesToTxos(
+          groupValues.head.withAsset(
+            groupValues.head.getAsset
+              .withCommitment(trivialByte32)
+              .withEphemeralMetadata(Struct(Map("test" -> StrucValue(StringValue("test")))))
+          ) +: groupValues.tail
+        )
+      )
       .run
     val expectedUtxo = buildMergeUtxo
       .withTxos(valuesToTxos(groupValues))
       .run
     assertEquals(testMergedUtxo, expectedUtxo)
   }
+
   test("Merge > Validate lexicographical order > changing orders does not affect merkle root") {
     val expectedUtxo = buildMergeUtxo
       .withTxos(groupTxos)

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
@@ -1,18 +1,19 @@
 package co.topl.brambl.builders
 
+import cats.Id
 import cats.data.ValidatedNec
-import co.topl.brambl.builders.MergingSpecBase.{BuildMergeStub, BuildValidMergeStub}
-import co.topl.brambl.models.LockAddress
-import co.topl.brambl.models.box.{QuantityDescriptorType, Value}
-import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.builders.MergingSpecBase.{BuildAssetMergeTransaction, BuildMergeStub, BuildValidMergeStub}
+import co.topl.brambl.models.{LockAddress, TransactionOutputAddress}
+import co.topl.brambl.models.box.{Lock, QuantityDescriptorType, Value}
+import co.topl.brambl.models.transaction.{IoTransaction, UnspentTransactionOutput}
 import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
 import co.topl.genus.services.Txo
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
 
 trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterSpecBase {
-  def valuesToTxos(values: Seq[Value]): Seq[Txo] =
-    values.zipWithIndex.map(x => (x._1, dummyTxoAddress.withIndex(x._2))).map(x => valToTxo(x._1, txAddr = x._2))
+  def valuesToTxos(values: Seq[Value], startingIdx: Int = 0): Seq[Txo] =
+    values.zipWithIndex.map(x => (x._1, dummyTxoAddress.withIndex(startingIdx + x._2))).map(x => valToTxo(x._1, txAddr = x._2))
 
   def withUpdatedSeriesId(asset: Value): Value = asset.withAsset(
     asset.getAsset.withSeriesId(mockSeriesPolicyAlt.computeId)
@@ -31,6 +32,9 @@ trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterS
 
   def buildValidMerge: BuildValidMergeStub = BuildValidMergeStub(groupTxos)
   def buildMergeUtxo: BuildMergeStub = BuildMergeStub(groupTxos, RecipientAddr, None, None)
+
+  def buildAssertMergeTransaction: BuildAssetMergeTransaction[Id] =
+    BuildAssetMergeTransaction(txBuilder, groupTxos.map(_.outputAddress), valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue)), Map(RecipientAddr -> inPredicateLockFull), 1L, RecipientAddr, ChangeAddr, None, None)
 
 }
 
@@ -56,5 +60,25 @@ object MergingSpecBase {
     def withCommitment(newCommitment: Option[ByteString]): BuildMergeStub = this.copy(commitment = newCommitment)
 
     def run: UnspentTransactionOutput = MergingOps.merge(values, mergedAssetLockAddress, ephemeralMetadata, commitment)
+  }
+
+  case class BuildAssetMergeTransaction[F[_]](txBuilder: TransactionBuilderApi[F], utxosToMerge: Seq[TransactionOutputAddress], txos: Seq[Txo], locks: Map[LockAddress, Lock.Predicate], fee: Long, mergedAssetLockAddress: LockAddress, changeAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]){
+    def withUtxosToMerge(newUtxos: Seq[TransactionOutputAddress]): BuildAssetMergeTransaction[F] = this.copy(utxosToMerge = newUtxos)
+    def addLock(lock: (LockAddress, Lock.Predicate)): BuildAssetMergeTransaction[F] = this.copy(locks = locks + lock)
+    def updateFee(newFee: Long): BuildAssetMergeTransaction[F] = this.copy(fee = newFee)
+    def withTxos(newTxos: Seq[Txo]): BuildAssetMergeTransaction[F] = this.copy(txos = newTxos)
+    def removeTxo(utxo: TransactionOutputAddress): BuildAssetMergeTransaction[F] = this.copy(txos = txos.filterNot(_.outputAddress == utxo))
+    def addTxo(txo: Txo): BuildAssetMergeTransaction[F] = this.copy(txos = txos :+ txo)
+    def run: F[Either[BuilderError, IoTransaction]] = txBuilder
+      .buildAssetMergeTransaction(
+        utxosToMerge,
+        txos,
+        locks,
+        fee,
+        mergedAssetLockAddress,
+        changeAddress,
+        ephemeralMetadata,
+        commitment
+      )
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
@@ -21,7 +21,7 @@ trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterS
   def withUpdatedGroupId(asset: Value): Value = asset.withAsset(
     asset.getAsset.withGroupId(mockGroupPolicyAlt.computeId)
   )
-  def withUpdatedQuantityDescriptor(asset: Value) = asset.withAsset(
+  def withUpdatedQuantityDescriptor(asset: Value): Value = asset.withAsset(
     asset.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR)
   )
 

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
@@ -12,15 +12,20 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Struct
 
 trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterSpecBase {
+
   def valuesToTxos(values: Seq[Value], startingIdx: Int = 0): Seq[Txo] =
-    values.zipWithIndex.map(x => (x._1, dummyTxoAddress.withIndex(startingIdx + x._2))).map(x => valToTxo(x._1, txAddr = x._2))
+    values.zipWithIndex
+      .map(x => (x._1, dummyTxoAddress.withIndex(startingIdx + x._2)))
+      .map(x => valToTxo(x._1, txAddr = x._2))
 
   def withUpdatedSeriesId(asset: Value): Value = asset.withAsset(
     asset.getAsset.withSeriesId(mockSeriesPolicyAlt.computeId)
   )
+
   def withUpdatedGroupId(asset: Value): Value = asset.withAsset(
     asset.getAsset.withGroupId(mockGroupPolicyAlt.computeId)
   )
+
   def withUpdatedQuantityDescriptor(asset: Value): Value = asset.withAsset(
     asset.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR)
   )
@@ -34,7 +39,17 @@ trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterS
   def buildMergeUtxo: BuildMergeStub = BuildMergeStub(groupTxos, RecipientAddr, None, None)
 
   def buildAssertMergeTransaction: BuildAssetMergeTransaction[Id] =
-    BuildAssetMergeTransaction(txBuilder, groupTxos.map(_.outputAddress), valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue)), Map(RecipientAddr -> inPredicateLockFull), 1L, RecipientAddr, ChangeAddr, None, None)
+    BuildAssetMergeTransaction(
+      txBuilder,
+      groupTxos.map(_.outputAddress),
+      valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue)),
+      Map(RecipientAddr -> inPredicateLockFull),
+      1L,
+      RecipientAddr,
+      ChangeAddr,
+      None,
+      None
+    )
 
 }
 
@@ -45,30 +60,50 @@ object MergingSpecBase {
 
   case class BuildValidMergeStub(txos: Seq[Txo]) {
 
-    def addTxo(txo: Txo): BuildValidMergeStub = this.copy(txos = txos :+ txo)
+    def addTxo(txo:       Txo): BuildValidMergeStub = this.copy(txos = txos :+ txo)
     def withTxos(newTxos: Seq[Txo]): BuildValidMergeStub = this.copy(txos = newTxos)
 
     def run: ValidatedNec[String, Unit] = MergingOps.validMerge(txos)
   }
 
-  case class BuildMergeStub(values: Seq[Txo], mergedAssetLockAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]) {
+  case class BuildMergeStub(
+    values:                 Seq[Txo],
+    mergedAssetLockAddress: LockAddress,
+    ephemeralMetadata:      Option[Struct],
+    commitment:             Option[ByteString]
+  ) {
 
     def addTxo(txo: Txo): BuildMergeStub = this.copy(values = values :+ txo)
 
-    def withTxos(newTxos: Seq[Txo]): BuildMergeStub = this.copy(values = newTxos)
+    def withTxos(newTxos:              Seq[Txo]): BuildMergeStub = this.copy(values = newTxos)
     def withEphemeralMetadata(newMeta: Option[Struct]): BuildMergeStub = this.copy(ephemeralMetadata = newMeta)
-    def withCommitment(newCommitment: Option[ByteString]): BuildMergeStub = this.copy(commitment = newCommitment)
+    def withCommitment(newCommitment:  Option[ByteString]): BuildMergeStub = this.copy(commitment = newCommitment)
 
     def run: UnspentTransactionOutput = MergingOps.merge(values, mergedAssetLockAddress, ephemeralMetadata, commitment)
   }
 
-  case class BuildAssetMergeTransaction[F[_]](txBuilder: TransactionBuilderApi[F], utxosToMerge: Seq[TransactionOutputAddress], txos: Seq[Txo], locks: Map[LockAddress, Lock.Predicate], fee: Long, mergedAssetLockAddress: LockAddress, changeAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]){
-    def withUtxosToMerge(newUtxos: Seq[TransactionOutputAddress]): BuildAssetMergeTransaction[F] = this.copy(utxosToMerge = newUtxos)
+  case class BuildAssetMergeTransaction[F[_]](
+    txBuilder:              TransactionBuilderApi[F],
+    utxosToMerge:           Seq[TransactionOutputAddress],
+    txos:                   Seq[Txo],
+    locks:                  Map[LockAddress, Lock.Predicate],
+    fee:                    Long,
+    mergedAssetLockAddress: LockAddress,
+    changeAddress:          LockAddress,
+    ephemeralMetadata:      Option[Struct],
+    commitment:             Option[ByteString]
+  ) {
+
+    def withUtxosToMerge(newUtxos: Seq[TransactionOutputAddress]): BuildAssetMergeTransaction[F] =
+      this.copy(utxosToMerge = newUtxos)
     def addLock(lock: (LockAddress, Lock.Predicate)): BuildAssetMergeTransaction[F] = this.copy(locks = locks + lock)
     def updateFee(newFee: Long): BuildAssetMergeTransaction[F] = this.copy(fee = newFee)
     def withTxos(newTxos: Seq[Txo]): BuildAssetMergeTransaction[F] = this.copy(txos = newTxos)
-    def removeTxo(utxo: TransactionOutputAddress): BuildAssetMergeTransaction[F] = this.copy(txos = txos.filterNot(_.outputAddress == utxo))
+
+    def removeTxo(utxo: TransactionOutputAddress): BuildAssetMergeTransaction[F] =
+      this.copy(txos = txos.filterNot(_.outputAddress == utxo))
     def addTxo(txo: Txo): BuildAssetMergeTransaction[F] = this.copy(txos = txos :+ txo)
+
     def run: F[Either[BuilderError, IoTransaction]] = txBuilder
       .buildAssetMergeTransaction(
         utxosToMerge,

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/MergingSpecBase.scala
@@ -1,0 +1,60 @@
+package co.topl.brambl.builders
+
+import cats.data.ValidatedNec
+import co.topl.brambl.builders.MergingSpecBase.{BuildMergeStub, BuildValidMergeStub}
+import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.box.{QuantityDescriptorType, Value}
+import co.topl.brambl.models.transaction.UnspentTransactionOutput
+import co.topl.brambl.syntax.{groupPolicyAsGroupPolicySyntaxOps, seriesPolicyAsSeriesPolicySyntaxOps}
+import co.topl.genus.services.Txo
+import com.google.protobuf.ByteString
+import com.google.protobuf.struct.Struct
+
+trait MergingSpecBase extends munit.FunSuite with TransactionBuilderInterpreterSpecBase {
+  def valuesToTxos(values: Seq[Value]): Seq[Txo] =
+    values.zipWithIndex.map(x => (x._1, dummyTxoAddress.withIndex(x._2))).map(x => valToTxo(x._1, txAddr = x._2))
+
+  def withUpdatedSeriesId(asset: Value): Value = asset.withAsset(
+    asset.getAsset.withSeriesId(mockSeriesPolicyAlt.computeId)
+  )
+  def withUpdatedGroupId(asset: Value): Value = asset.withAsset(
+    asset.getAsset.withGroupId(mockGroupPolicyAlt.computeId)
+  )
+  def withUpdatedQuantityDescriptor(asset: Value) = asset.withAsset(
+    asset.getAsset.withQuantityDescriptor(QuantityDescriptorType.ACCUMULATOR)
+  )
+
+  val groupValues: Seq[Value] = Seq(assetGroup, withUpdatedSeriesId(assetGroup))
+  val groupTxos: Seq[Txo] = valuesToTxos(groupValues)
+  val seriesValues: Seq[Value] = Seq(assetSeries, withUpdatedGroupId(assetSeries))
+  val seriesTxos: Seq[Txo] = valuesToTxos(seriesValues)
+
+  def buildValidMerge: BuildValidMergeStub = BuildValidMergeStub(groupTxos)
+  def buildMergeUtxo: BuildMergeStub = BuildMergeStub(groupTxos, RecipientAddr, None, None)
+
+}
+
+/**
+ * Helpers for the Merging test cases
+ */
+object MergingSpecBase {
+
+  case class BuildValidMergeStub(txos: Seq[Txo]) {
+
+    def addTxo(txo: Txo): BuildValidMergeStub = this.copy(txos = txos :+ txo)
+    def withTxos(newTxos: Seq[Txo]): BuildValidMergeStub = this.copy(txos = newTxos)
+
+    def run: ValidatedNec[String, Unit] = MergingOps.validMerge(txos)
+  }
+
+  case class BuildMergeStub(values: Seq[Txo], mergedAssetLockAddress: LockAddress, ephemeralMetadata: Option[Struct], commitment: Option[ByteString]) {
+
+    def addTxo(txo: Txo): BuildMergeStub = this.copy(values = values :+ txo)
+
+    def withTxos(newTxos: Seq[Txo]): BuildMergeStub = this.copy(values = newTxos)
+    def withEphemeralMetadata(newMeta: Option[Struct]): BuildMergeStub = this.copy(ephemeralMetadata = newMeta)
+    def withCommitment(newCommitment: Option[ByteString]): BuildMergeStub = this.copy(commitment = newCommitment)
+
+    def run: UnspentTransactionOutput = MergingOps.merge(values, mergedAssetLockAddress, ephemeralMetadata, commitment)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
@@ -1,0 +1,22 @@
+package co.topl.brambl.builders
+
+class TransactionBuilderInterpreterAssetMergingSpec extends TransactionBuilderInterpreterSpecBase {
+  test("Invalid user params > a UTXO in UTXOs to merge does not exist in TXOs") {
+  }
+  test("Invalid user params > UTXOs to merge are not compatible") {
+  }
+  test("Invalid user params > a TXO does not have a corresponding lock") {
+  }
+  test("Invalid user params > a lock does not have a corresponding TXO") {
+  }
+  test("Invalid user params > insufficient funds for fees") {
+  }
+  test("Fee edge case (exact funds, no change)") {
+  }
+  test("Generic case") {
+    // Check ASM to see if its valid; contains everythign mentioned in utxosToMerge, outputIDX points to the right utxo
+    // Check merged output (correct lock address, ephemeral metadata, commitment, merkleroot, IDs, etc
+    // check change; goes to right changeAddress, correct amount
+    // check the ability to split (construct UTXOs and verify)
+  }
+}

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterAssetMergingSpec.scala
@@ -1,22 +1,149 @@
 package co.topl.brambl.builders
 
-class TransactionBuilderInterpreterAssetMergingSpec extends TransactionBuilderInterpreterSpecBase {
+import co.topl.brambl.models.box.FungibilityType.GROUP
+import co.topl.brambl.models.box.QuantityDescriptorType.LIQUID
+import co.topl.brambl.models.box.{AssetMergingStatement, Value}
+import co.topl.brambl.models.transaction.IoTransaction
+import co.topl.brambl.syntax.ioTransactionAsTransactionSyntaxOps
+import co.topl.brambl.syntax.bigIntAsInt128
+import com.google.protobuf.struct.{Struct, Value => StructValue}
+import com.google.protobuf.struct.Value.Kind.StringValue
+
+
+class TransactionBuilderInterpreterAssetMergingSpec extends MergingSpecBase {
   test("Invalid user params > a UTXO in UTXOs to merge does not exist in TXOs") {
+    val testTx = buildAssertMergeTransaction
+      .removeTxo(groupTxos.head.outputAddress)
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(
+          Seq(UserInputError("All UTXOs to merge must be accounted for in txos"))
+        )
+      )
+    )
   }
   test("Invalid user params > UTXOs to merge are not compatible") {
+    val txos = valuesToTxos(Seq(assetGroup, assetSeries))
+    val testTx = buildAssertMergeTransaction
+      .withUtxosToMerge(txos.map(_.outputAddress))
+      .withTxos(txos ++ valuesToTxos(Seq(lvlValue, lvlValue, lvlValue), txos.length))
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(
+          Seq(UserInputError("Assets to merge must all share the same fungibility type"))
+        )
+      )
+    )
   }
   test("Invalid user params > a TXO does not have a corresponding lock") {
+    val testTx = buildAssertMergeTransaction
+      .addTxo(valToTxo(lvlValue, trivialLockAddress.withLedger(3), dummyTxoAddress.withIndex(99)))
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(
+          Seq(UserInputError("every lock in the txos must correspond to a lock in the lock map"))
+        )
+      )
+    )
   }
   test("Invalid user params > a lock does not have a corresponding TXO") {
+    val testTx = buildAssertMergeTransaction
+      .addLock(trivialLockAddress.withLedger(3) -> trivialOutLock.getPredicate)
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(
+          Seq(UserInputError("every lock in the lock map must correspond to a lock in the txos"))
+        )
+      )
+    )
   }
   test("Invalid user params > insufficient funds for fees") {
+    val testTx = buildAssertMergeTransaction
+      .updateFee(4L)
+      .run
+    assertEquals(
+      testTx,
+      Left(
+        UserInputErrors(
+          Seq(UserInputError("Not enough LVLs in input to satisfy fee"))
+        )
+      )
+    )
   }
   test("Fee edge case (exact funds, no change)") {
+    val testTx = buildAssertMergeTransaction
+      .updateFee(3L)
+      .run
+    val merkleRoot = MergingOps.getAlloy(groupValues.map(_.getAsset))
+    val expectedTx: IoTransaction = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 0)))
+      .withInputs(buildStxos(valuesToTxos(groupValues ++ Seq(lvlValue, lvlValue, lvlValue))))
+      .withOutputs(
+        buildRecipientUtxos(List(
+          Value.defaultInstance.withAsset(
+            Value.Asset(
+              groupId = groupValues.head.getAsset.groupId,
+              seriesId = None,
+              groupAlloy = None,
+              seriesAlloy = Some(merkleRoot),
+              quantity = BigInt(groupValues.length),
+              fungibility = GROUP,
+              quantityDescriptor = LIQUID,
+              ephemeralMetadata = None,
+              commitment = None
+            )
+          )
+        ))
+      )
+    assert(testTx.isRight && sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx).computeId)
   }
   test("Generic case") {
-    // Check ASM to see if its valid; contains everythign mentioned in utxosToMerge, outputIDX points to the right utxo
-    // Check merged output (correct lock address, ephemeral metadata, commitment, merkleroot, IDs, etc
-    // check change; goes to right changeAddress, correct amount
-    // check the ability to split (construct UTXOs and verify)
+    val assetValues = groupValues :+ assetGroup.withAsset(assetGroup.getAsset.clearSeriesId.withSeriesAlloy(trivialByte32))
+    val assetTxos = valuesToTxos(assetValues)
+    val testTx = buildAssertMergeTransaction
+      .withTxos(assetTxos ++ valuesToTxos(Seq(lvlValue, lvlValue, lvlValue), assetTxos.length))
+      .withUtxosToMerge(assetTxos.map(_.outputAddress))
+      .run
+    val merkleRoot = MergingOps.getAlloy(assetValues.map(_.getAsset))
+    val expectedTx: IoTransaction = IoTransaction.defaultInstance
+      .withDatum(txDatum)
+      .withMergingStatements(Seq(AssetMergingStatement(groupTxos.map(_.outputAddress), 1)))
+      .withInputs(buildStxos(valuesToTxos(assetValues ++ Seq(lvlValue, lvlValue, lvlValue))))
+      .withOutputs(
+        buildChangeUtxos(List(lvlValue.withLvl(lvlValue.getLvl.withQuantity(BigInt(2)))))
+          ++
+        buildRecipientUtxos(List(
+          Value.defaultInstance.withAsset(
+            Value.Asset(
+              groupId = assetValues.head.getAsset.groupId,
+              seriesId = None,
+              groupAlloy = None,
+              seriesAlloy = Some(merkleRoot),
+              quantity = BigInt(assetValues.length),
+              fungibility = GROUP,
+              quantityDescriptor = LIQUID,
+              ephemeralMetadata = None,
+              commitment = None
+            )
+          )
+        ))
+      )
+    assert(testTx.isRight && sortedTx(testTx.toOption.get).computeId == sortedTx(expectedTx).computeId)
+    // Ensure split utxo's commitment and metadata does not affect merkle root
+    // Ensure split order does not matter
+    val testSplit = assetValues.map(
+      _.getAsset.withCommitment(trivialByte32).withEphemeralMetadata(Struct(Map("test" -> StructValue(StringValue("test")))))
+    ).reverse
+    val testSplitMerkle = MergingOps.getAlloy(testSplit)
+    assertEquals(testSplitMerkle, merkleRoot)
   }
 }

--- a/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
+++ b/brambl-sdk/src/test/scala/co/topl/brambl/builders/TransactionBuilderInterpreterSpecBase.scala
@@ -141,7 +141,7 @@ trait TransactionBuilderInterpreterSpecBase extends munit.FunSuite with MockHelp
   val assetGroupImmutableAlt: Value = toAltAsset(assetGroupImmutable)
   val assetSeriesImmutableAlt: Value = toAltAsset(assetSeriesImmutable)
 
-  private val trivialByte32 = ByteString.copyFrom(Array.fill(32)(0: Byte))
+  val trivialByte32: ByteString = ByteString.copyFrom(Array.fill(32)(0: Byte))
 
   private val trivialSignatureKesSum =
     SignatureKesSum(trivialByte32, trivialByte32 concat trivialByte32, Seq(trivialByte32))


### PR DESCRIPTION
## Purpose

To add support for TAMv2 asset merging.

## Approach

- Added asset merging to the Transaction Builder API. This takes in UTXOs to merge, runs validations, and returns the resulting transaction
- Added MergingOps to contain merge logic; it contains the merging validators (describing what constitutes a compatible and valid merge) as well as the actual merge logic
- Added other user argument validation
- Added tests and helpers

## Testing

Added unit tests and ensured all pass

## Tickets
* closes TSDK-580